### PR TITLE
Improve performance of SourceCatalog properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,8 +274,10 @@ New Features
   - Significantly improved the performance of the ``SourceCatalog``
     windowed centroids, quadratic centroids, Kron radii and photometry,
     ``flux_radius``, ``circular_photometry``, image moments,
-    ``perimeter``, ``gini``, and segment pixel statistics (e.g.,
+    ``perimeter``, ``gini``, segment pixel statistics (e.g.,
     ``segment_flux``, ``segment_area``, ``area``, and ``min_value``),
+    and the positions of the minimum and maximum pixel values (e.g.,
+    ``min_value_index`` and ``max_value_xindex``),
     typically by factors of ~3-20 depending on the property, by
     computing all sources in a single call into compiled code. The
     ``flags`` attribute and the default ``to_table()`` output are about

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@ General
 
 - The ``asdf-astropy`` package is now an optional dependency. [#2211]
 
+- SciPy is now also a build-time dependency. Its Cython interface to
+  the Brent root finder is used by the compiled code that computes the
+  ``SourceCatalog`` flux radii. [#2406]
+
 - Added serialization to ASDF for all PSF models. [#2335]
 
 - Added serialization to ASDF for all apertures. [#2341]
@@ -266,6 +270,16 @@ New Features
     column combining provenance and measurement flags, along with a
     ``decode_flags`` convenience method that returns a dictionary keyed
     by source label. [#2402]
+
+  - Significantly improved the performance of the ``SourceCatalog``
+    windowed centroids, Kron photometry, ``flux_radius``, and image
+    moments, typically by factors of ~2-18 depending on the property,
+    by computing all sources in a single call into compiled code.
+    The moment-based properties (e.g., ``covariance``, ``fwhm``,
+    ``orientation``, and the centroid errors) are about 10 times faster,
+    and the ``flags`` attribute and the default ``to_table()`` output
+    are about 3 times faster for large catalogs. Progress bars are no
+    longer displayed for these calculations. [#2406]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -272,14 +272,15 @@ New Features
     by source label. [#2402]
 
   - Significantly improved the performance of the ``SourceCatalog``
-    windowed centroids, Kron photometry, ``flux_radius``, and image
-    moments, typically by factors of ~2-18 depending on the property,
-    by computing all sources in a single call into compiled code.
-    The moment-based properties (e.g., ``covariance``, ``fwhm``,
-    ``orientation``, and the centroid errors) are about 10 times faster,
-    and the ``flags`` attribute and the default ``to_table()`` output
-    are about 3 times faster for large catalogs. Progress bars are no
-    longer displayed for these calculations. [#2406]
+    windowed centroids, quadratic centroids, Kron radii and photometry,
+    ``flux_radius``, ``circular_photometry``, image moments, and
+    segment pixel statistics (e.g., ``segment_flux``, ``area``, and
+    ``min_value``), typically by factors of ~3-20 depending on the
+    property, by computing all sources in a single call into compiled
+    code. The ``flags`` attribute and the default ``to_table()`` output
+    are about 5 times faster for large catalogs. No property displays a
+    progress bar any more; the ``progress_bar`` keyword is retained for
+    backwards compatibility. [#2406]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,8 +279,8 @@ New Features
     property, by computing all sources in a single call into compiled
     code. The ``flags`` attribute and the default ``to_table()`` output
     are about 5 times faster for large catalogs. No property displays a
-    progress bar any more; the ``progress_bar`` keyword is retained for
-    backwards compatibility. [#2406]
+    progress bar any more, but the ``progress_bar`` keyword is retained
+    for backwards compatibility. [#2406]
 
 - ``photutils.utils``
 
@@ -1001,6 +1001,11 @@ API Changes
     non-positive, the windowed second-order moments are negative, or the
     windowed covariance determinant is negative. Previously, only the
     ellipse condition was applied. [#2397]
+
+  - The ``SourceCatalog`` ``progress_bar`` keyword is now deprecated
+    and will be removed in version 4.0. All property calculations are
+    now computed for all sources at once in compiled code, so no
+    progress bar is displayed and the keyword has no effect. [#2406]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -273,14 +273,15 @@ New Features
 
   - Significantly improved the performance of the ``SourceCatalog``
     windowed centroids, quadratic centroids, Kron radii and photometry,
-    ``flux_radius``, ``circular_photometry``, image moments, and
-    segment pixel statistics (e.g., ``segment_flux``, ``area``, and
-    ``min_value``), typically by factors of ~3-20 depending on the
-    property, by computing all sources in a single call into compiled
-    code. The ``flags`` attribute and the default ``to_table()`` output
-    are about 5 times faster for large catalogs. No property displays a
-    progress bar any more, but the ``progress_bar`` keyword is retained
-    for backwards compatibility. [#2406]
+    ``flux_radius``, ``circular_photometry``, image moments,
+    ``perimeter``, ``gini``, and segment pixel statistics (e.g.,
+    ``segment_flux``, ``segment_area``, ``area``, and ``min_value``),
+    typically by factors of ~3-20 depending on the property, by
+    computing all sources in a single call into compiled code. The
+    ``flags`` attribute and the default ``to_table()`` output are about
+    5 times faster for large catalogs. No property displays a progress
+    bar any more, but the ``progress_bar`` keyword is retained for
+    backwards compatibility. [#2406]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1004,8 +1004,8 @@ API Changes
     ellipse condition was applied. [#2397]
 
   - The ``SourceCatalog`` ``progress_bar`` keyword is now deprecated
-    and will be removed in version 4.0. All property calculations are
-    now computed for all sources at once in compiled code, so no
+    and will be removed in version 4.0. All property calculations
+    are now computed for all sources at once in compiled code, so no
     progress bar is displayed and the keyword has no effect. [#2406]
 
 - ``photutils.utils``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -280,8 +280,8 @@ New Features
     computing all sources in a single call into compiled code. The
     ``flags`` attribute and the default ``to_table()`` output are about
     5 times faster for large catalogs. No property displays a progress
-    bar any more, but the ``progress_bar`` keyword is retained for
-    backwards compatibility. [#2406]
+    bar any more (see the ``progress_bar`` deprecation under API
+    Changes). [#2406]
 
 - ``photutils.utils``
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -75,6 +75,26 @@ python benchmarks/bench_catalog_sep.py
 python benchmarks/bench_catalog_sep.py --which benchmark --n-sources 4000
 ```
 
+## SourceCatalog cross-version validation (`validate_catalog_versions.py`)
+
+Validation of `SourceCatalog` results across photutils versions. The
+`dump` command computes every array-valued property (plus the
+`flux_radius`, `circular_photometry`, `kron_photometry`, and default
+`to_table` outputs) for the benchmark scene and an edge-case scene
+across several catalog configurations, using whichever photutils is
+importable, and writes them to a file; the `compare` command reports
+every entry that differs between two such files, grouped by property,
+and the properties that exist in only one version. The `dump` command
+uses only APIs available in photutils 3.0.0, so run it once per
+installation (e.g., with `PYTHONPATH` pointing at an unpacked wheel,
+from a directory without a photutils checkout) and then compare.
+
+```bash
+python benchmarks/validate_catalog_versions.py dump old.pkl
+python benchmarks/validate_catalog_versions.py dump new.pkl
+python benchmarks/validate_catalog_versions.py compare old.pkl new.pkl
+```
+
 ## Centroids (`bench_centroids.py`)
 
 Benchmarks for the `photutils.centroids` subpackage:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -47,6 +47,34 @@ python benchmarks/bench_aperture_sep.py
 python benchmarks/bench_aperture_sep.py --which threads --n-threads 1,4,12
 ```
 
+## SourceCatalog versus SEP (`bench_catalog_sep.py`)
+
+Benchmark and validation of `SourceCatalog` against the SEP package,
+using the same blended Gaussian-pair image, convolved image, and
+segmentation image as the `SourceCatalog` benchmarks in
+`bench_segmentation.py`. For each `aperture_mask_method` with a SEP
+analogue (`'none'` and `'mask'`), the script:
+
+- validates the isophotal properties (centroid and its error,
+  covariance, shape parameters, ellipse coefficients, segment flux
+  and area, peak, and bounding box) against `sep.extract` run on the
+  existing segmentation map, and `kron_radius`, `kron_flux`,
+  `flux_radius`, `centroid_win`, and `circular_photometry` against
+  the corresponding SEP functions (the module docstring lists the
+  conventions that make the two packages comparable)
+- benchmarks each of these measurements as a single step (on a
+  catalog whose prerequisite properties are already computed) against
+  the SEP function with its inputs precomputed, plus the full chain of
+  measurements from a cold catalog, reporting the photutils/SEP
+  runtime ratio
+
+Requires the optional `sep` package.
+
+```bash
+python benchmarks/bench_catalog_sep.py
+python benchmarks/bench_catalog_sep.py --which benchmark --n-sources 4000
+```
+
 ## Centroids (`bench_centroids.py`)
 
 Benchmarks for the `photutils.centroids` subpackage:

--- a/benchmarks/bench_catalog_sep.py
+++ b/benchmarks/bench_catalog_sep.py
@@ -1,0 +1,886 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmark and validation of SourceCatalog against SEP.
+
+The script uses the same image of blended Gaussian-source pairs, the
+same convolved image, and the same segmentation image as the
+``SourceCatalog`` benchmarks in ``bench_segmentation.py`` (see its
+``make_inputs`` function) and, for each ``aperture_mask_method`` that
+has a SEP analogue ('none' and 'mask'):
+
+1. Validates the ``SourceCatalog`` properties against the equivalent
+   SEP measurements on the same inputs:
+
+   * the isophotal properties (centroid and its error, covariance,
+     semimajor and semiminor axes, orientation, ellipse coefficients,
+     segment flux and area, peak value and position, and bounding
+     box) against ``sep.extract`` run on the existing segmentation
+     map (``segmentation_map=<array>``) with the same convolution
+     kernel (``filter_type='conv'``)
+   * ``kron_radius`` against ``sep.kron_radius``
+   * ``kron_flux`` against ``sep.sum_ellipse`` in the Kron aperture
+   * ``flux_radius`` against ``sep.flux_radius``
+   * ``centroid_win`` against ``sep.winpos``
+   * ``circular_photometry`` against ``sep.sum_circle``
+
+2. Benchmarks each of these measurements, timing the ``SourceCatalog``
+   property on a fresh catalog whose prerequisite properties are
+   already computed (so each row is the cost of that step alone) and
+   the SEP function with its inputs precomputed, and then the full
+   chain of measurements from a cold catalog against the same chain
+   of SEP calls.
+
+SEP's ``segmap`` and positive ``seg_id`` inputs mask the pixels of
+neighboring sources, which corresponds to the photutils
+``aperture_mask_method='mask'``; without them, neighboring sources
+are included (``aperture_mask_method='none'``). The photutils
+``'correct'`` method has no SEP analogue. ``sep.winpos`` has no
+segmentation-map support, so ``centroid_win`` is only compared and
+benchmarked against SEP in the 'none' scenario.
+
+The following conventions make the two packages comparable:
+
+* SEP computes the isophotal properties from the internally filtered
+  image and the segment flux from the unfiltered image, exactly as
+  ``SourceCatalog`` uses ``convolved_data`` and ``data``. The plain
+  SEP convolution (``filter_type='conv'``) matches the zero-padded
+  ``astropy.convolution.convolve`` used to make ``convolved_data``.
+  SEP stores pixel values as float32, so the isophotal properties
+  agree to roughly 1e-7 relative precision.
+* SEP objects are returned in segment-label order, matching the
+  ``SourceCatalog`` label order.
+* ``SourceCatalog`` applies its ``kron_params`` to the measured Kron
+  radius (the minimum unscaled radius ``kron_params[1]`` and a NaN
+  above the 6.0 measurement scale), while ``sep.kron_radius`` returns
+  the raw measurement. The same limits are applied to the SEP value
+  before it is compared and before it defines the SEP Kron aperture.
+* ``sep.flux_radius`` measures the flux in 256 annuli out to the
+  maximum radius and linearly interpolates the cumulative profile,
+  whereas ``SourceCatalog.flux_radius`` solves for the exact-overlap
+  circular aperture enclosing the flux fraction. The two agree only to
+  roughly 1% (``FLUX_RADIUS_RTOL``). For the ``centroid_win``
+  comparison, SEP is therefore given the window sigma derived from the
+  photutils half-light radius so that the windowed algorithms are
+  compared on the same window; its benchmark uses SEP's own chain.
+* SEP weights each pixel's variance by its aperture overlap fraction,
+  whereas photutils weights it by the square of the overlap fraction,
+  so the aperture flux errors are not compared.
+* The catalog has no ``background`` or ``wcs`` inputs, which have no
+  SEP analogue.
+
+Requires the optional ``sep`` package. Run ``python
+benchmarks/bench_catalog_sep.py --help`` to see the available options.
+"""
+
+import argparse
+import sys
+import time
+
+import astropy.units as u
+import numpy as np
+from astropy.stats import gaussian_fwhm_to_sigma
+from bench_helpers import print_environment, time_best
+from bench_segmentation import THRESHOLD, make_inputs
+from numpy.testing import assert_allclose, assert_array_equal
+
+from photutils.segmentation import SourceCatalog, make_2dgaussian_kernel
+
+try:
+    import sep
+    HAS_SEP = True
+    SEP_IMPORT_ERROR = None
+except ImportError as exc:
+    HAS_SEP = False
+    SEP_IMPORT_ERROR = str(exc)
+
+KRON_PARAMS = (2.5, 1.4, 0.0)  # the SourceCatalog default
+MAX_KRON_RADIUS = 6.0  # the SourceCatalog Kron measurement scale
+FRACTION = 0.5  # the flux_radius fraction (half-light radius)
+RADIUS = 5.0  # the circular photometry radius
+MIN_HALF_LIGHT_RADIUS = 0.5  # the centroid_win minimum (SourceExtractor)
+
+SEP_RTOL = 1e-5
+SEP_ATOL = 1e-5
+FLUX_RADIUS_RTOL = 1e-2
+CENTROID_WIN_ATOL = 1e-5
+
+# The SourceCatalog properties that sep.extract also measures, in
+# the (name, SEP field) pairs used by the validation
+ISOPHOTAL_PROPERTIES = [
+    ('x_centroid', 'x'),
+    ('y_centroid', 'y'),
+    ('x_centroid_err', 'errx2'),
+    ('y_centroid_err', 'erry2'),
+    ('covariance_xx', 'x2'),
+    ('covariance_yy', 'y2'),
+    ('covariance_xy', 'xy'),
+    ('semimajor_axis', 'a'),
+    ('semiminor_axis', 'b'),
+    ('orientation', 'theta'),
+    ('ellipse_cxx', 'cxx'),
+    ('ellipse_cyy', 'cyy'),
+    ('ellipse_cxy', 'cxy'),
+    ('segment_flux', 'flux'),
+    ('moments', 'cflux'),
+    ('max_value', 'peak'),
+    ('max_value_xindex', 'xpeak'),
+    ('max_value_yindex', 'ypeak'),
+    ('bbox_xmin', 'xmin'),
+    ('bbox_xmax', 'xmax'),
+    ('bbox_ymin', 'ymin'),
+    ('bbox_ymax', 'ymax'),
+    ('segment_area', 'npix'),
+    ('area', 'npix'),
+]
+INTEGER_PROPERTIES = ('max_value_xindex', 'max_value_yindex', 'bbox_xmin',
+                      'bbox_xmax', 'bbox_ymin', 'bbox_ymax', 'segment_area',
+                      'area')
+
+
+def make_scene(n_sources, *, seed=0):
+    """
+    Build the shared benchmark scene.
+
+    Parameters
+    ----------
+    n_sources : int
+        The total number of Gaussian sources in the image.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    scene : dict
+        The ``data``, ``convolved_data``, ``kernel``, ``error``,
+        ``segm`` (a `~photutils.segmentation.SegmentationImage`),
+        ``segm32`` (the int32 segmentation array for SEP), and
+        ``labels`` (int32, for SEP ``seg_id``) values.
+    """
+    data, convolved_data, segm = make_inputs(n_sources, seed=seed)
+    kernel = make_2dgaussian_kernel(3.0, size=5)  # as in make_inputs
+    return {'data': data,
+            'convolved_data': convolved_data,
+            'kernel': np.ascontiguousarray(kernel.array),
+            'error': np.ones_like(data),
+            'segm': segm,
+            'segm32': np.ascontiguousarray(segm.data, dtype=np.int32),
+            'labels': np.ascontiguousarray(segm.labels, dtype=np.int32)}
+
+
+def build_scenarios():
+    """
+    Build the ``aperture_mask_method`` scenarios that have a SEP
+    analogue.
+
+    Returns
+    -------
+    result : list of dict
+        The scenarios, each with the photutils ``method`` and a
+        ``use_segm`` flag for the SEP ``segmap``/``seg_id`` inputs.
+    """
+    return [
+        {'name': "aperture_mask_method='none' (SEP: no segmap)",
+         'method': 'none', 'use_segm': False},
+        {'name': "aperture_mask_method='mask' (SEP: segmap + seg_id)",
+         'method': 'mask', 'use_segm': True},
+    ]
+
+
+def make_catalog(scene, method):
+    """
+    Make a fresh `~photutils.segmentation.SourceCatalog` for a
+    scenario.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    method : str
+        The ``aperture_mask_method``.
+
+    Returns
+    -------
+    result : `~photutils.segmentation.SourceCatalog`
+        The catalog.
+    """
+    return SourceCatalog(scene['data'], scene['segm'],
+                         convolved_data=scene['convolved_data'],
+                         error=scene['error'], aperture_mask_method=method,
+                         kron_params=KRON_PARAMS)
+
+
+def compute_isophotal(catalog):
+    """
+    Compute the isophotal properties of a catalog.
+
+    Parameters
+    ----------
+    catalog : `~photutils.segmentation.SourceCatalog`
+        The catalog.
+    """
+    for name, _ in ISOPHOTAL_PROPERTIES:
+        getattr(catalog, name)
+
+
+def property_values(catalog, name):
+    """
+    Return a catalog property as a plain float array in the SEP
+    convention.
+
+    Parameters
+    ----------
+    catalog : `~photutils.segmentation.SourceCatalog`
+        The catalog.
+
+    name : str
+        The property name.
+
+    Returns
+    -------
+    result : `~numpy.ndarray`
+        The values (the orientation in radians, the zeroth-order
+        moment for ``'moments'``).
+    """
+    values = getattr(catalog, name)
+    if name == 'orientation':
+        return values.to_value(u.rad)
+    if name == 'moments':
+        return np.asarray(values[:, 0, 0], dtype=float)
+    return np.asarray(getattr(values, 'value', values), dtype=float)
+
+
+def sep_values(objects, field):
+    """
+    Return a ``sep.extract`` field in the photutils convention.
+
+    Parameters
+    ----------
+    objects : `~numpy.ndarray`
+        The ``sep.extract`` structured array.
+
+    field : str
+        The field name.
+
+    Returns
+    -------
+    result : `~numpy.ndarray`
+        The values (the centroid errors as standard deviations).
+    """
+    values = np.asarray(objects[field], dtype=float)
+    if field in ('errx2', 'erry2'):
+        return np.sqrt(values)
+    return values
+
+
+def sep_seg_kwargs(scene, scenario):
+    """
+    Return the SEP ``segmap``/``seg_id`` keyword arguments for a
+    scenario.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    scenario : dict
+        The scenario (an entry from ``build_scenarios``).
+
+    Returns
+    -------
+    result : dict
+        The keyword arguments (empty for the 'none' scenario).
+    """
+    if not scenario['use_segm']:
+        return {}
+    return {'segmap': scene['segm32'], 'seg_id': scene['labels']}
+
+
+def run_sep_extract(scene):
+    """
+    Run ``sep.extract`` on the existing segmentation map.
+
+    The detection threshold only sets the bookkeeping fields of the
+    SEP objects (the segmentation map defines the members of every
+    source); it matches the ``detect_sources`` threshold used to make
+    the scene.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    Returns
+    -------
+    objects : `~numpy.ndarray`
+        The ``sep.extract`` structured array, in segment-label order.
+    """
+    objects, _ = sep.extract(scene['data'], THRESHOLD, err=scene['error'],
+                             filter_kernel=scene['kernel'],
+                             filter_type='conv',
+                             segmentation_map=scene['segm32'])
+    return objects
+
+
+def sep_shape_inputs(objects):
+    """
+    Return the per-source SEP aperture inputs from the extracted
+    objects.
+
+    Parameters
+    ----------
+    objects : `~numpy.ndarray`
+        The ``sep.extract`` structured array.
+
+    Returns
+    -------
+    x, y, a, b, theta : `~numpy.ndarray`
+        The contiguous float64 centroid and ellipse parameter arrays.
+    """
+    return tuple(np.ascontiguousarray(objects[field], dtype=np.float64)
+                 for field in ('x', 'y', 'a', 'b', 'theta'))
+
+
+def run_sep_kron_radius(scene, shape, seg_kwargs):
+    """
+    Run ``sep.kron_radius`` and apply the ``SourceCatalog``
+    ``kron_params`` limits.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    shape : tuple of `~numpy.ndarray`
+        The ``(x, y, a, b, theta)`` arrays from ``sep_shape_inputs``.
+
+    seg_kwargs : dict
+        The SEP ``segmap``/``seg_id`` keyword arguments.
+
+    Returns
+    -------
+    kron_radius : `~numpy.ndarray`
+        The unscaled Kron radius with the minimum radius applied and
+        NaN above the measurement scale.
+
+    raw_kron_radius : `~numpy.ndarray`
+        The raw SEP measurement.
+    """
+    x, y, a, b, theta = shape
+    raw, _ = sep.kron_radius(scene['data'], x, y, a, b, theta,
+                             MAX_KRON_RADIUS, **seg_kwargs)
+    raw = np.asarray(raw, dtype=float)
+    kron_radius = np.where(raw > MAX_KRON_RADIUS, np.nan,
+                           np.maximum(raw, KRON_PARAMS[1]))
+    return kron_radius, raw
+
+
+def run_sep_kron_flux(scene, shape, kron_radius, seg_kwargs):
+    """
+    Run ``sep.sum_ellipse`` in the Kron aperture (exact overlap).
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    shape : tuple of `~numpy.ndarray`
+        The ``(x, y, a, b, theta)`` arrays from ``sep_shape_inputs``.
+
+    kron_radius : `~numpy.ndarray`
+        The unscaled Kron radius (NaN where undefined).
+
+    seg_kwargs : dict
+        The SEP ``segmap``/``seg_id`` keyword arguments.
+
+    Returns
+    -------
+    flux : `~numpy.ndarray`
+        The Kron flux (NaN where the Kron radius is undefined).
+    """
+    x, y, a, b, theta = shape
+    valid = np.isfinite(kron_radius)
+    scale = np.where(valid, KRON_PARAMS[0] * kron_radius, 1.0)
+    flux, _, _ = sep.sum_ellipse(scene['data'], x, y, a, b, theta, scale,
+                                 err=scene['error'], subpix=0,
+                                 **seg_kwargs)
+    return np.where(valid, flux, np.nan)
+
+
+def run_sep_flux_radius(scene, shape, kron_radius, kron_flux, seg_kwargs):
+    """
+    Run ``sep.flux_radius`` normalized by the Kron flux.
+
+    The maximum radius is the circular Kron radius
+    ``kron_params[0] * kron_radius * a``, as in
+    ``SourceCatalog.flux_radius``.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    shape : tuple of `~numpy.ndarray`
+        The ``(x, y, a, b, theta)`` arrays from ``sep_shape_inputs``.
+
+    kron_radius : `~numpy.ndarray`
+        The unscaled Kron radius (NaN where undefined).
+
+    kron_flux : `~numpy.ndarray`
+        The Kron flux.
+
+    seg_kwargs : dict
+        The SEP ``segmap``/``seg_id`` keyword arguments.
+
+    Returns
+    -------
+    radius : `~numpy.ndarray`
+        The radius enclosing ``FRACTION`` of the Kron flux (NaN where
+        the Kron radius or flux is undefined or the flux is zero).
+    """
+    x, y, a, _, _ = shape
+    rmax = KRON_PARAMS[0] * kron_radius * a
+    valid = (np.isfinite(rmax) & np.isfinite(kron_flux)
+             & (kron_flux != 0))
+    rmax = np.where(valid, rmax, 1.0)
+    normflux = np.where(valid, kron_flux, 1.0)
+    radius, _ = sep.flux_radius(scene['data'], x, y, rmax, FRACTION,
+                                normflux=normflux, subpix=5, **seg_kwargs)
+    return np.where(valid, radius, np.nan)
+
+
+def window_sigma(half_light_radius):
+    """
+    Return the windowed-centroid Gaussian sigma for a half-light
+    radius, as in ``SourceCatalog.centroid_win``.
+
+    Parameters
+    ----------
+    half_light_radius : `~numpy.ndarray`
+        The half-light radius.
+
+    Returns
+    -------
+    result : `~numpy.ndarray`
+        The window sigma (non-finite radii use the minimum radius).
+    """
+    radius = np.where(np.isfinite(half_light_radius), half_light_radius,
+                      MIN_HALF_LIGHT_RADIUS)
+    radius = np.maximum(radius, MIN_HALF_LIGHT_RADIUS)
+    return 2.0 * gaussian_fwhm_to_sigma * radius
+
+
+def run_sep_winpos(scene, shape, sigma):
+    """
+    Run ``sep.winpos`` with the 'center' pixel overlap (``subpix=1``),
+    matching the ``SourceCatalog`` default.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    shape : tuple of `~numpy.ndarray`
+        The ``(x, y, a, b, theta)`` arrays from ``sep_shape_inputs``.
+
+    sigma : `~numpy.ndarray`
+        The per-source window sigma.
+
+    Returns
+    -------
+    x, y : `~numpy.ndarray`
+        The windowed centroid.
+    """
+    x0, y0 = shape[0], shape[1]
+    x, y, _ = sep.winpos(scene['data'], x0, y0, sigma, subpix=1)
+    return np.asarray(x), np.asarray(y)
+
+
+def run_sep_sum_circle(scene, shape, seg_kwargs):
+    """
+    Run ``sep.sum_circle`` with exact overlap.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    shape : tuple of `~numpy.ndarray`
+        The ``(x, y, a, b, theta)`` arrays from ``sep_shape_inputs``.
+
+    seg_kwargs : dict
+        The SEP ``segmap``/``seg_id`` keyword arguments.
+
+    Returns
+    -------
+    flux : `~numpy.ndarray`
+        The circular aperture flux.
+    """
+    x, y = shape[0], shape[1]
+    flux, _, _ = sep.sum_circle(scene['data'], x, y, RADIUS,
+                                err=scene['error'], subpix=0, **seg_kwargs)
+    return np.asarray(flux)
+
+
+def run_sep_chain(scene, scenario):
+    """
+    Run the full SEP measurement chain.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    scenario : dict
+        The scenario (an entry from ``build_scenarios``).
+    """
+    seg_kwargs = sep_seg_kwargs(scene, scenario)
+    objects = run_sep_extract(scene)
+    shape = sep_shape_inputs(objects)
+    kron_radius, _ = run_sep_kron_radius(scene, shape, seg_kwargs)
+    kron_flux = run_sep_kron_flux(scene, shape, kron_radius, seg_kwargs)
+    half_light = run_sep_flux_radius(scene, shape, kron_radius, kron_flux,
+                                     seg_kwargs)
+    if not scenario['use_segm']:
+        run_sep_winpos(scene, shape, window_sigma(half_light))
+    run_sep_sum_circle(scene, shape, seg_kwargs)
+
+
+def run_catalog_chain(catalog):
+    """
+    Run the full ``SourceCatalog`` measurement chain.
+
+    Parameters
+    ----------
+    catalog : `~photutils.segmentation.SourceCatalog`
+        A fresh catalog.
+    """
+    compute_isophotal(catalog)
+    _ = catalog.kron_radius
+    _ = catalog.kron_flux
+    catalog.flux_radius(FRACTION)
+    _ = catalog.centroid_win
+    catalog.circular_photometry(RADIUS)
+
+
+def _check(name, phot, ref, *, rtol, atol, exact=False):
+    """
+    Compare photutils and SEP values and print one validation row.
+
+    Parameters
+    ----------
+    name : str
+        The row label.
+
+    phot, ref : `~numpy.ndarray`
+        The photutils and SEP values.
+
+    rtol, atol : float
+        The tolerances for `~numpy.testing.assert_allclose`.
+
+    exact : bool, optional
+        Whether to require exact equality (integer properties).
+
+    Returns
+    -------
+    ok : bool
+        Whether the comparison passed.
+    """
+    phot = np.asarray(phot, dtype=float)
+    ref = np.asarray(ref, dtype=float)
+    finite = np.isfinite(phot) & np.isfinite(ref)
+    n_nan_mismatch = np.count_nonzero(np.isfinite(phot) != np.isfinite(ref))
+    diff = np.abs(phot[finite] - ref[finite])
+    max_abs = diff.max() if diff.size else 0.0
+    scale = np.maximum(np.abs(ref[finite]), 1e-12)
+    max_rel = (diff / scale).max() if diff.size else 0.0
+
+    ok = n_nan_mismatch == 0
+    try:
+        if exact:
+            assert_array_equal(phot[finite], ref[finite])
+        else:
+            assert_allclose(phot[finite], ref[finite], rtol=rtol, atol=atol)
+    except AssertionError:
+        ok = False
+
+    status = 'ok  ' if ok else 'FAIL'
+    print(f'  {name:26s} {status}  n={finite.sum():5d}  '
+          f'max abs diff {max_abs:.2e}  max rel diff {max_rel:.2e}'
+          + (f'  ({n_nan_mismatch} NaN mismatches)' if n_nan_mismatch
+             else ''))
+    return ok
+
+
+def validate(scene, scenarios):
+    """
+    Validate the ``SourceCatalog`` properties against SEP.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    scenarios : list of dict
+        The scenarios from ``build_scenarios``.
+
+    Returns
+    -------
+    n_fail : int
+        The number of failed checks.
+    """
+    n_fail = 0
+    print('\n== Validation ==')
+    objects = run_sep_extract(scene)
+    shape = sep_shape_inputs(objects)
+
+    for scenario in scenarios:
+        print(f'\nScenario: {scenario["name"]}')
+        seg_kwargs = sep_seg_kwargs(scene, scenario)
+        catalog = make_catalog(scene, scenario['method'])
+
+        if len(objects) != catalog.n_labels:
+            print(f'  FAIL: SEP extracted {len(objects)} objects for '
+                  f'{catalog.n_labels} labels')
+            n_fail += 1
+            continue
+
+        if scenario is scenarios[0]:
+            # The isophotal properties do not depend on the
+            # aperture_mask_method
+            for name, field in ISOPHOTAL_PROPERTIES:
+                ok = _check(name, property_values(catalog, name),
+                            sep_values(objects, field), rtol=SEP_RTOL,
+                            atol=SEP_ATOL,
+                            exact=name in INTEGER_PROPERTIES)
+                n_fail += not ok
+        else:
+            print('  (isophotal properties are independent of the '
+                  'aperture_mask_method; see the first scenario)')
+
+        kron_radius, raw = run_sep_kron_radius(scene, shape, seg_kwargs)
+        n_unclipped = np.count_nonzero(np.isfinite(kron_radius)
+                                       & (raw == kron_radius))
+        ok = _check(f'kron_radius ({n_unclipped} unclipped)',
+                    property_values(catalog, 'kron_radius'), kron_radius,
+                    rtol=SEP_RTOL, atol=SEP_ATOL)
+        n_fail += not ok
+
+        kron_flux = run_sep_kron_flux(scene, shape, kron_radius, seg_kwargs)
+        ok = _check('kron_flux', catalog.kron_flux, kron_flux,
+                    rtol=SEP_RTOL, atol=SEP_ATOL)
+        n_fail += not ok
+
+        half_light = catalog.flux_radius(FRACTION).value
+        sep_half_light = run_sep_flux_radius(scene, shape, kron_radius,
+                                             kron_flux, seg_kwargs)
+        ok = _check(f'flux_radius({FRACTION}) [binned]', half_light,
+                    sep_half_light, rtol=FLUX_RADIUS_RTOL, atol=SEP_ATOL)
+        n_fail += not ok
+
+        if scenario['use_segm']:
+            print(f'  {"centroid_win":26s} n/a   (sep.winpos has no '
+                  'segmap support)')
+        else:
+            xwin, ywin = run_sep_winpos(scene, shape,
+                                        window_sigma(half_light))
+            finite = np.isfinite(half_light)
+            ok = _check('x_centroid_win [phot sigma]',
+                        np.asarray(catalog.x_centroid_win)[finite],
+                        xwin[finite], rtol=0.0, atol=CENTROID_WIN_ATOL)
+            n_fail += not ok
+            ok = _check('y_centroid_win [phot sigma]',
+                        np.asarray(catalog.y_centroid_win)[finite],
+                        ywin[finite], rtol=0.0, atol=CENTROID_WIN_ATOL)
+            n_fail += not ok
+
+        flux, _ = catalog.circular_photometry(RADIUS)
+        ok = _check(f'circular_photometry({RADIUS:g})', flux,
+                    run_sep_sum_circle(scene, shape, seg_kwargs),
+                    rtol=SEP_RTOL, atol=SEP_ATOL)
+        n_fail += not ok
+
+    result = 'ALL PASS' if n_fail == 0 else f'{n_fail} FAILURE(S)'
+    print(f'\nValidation result: {result}')
+    return n_fail
+
+
+def time_step(make_fresh_catalog, step, *, prepare=None, repeats=3):
+    """
+    Return the best time of ``step`` on fresh catalogs whose
+    prerequisite properties are computed by ``prepare``.
+
+    Parameters
+    ----------
+    make_fresh_catalog : callable
+        The zero-argument callable returning a fresh catalog.
+
+    step : callable
+        The callable taking the catalog and computing the timed step.
+
+    prepare : callable or `None`, optional
+        The callable taking the catalog and computing the
+        prerequisites outside of the timed region.
+
+    repeats : int, optional
+        The number of repeats (the best time is kept).
+
+    Returns
+    -------
+    result : float
+        The best wall-clock time in seconds.
+    """
+    best = np.inf
+    for _ in range(repeats):
+        catalog = make_fresh_catalog()
+        if prepare is not None:
+            prepare(catalog)
+        t0 = time.perf_counter()
+        step(catalog)
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+def benchmark(scene, scenarios, *, repeats=3):
+    """
+    Benchmark the ``SourceCatalog`` measurements against SEP.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene from ``make_scene``.
+
+    scenarios : list of dict
+        The scenarios from ``build_scenarios``.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    n_src = scene['segm'].n_labels
+    shape_ = scene['data'].shape
+    print(f'\n== Benchmark (best of {repeats}, {n_src} segments, '
+          f'{shape_[0]}x{shape_[1]} image; step times on a catalog with '
+          'the prerequisites computed) ==')
+
+    # The SEP inputs for the per-step timings
+    objects = run_sep_extract(scene)
+    shape = sep_shape_inputs(objects)
+
+    header = (f'{"benchmark":34s} {"photutils":>11s} {"SEP":>11s} '
+              f'{"phot/SEP":>10s}')
+
+    for scenario in scenarios:
+        seg_kwargs = sep_seg_kwargs(scene, scenario)
+        kron_radius, _ = run_sep_kron_radius(scene, shape, seg_kwargs)
+        kron_flux = run_sep_kron_flux(scene, shape, kron_radius, seg_kwargs)
+        half_light = run_sep_flux_radius(scene, shape, kron_radius,
+                                         kron_flux, seg_kwargs)
+        sigma = window_sigma(half_light)
+
+        def make_fresh_catalog(method=scenario['method']):
+            return make_catalog(scene, method)
+
+        def warm_kron_radius(catalog):
+            compute_isophotal(catalog)
+            _ = catalog.kron_radius
+
+        def warm_kron_flux(catalog):
+            warm_kron_radius(catalog)
+            _ = catalog.kron_flux
+
+        def warm_flux_radius(catalog):
+            warm_kron_flux(catalog)
+            catalog.flux_radius(FRACTION)
+
+        rows = [
+            ('isophotal properties (extract)', None, compute_isophotal,
+             lambda: run_sep_extract(scene)),
+            ('kron_radius', compute_isophotal,
+             lambda cat: cat.kron_radius,
+             lambda sk=seg_kwargs: run_sep_kron_radius(scene, shape, sk)),
+            ('kron_flux', warm_kron_radius,
+             lambda cat: cat.kron_flux,
+             lambda kr=kron_radius, sk=seg_kwargs:
+             run_sep_kron_flux(scene, shape, kr, sk)),
+            (f'flux_radius({FRACTION})', warm_kron_flux,
+             lambda cat: cat.flux_radius(FRACTION),
+             lambda kr=kron_radius, kf=kron_flux, sk=seg_kwargs:
+             run_sep_flux_radius(scene, shape, kr, kf, sk)),
+            ('centroid_win', warm_flux_radius,
+             lambda cat: cat.centroid_win,
+             None if scenario['use_segm']
+             else lambda sig=sigma: run_sep_winpos(scene, shape, sig)),
+            (f'circular_photometry({RADIUS:g})',
+             lambda cat: cat.x_centroid,
+             lambda cat: cat.circular_photometry(RADIUS),
+             lambda sk=seg_kwargs: run_sep_sum_circle(scene, shape, sk)),
+            ('full chain (cold catalog)', None, run_catalog_chain,
+             lambda sc=scenario: run_sep_chain(scene, sc)),
+        ]
+
+        print(f'\nScenario: {scenario["name"]}')
+        print(header)
+        print('-' * len(header))
+        for name, prepare, step, sep_step in rows:
+            t_phot = time_step(make_fresh_catalog, step, prepare=prepare,
+                               repeats=repeats)
+            if sep_step is None:
+                sep_ms = f'{"--":>11s}'
+                ratio = f'{"--":>10s}'
+            else:
+                t_sep = time_best(sep_step, repeats=repeats)
+                sep_ms = f'{t_sep * 1e3:11.2f}'
+                ratio = f'{t_phot / t_sep:10.2f}'
+            print(f'{name:34s} {t_phot * 1e3:11.2f} {sep_ms} {ratio}')
+
+    print('\n(times in ms; phot/SEP = SourceCatalog / SEP runtime ratio, '
+          'lower is faster; -- = no SEP analogue)')
+
+
+def main():
+    """
+    Run the SourceCatalog versus SEP comparison.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmark and validate SourceCatalog against SEP.')
+    parser.add_argument('--n-sources', type=int, default=1000,
+                        help='total number of Gaussian sources in the '
+                             'image (default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'validate', 'benchmark'],
+                        help='which part to run (default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+    if not HAS_SEP:
+        print(f'sep is not available ({SEP_IMPORT_ERROR}); nothing to '
+              'compare')
+        sys.exit(1)
+    print(f'sep {sep.__version__}')
+
+    scene = make_scene(args.n_sources, seed=args.seed)
+    # SEP needs room for every segment pixel on its pixel stack
+    sep.set_extract_pixstack(max(sep.get_extract_pixstack(),
+                                 scene['data'].size))
+    scenarios = build_scenarios()
+
+    n_fail = 0
+    if args.which in ('all', 'validate'):
+        n_fail = validate(scene, scenarios)
+    if args.which in ('all', 'benchmark'):
+        benchmark(scene, scenarios, repeats=args.repeats)
+
+    if n_fail:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/validate_catalog_versions.py
+++ b/benchmarks/validate_catalog_versions.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Validate SourceCatalog results across photutils versions.
+
+The ``dump`` command computes every array-valued ``SourceCatalog``
+property (plus the ``flux_radius``, ``circular_photometry``,
+``kron_photometry``, and default ``to_table`` outputs) for two
+deterministic scenes and several catalog configurations, using
+whichever photutils is importable, and writes them to a file. The
+``compare`` command loads two such files (e.g., from a released
+version and a development branch) and reports every entry that
+differs, grouped by property, along with the properties that exist in
+only one of the versions.
+
+The scenes are the blended Gaussian-pair image used by the
+``SourceCatalog`` benchmarks in ``bench_segmentation.py`` (with error,
+background, mask, and WCS inputs) and a small edge-case scene with
+close source pairs, sources touching every image edge, masked pixels
+spanning a close pair, and non-finite data values. The configurations
+cover the three ``aperture_mask_method`` values, a bare catalog, a
+local background, the minimum-circular-radius Kron aperture, sliced
+and scalar catalogs, and a ``detection_catalog``.
+
+The ``dump`` command uses only APIs available in photutils 3.0.0, so
+it can be run against that release and later. Run it once per
+photutils installation (e.g., with ``PYTHONPATH`` pointing at an
+unpacked wheel, from a directory that does not contain a photutils
+checkout), then compare::
+
+    python benchmarks/validate_catalog_versions.py dump old.pkl
+    python benchmarks/validate_catalog_versions.py dump new.pkl
+    python benchmarks/validate_catalog_versions.py compare old.pkl new.pkl
+
+The dump files are pickles; only load files that you created.
+
+Run ``python benchmarks/validate_catalog_versions.py --help`` to see
+the available options.
+"""
+
+import argparse
+import pickle
+import sys
+import warnings
+from collections import defaultdict
+
+import astropy.units as u
+import numpy as np
+from astropy.convolution import convolve
+from astropy.coordinates import SkyCoord
+from astropy.modeling.models import Gaussian2D
+from astropy.stats import gaussian_fwhm_to_sigma
+
+import photutils
+from photutils.datasets import make_wcs
+from photutils.segmentation import (SourceCatalog, detect_sources,
+                                    make_2dgaussian_kernel)
+
+
+def make_bench_scene(*, n_sources=300, spacing=25, fwhm=4.0, offset=6.0,
+                     seed=0):
+    """
+    Build the blended Gaussian-pair scene of the SourceCatalog
+    benchmarks, with error, background, mask, and WCS inputs.
+
+    This replicates ``bench_segmentation.make_source_image`` and
+    ``make_inputs`` without importing them, so that the dump can run
+    against any photutils installation.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources.
+
+    spacing : int, optional
+        The grid cell size in pixels.
+
+    fwhm : float, optional
+        The FWHM of the Gaussian sources in pixels.
+
+    offset : float, optional
+        The separation of the two sources within a cell in pixels.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    scene : dict
+        The ``data``, ``convolved_data``, ``segm``, ``error``,
+        ``background``, ``mask``, and ``wcs`` inputs.
+    """
+    n_cells = (n_sources + 1) // 2
+    n_grid = int(np.ceil(np.sqrt(n_cells)))
+    size = n_grid * spacing
+    rng = np.random.default_rng(seed)
+    data = rng.normal(0.0, 1.0, (size, size))
+    sigma = fwhm * gaussian_fwhm_to_sigma
+    yy, xx = np.mgrid[0:spacing, 0:spacing]
+    cen = (spacing - 1) / 2.0
+    half = offset / 2.0
+    for i in range(n_sources):
+        cell, pair = divmod(i, 2)
+        gy, gx = divmod(cell, n_grid)
+        sign = 1.0 if pair == 0 else -1.0
+        amplitude = 100.0 if pair == 0 else 60.0
+        xc = cen + sign * half + rng.uniform(-0.5, 0.5)
+        yc = cen + sign * half + rng.uniform(-0.5, 0.5)
+        model = Gaussian2D(amplitude, xc, yc, sigma, sigma)
+        x0 = gx * spacing
+        y0 = gy * spacing
+        data[y0:y0 + spacing, x0:x0 + spacing] += model(xx, yy)
+
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    segm = detect_sources(convolved_data, 5.0, 10)
+    error = np.full(data.shape, 1.0)
+    error[::7, ::11] = 1.5
+    background = rng.normal(0.1, 0.02, data.shape)
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[::23, ::17] = True
+    return {'data': data, 'convolved_data': convolved_data, 'segm': segm,
+            'error': error, 'background': background, 'mask': mask,
+            'wcs': make_wcs(data.shape)}
+
+
+def make_edge_scene(*, seed=0):
+    """
+    Build a small scene exercising the edge cases of the catalog
+    computations.
+
+    The scene contains isolated sources, close/overlapping pairs,
+    sources touching every image edge, masked pixels inside a source
+    and spanning a close pair, and non-finite data values inside a
+    source.
+
+    Parameters
+    ----------
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    scene : dict
+        The ``data``, ``convolved_data``, ``segm``, ``error``,
+        ``background``, ``mask``, and ``wcs`` inputs.
+    """
+    rng = np.random.default_rng(seed)
+    ny = nx = 151
+    yy, xx = np.mgrid[0:ny, 0:nx]
+    data = rng.normal(0.0, 0.1, (ny, nx))
+    positions = [(20, 20), (24, 26), (75, 75), (75, 81), (140, 20),
+                 (5, 100), (100, 4), (147, 147), (50, 120), (120, 50),
+                 (100, 100)]
+    for i, (xc, yc) in enumerate(positions):
+        amp = 5.0 + i
+        sig = 1.5 + 0.2 * (i % 4)
+        data += amp * np.exp(-((xx - xc) ** 2 + (yy - yc) ** 2)
+                             / (2 * sig ** 2))
+    error = np.full((ny, nx), 0.1)
+    error[::17, ::13] = 0.3
+    mask = np.zeros((ny, nx), dtype=bool)
+    mask[18:20, 22:24] = True  # inside a source of a close pair
+    mask[73:75, 72:84] = True  # spans a close pair
+    data[77, 78] = np.nan  # non-finite inside a source
+    data[75, 83] = np.inf
+    segm = detect_sources(data, 1.0, 5)
+    kernel = make_2dgaussian_kernel(2.0, size=5)
+    convolved_data = convolve(data, kernel)
+    return {'data': data, 'convolved_data': convolved_data, 'segm': segm,
+            'error': error, 'background': np.full(data.shape, 0.05),
+            'mask': mask, 'wcs': make_wcs(data.shape)}
+
+
+def build_configurations(scene):
+    """
+    Build the catalog keyword configurations for a scene.
+
+    Parameters
+    ----------
+    scene : dict
+        The scene inputs.
+
+    Returns
+    -------
+    result : dict
+        The ``SourceCatalog`` keyword arguments keyed by configuration
+        name.
+    """
+    full = {'convolved_data': scene['convolved_data'],
+            'error': scene['error'], 'background': scene['background'],
+            'mask': scene['mask'], 'wcs': scene['wcs']}
+    return {
+        'full_correct': dict(full),
+        'full_mask': {**full, 'aperture_mask_method': 'mask'},
+        'full_none': {**full, 'aperture_mask_method': 'none'},
+        'bare': {},
+        'localbkg': {'error': scene['error'], 'local_bkg_width': 6},
+        'kron_circ': {'error': scene['error'],
+                      'kron_params': (2.5, 1.4, 6.0)},
+    }
+
+
+def to_plain(value):
+    """
+    Convert a property value to plain NumPy data.
+
+    Parameters
+    ----------
+    value : object
+        The property value.
+
+    Returns
+    -------
+    result : `~numpy.ndarray`, list of `~numpy.ndarray`, or `None`
+        The plain data, or `None` if the value has no array form (e.g.,
+        a list of aperture objects).
+    """
+    if isinstance(value, SkyCoord):
+        return np.column_stack([value.ra.deg, value.dec.deg])
+    if isinstance(value, u.Quantity):
+        value = np.asarray(value.value)
+    if isinstance(value, np.ndarray):
+        return None if value.dtype == object else value
+    if (isinstance(value, (list, tuple)) and len(value)
+            and isinstance(value[0], np.ndarray)):
+        # A list of per-source arrays (cutouts)
+        return [np.ma.getdata(item) if isinstance(item, np.ma.MaskedArray)
+                else np.asarray(item) for item in value]
+    return None
+
+
+def dump_catalog(catalog, prefix, out):
+    """
+    Dump the results of a catalog into a dictionary.
+
+    Parameters
+    ----------
+    catalog : `~photutils.segmentation.SourceCatalog`
+        The catalog.
+
+    prefix : str
+        The key prefix (the scene and configuration names).
+
+    out : dict
+        The dictionary to update, keyed by ``'<prefix>:<property>'``.
+    """
+    for name in catalog.properties:
+        try:
+            value = getattr(catalog, name)
+        except Exception as exc:  # noqa: BLE001
+            out[f'{prefix}:{name}'] = f'ERROR: {exc!r}'
+            continue
+        plain = to_plain(value)
+        if plain is not None:
+            out[f'{prefix}:{name}'] = plain
+
+    for fraction in (0.5, 0.3):
+        out[f'{prefix}:flux_radius({fraction})'] = np.asarray(
+            catalog.flux_radius(fraction).value)
+    flux, flux_err = catalog.circular_photometry(5.0)
+    out[f'{prefix}:circular_photometry(5).flux'] = np.asarray(flux)
+    out[f'{prefix}:circular_photometry(5).flux_err'] = np.asarray(flux_err)
+    for kron_params in ((2.5, 1.4), (1.8, 1.0, 2.0)):
+        flux, flux_err = catalog.kron_photometry(kron_params)
+        name = f'kron_photometry({kron_params})'
+        out[f'{prefix}:{name}.flux'] = np.asarray(flux)
+        out[f'{prefix}:{name}.flux_err'] = np.asarray(flux_err)
+
+    table = catalog.to_table()
+    for column in table.colnames:
+        plain = to_plain(table[column])
+        if plain is None:
+            plain = np.asarray(table[column])
+        out[f'{prefix}:to_table.{column}'] = plain
+
+
+def dump(filename):
+    """
+    Compute the catalog results of the importable photutils and write
+    them to a file.
+
+    Parameters
+    ----------
+    filename : str
+        The output file.
+    """
+    warnings.simplefilter('ignore')
+    out = {'__version__': photutils.__version__}
+    scenes = (('bench', make_bench_scene()), ('edge', make_edge_scene()))
+    for scene_name, scene in scenes:
+        configurations = build_configurations(scene)
+        for config_name, kwargs in configurations.items():
+            catalog = SourceCatalog(scene['data'], scene['segm'], **kwargs)
+            dump_catalog(catalog, f'{scene_name}/{config_name}', out)
+
+        catalog = SourceCatalog(scene['data'], scene['segm'],
+                                **configurations['full_correct'])
+        dump_catalog(catalog[[0, 2, 3]], f'{scene_name}/slice', out)
+        dump_catalog(catalog[1], f'{scene_name}/scalar', out)
+
+        detection_catalog = SourceCatalog(scene['convolved_data'],
+                                          scene['segm'],
+                                          error=scene['error'])
+        catalog = SourceCatalog(scene['data'], scene['segm'],
+                                error=scene['error'],
+                                detection_catalog=detection_catalog)
+        dump_catalog(catalog, f'{scene_name}/detcat', out)
+
+    with open(filename, 'wb') as fh:
+        pickle.dump(out, fh)
+    print(f'photutils {photutils.__version__} ({photutils.__file__}): '
+          f'{len(out) - 1} entries written to {filename}')
+
+
+def _compare_arrays(value, reference, *, rtol, atol):
+    """
+    Compare two dumped arrays (see ``compare_values``).
+
+    Parameters
+    ----------
+    value, reference : array_like
+        The dumped arrays.
+
+    rtol, atol : float
+        The tolerances of the comparison.
+
+    Returns
+    -------
+    result : tuple
+        The ``(equal, max_abs, max_rel, note)`` tuple of
+        ``compare_values``.
+    """
+    value = np.asarray(value)
+    reference = np.asarray(reference)
+    if value.shape != reference.shape:
+        return (False, np.nan, np.nan,
+                f'shape {value.shape} versus {reference.shape}')
+    if value.dtype.kind in 'OUSb' or reference.dtype.kind in 'OUSb':
+        equal = np.array_equal(value, reference)
+        return equal, np.nan, np.nan, '' if equal else 'value mismatch'
+
+    value = value.astype(float)
+    reference = reference.astype(float)
+    if not (np.array_equal(np.isnan(value), np.isnan(reference))
+            and np.array_equal(np.isinf(value), np.isinf(reference))):
+        return False, np.nan, np.nan, 'NaN/inf pattern mismatch'
+    infinite = np.isinf(reference)
+    if not np.array_equal(value[infinite], reference[infinite]):
+        return False, np.nan, np.nan, 'inf sign mismatch'
+    finite = np.isfinite(reference)
+    diff = np.abs(value[finite] - reference[finite])
+    if diff.size == 0:
+        return True, 0.0, 0.0, ''
+    scale = np.maximum(np.abs(reference[finite]), 1e-300)
+    equal = bool(np.allclose(value[finite], reference[finite], rtol=rtol,
+                             atol=atol))
+    return equal, float(diff.max()), float((diff / scale).max()), ''
+
+
+def compare_values(value, reference, *, rtol, atol):
+    """
+    Compare two dumped values.
+
+    Parameters
+    ----------
+    value, reference : object
+        The dumped values.
+
+    rtol, atol : float
+        The tolerances of the comparison.
+
+    Returns
+    -------
+    equal : bool
+        Whether the values agree within the tolerances.
+
+    max_abs, max_rel : float
+        The maximum absolute and relative differences of the finite
+        values (NaN if not applicable).
+
+    note : str
+        A description of a structural mismatch, or an empty string.
+    """
+    if isinstance(value, str) or isinstance(reference, str):
+        equal = value == reference
+        return equal, np.nan, np.nan, '' if equal else 'error mismatch'
+    if not (isinstance(value, list) or isinstance(reference, list)):
+        return _compare_arrays(value, reference, rtol=rtol, atol=atol)
+
+    # Lists of per-source arrays (cutouts)
+    if not (isinstance(value, list) and isinstance(reference, list)):
+        return False, np.nan, np.nan, 'list versus array'
+    if len(value) != len(reference):
+        return (False, np.nan, np.nan,
+                f'length {len(value)} versus {len(reference)}')
+    worst = (True, 0.0, 0.0, '')
+    for item, ref_item in zip(value, reference, strict=True):
+        result = _compare_arrays(item, ref_item, rtol=rtol, atol=atol)
+        if not result[0]:
+            worst = (False, np.nanmax([worst[1], result[1]]),
+                     np.nanmax([worst[2], result[2]]), result[3])
+    return worst
+
+
+def compare(reference_file, new_file, *, rtol, atol):
+    """
+    Compare two dump files and print the differences.
+
+    Parameters
+    ----------
+    reference_file, new_file : str
+        The reference and new dump files.
+
+    rtol, atol : float
+        The tolerances of the comparison.
+
+    Returns
+    -------
+    n_differ : int
+        The number of differing entries.
+    """
+    with open(reference_file, 'rb') as fh:
+        reference = pickle.load(fh)  # noqa: S301
+    with open(new_file, 'rb') as fh:
+        new = pickle.load(fh)  # noqa: S301
+    ref_version = reference.pop('__version__', 'unknown')
+    new_version = new.pop('__version__', 'unknown')
+    print(f'reference: photutils {ref_version} ({len(reference)} entries)')
+    print(f'new:       photutils {new_version} ({len(new)} entries)')
+
+    ref_keys = set(reference)
+    new_keys = set(new)
+    only_ref = sorted({key.split(':', 1)[1] for key in ref_keys - new_keys})
+    only_new = sorted({key.split(':', 1)[1] for key in new_keys - ref_keys})
+    if only_ref:
+        print(f'\nproperties only in the reference: {only_ref}')
+    if only_new:
+        print(f'\nproperties only in the new version: {only_new}')
+
+    common = sorted(ref_keys & new_keys)
+    same = defaultdict(int)
+    differ = defaultdict(list)
+    for key in common:
+        name = key.split(':', 1)[1]
+        result = compare_values(new[key], reference[key], rtol=rtol,
+                                atol=atol)
+        if result[0]:
+            same[name] += 1
+        else:
+            differ[name].append((key, *result[1:]))
+
+    print(f'\n== identical within rtol={rtol:g}, atol={atol:g}: '
+          f'{sum(same.values())} entries, {len(same)} properties ==')
+    n_differ = sum(len(items) for items in differ.values())
+    print(f'\n== differing: {n_differ} entries, {len(differ)} '
+          'properties ==')
+    for name in sorted(differ):
+        items = differ[name]
+        rel = [item[2] for item in items if np.isfinite(item[2])]
+        max_rel = f'{max(rel):.2e}' if rel else 'n/a'
+        notes = sorted({item[3] for item in items} - {''})
+        print(f'  {name:44s} n={len(items):3d}  max rel diff '
+              f'{max_rel:>8s}  {notes}')
+        for key, max_abs, max_rel, note in items:
+            print(f'      {key:56s} max abs {max_abs:.2e} '
+                  f'max rel {max_rel:.2e} {note}')
+    return n_differ
+
+
+def main():
+    """
+    Run the SourceCatalog cross-version validation.
+    """
+    parser = argparse.ArgumentParser(
+        description='Validate SourceCatalog results across photutils '
+                    'versions.')
+    subparsers = parser.add_subparsers(dest='command', required=True)
+    dump_parser = subparsers.add_parser(
+        'dump', help='compute the results of the importable photutils '
+                     'and write them to a file')
+    dump_parser.add_argument('filename', help='the output file')
+    compare_parser = subparsers.add_parser(
+        'compare', help='compare two dump files')
+    compare_parser.add_argument('reference', help='the reference dump '
+                                                  'file')
+    compare_parser.add_argument('new', help='the new dump file')
+    compare_parser.add_argument('--rtol', type=float, default=1e-10,
+                                help='relative tolerance '
+                                     '(default: %(default)s)')
+    compare_parser.add_argument('--atol', type=float, default=1e-6,
+                                help='absolute tolerance '
+                                     '(default: %(default)s)')
+    args = parser.parse_args()
+
+    if args.command == 'dump':
+        dump(args.filename)
+    else:
+        n_differ = compare(args.reference, args.new, rtol=args.rtol,
+                           atol=args.atol)
+        if n_differ:
+            sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -614,6 +614,25 @@ are package-specific, so always decode a flag column with the decoder of
 the package that produced it.
 
 
+Faster Source Catalog Measurements
+==================================
+
+`~photutils.segmentation.SourceCatalog` is now significantly faster.
+The windowed and quadratic centroids, Kron radii and photometry,
+``flux_radius``, ``circular_photometry``, image moments, ``perimeter``,
+``gini``, and the segment pixel statistics (e.g., ``segment_flux``,
+``area``, and ``min_value``) are each computed for all sources in a
+single call into compiled code, replacing the per-source Python loops
+and cutouts. Typical speedups range from ~3x to ~20x depending on
+the property, and the ``flags`` attribute and the default
+:meth:`~photutils.segmentation.SourceCatalog.to_table` output are
+about 5x faster for large catalogs. The results are unchanged to
+within floating-point rounding. Because no property loops over the
+sources in Python any more, no progress bar is displayed and the
+``progress_bar`` keyword is deprecated (see :ref:`New Deprecations
+<whatsnew-3.1-deprecations>`).
+
+
 ``GriddedPSFModel`` Performance Improvements
 ============================================
 
@@ -664,6 +683,14 @@ attribute has been renamed to ``n_positions``, matching the
 `~photutils.aperture.AperturePhotometry` attribute of the same name
 (both count the aperture positions). The old ``n_apertures`` name is
 deprecated and will be removed in version 4.0.
+
+``SourceCatalog.progress_bar`` Deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `~photutils.segmentation.SourceCatalog` ``progress_bar`` keyword
+is deprecated and will be removed in version 4.0. All property
+calculations are now computed for all sources at once in compiled
+code, so no progress bar is displayed and the keyword has no effect.
 
 
 Removed Deprecations

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -620,8 +620,9 @@ Faster Source Catalog Measurements
 `~photutils.segmentation.SourceCatalog` is now significantly faster.
 The windowed and quadratic centroids, Kron radii and photometry,
 ``flux_radius``, ``circular_photometry``, image moments, ``perimeter``,
-``gini``, and the segment pixel statistics (e.g., ``segment_flux``,
-``area``, and ``min_value``) are each computed for all sources in a
+``gini``, the segment pixel statistics (e.g., ``segment_flux``,
+``area``, and ``min_value``), and the positions of the minimum and
+maximum pixel values are each computed for all sources in a
 single call into compiled code, replacing the per-source Python loops
 and cutouts. Typical speedups range from ~3x to ~20x depending on
 the property, and the ``flags`` attribute and the default

--- a/photutils/aperture/_batch_outside.pxd
+++ b/photutils/aperture/_batch_outside.pxd
@@ -1,0 +1,58 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Declarations of the outside-weight scan of the batch aperture
+photometry driver (see ``_batch_outside.pyx``).
+"""
+
+
+ctypedef struct _ShapeSpec:
+    # The aperture shape parameters of one batch_aperture_sums call.
+    # The pointer members reference scratch buffers local to that call.
+    int shape_code
+    int use_exact
+    int subpixels
+    double r_in
+    double r_out
+    double rx_in
+    double ry_in
+    double rx_out
+    double ry_out
+    double cos_theta
+    double sin_theta
+    double half_width_in
+    double half_height_in
+    double half_width_out
+    double half_height_out
+    double bbox_dx_in
+    double bbox_dy_in
+    double bbox_dx_out
+    double bbox_dy_out
+    double *poly_x_in
+    double *poly_y_in
+    double *poly_x_out
+    double *poly_y_out
+    double *buf_a_x
+    double *buf_a_y
+    double *buf_b_x
+    double *buf_b_y
+    double *poly_x
+    double *poly_y
+    int n_poly
+    int poly_buf_size
+    int is_poly_convex
+    double *pedge_nx
+    double *pedge_ny
+    double *pedge_c
+    double *pbuf_a_x
+    double *pbuf_a_y
+    double *pbuf_b_x
+    double *pbuf_b_y
+
+
+cdef bint outside_weight(const _ShapeSpec *sp, bint inside_any,
+                         double gxmin, double gymin, double dx, double dy,
+                         double pixel_radius, double norm,
+                         Py_ssize_t ixmin, Py_ssize_t iymin,
+                         Py_ssize_t ixmax_full, Py_ssize_t iymax_full,
+                         Py_ssize_t ix0, Py_ssize_t ix1, Py_ssize_t iy0,
+                         Py_ssize_t iy1) noexcept nogil

--- a/photutils/aperture/_batch_outside.pyx
+++ b/photutils/aperture/_batch_outside.pyx
@@ -75,6 +75,66 @@ cdef inline double _shape_pixel_frac(const _ShapeSpec *sp, double pxmin,
         sp.pbuf_b_y, sp.poly_buf_size, sp.use_exact, sp.subpixels)
 
 
+cdef inline bint _ring_row(const _ShapeSpec *sp, Py_ssize_t iy,
+                           Py_ssize_t ix_start, Py_ssize_t ix_stop,
+                           Py_ssize_t ixc, double gxmin, double gymin,
+                           double dx, double dy, double pixel_radius,
+                           double norm, Py_ssize_t ixmin,
+                           Py_ssize_t iymin) noexcept nogil:
+    """
+    Whether a pixel of row ``iy`` in ``[ix_start, ix_stop)`` has a
+    nonzero fraction, testing outward from the column ``ixc`` nearest
+    the aperture center (where a crossing of the data edge is found
+    soonest).
+    """
+    cdef Py_ssize_t lo, hi
+    cdef double pymin = gymin + (iy - iymin) * dy
+    lo = ixc if ixc > ix_start else ix_start
+    lo = lo if lo < ix_stop else ix_stop - 1
+    hi = lo + 1
+    while lo >= ix_start or hi < ix_stop:
+        if lo >= ix_start:
+            if _shape_pixel_frac(sp, gxmin + (lo - ixmin) * dx, pymin,
+                                 dx, dy, pixel_radius, norm) > 0.0:
+                return True
+            lo -= 1
+        if hi < ix_stop:
+            if _shape_pixel_frac(sp, gxmin + (hi - ixmin) * dx, pymin,
+                                 dx, dy, pixel_radius, norm) > 0.0:
+                return True
+            hi += 1
+    return False
+
+
+cdef inline bint _ring_column(const _ShapeSpec *sp, Py_ssize_t ix,
+                              Py_ssize_t iy_start, Py_ssize_t iy_stop,
+                              Py_ssize_t iyc, double gxmin, double gymin,
+                              double dx, double dy, double pixel_radius,
+                              double norm, Py_ssize_t ixmin,
+                              Py_ssize_t iymin) noexcept nogil:
+    """
+    The ``_ring_row`` test for the column ``ix`` over the rows
+    ``[iy_start, iy_stop)``, testing outward from the row ``iyc``.
+    """
+    cdef Py_ssize_t lo, hi
+    cdef double pxmin = gxmin + (ix - ixmin) * dx
+    lo = iyc if iyc > iy_start else iy_start
+    lo = lo if lo < iy_stop else iy_stop - 1
+    hi = lo + 1
+    while lo >= iy_start or hi < iy_stop:
+        if lo >= iy_start:
+            if _shape_pixel_frac(sp, pxmin, gymin + (lo - iymin) * dy,
+                                 dx, dy, pixel_radius, norm) > 0.0:
+                return True
+            lo -= 1
+        if hi < iy_stop:
+            if _shape_pixel_frac(sp, pxmin, gymin + (hi - iymin) * dy,
+                                 dx, dy, pixel_radius, norm) > 0.0:
+                return True
+            hi += 1
+    return False
+
+
 cdef bint outside_weight(const _ShapeSpec *sp, bint inside_any,
                          double gxmin, double gymin, double dx, double dy,
                          double pixel_radius, double norm,
@@ -128,42 +188,34 @@ cdef bint outside_weight(const _ShapeSpec *sp, bint inside_any,
         `True` if a pixel outside the data has a nonzero overlap
         fraction.
     """
-    cdef Py_ssize_t ix, iy, cx0, cx1
+    cdef Py_ssize_t ix, iy, cx0, cx1, ixc, iyc
     cdef double pxmin, pymin
 
     if sp.use_exact and inside_any:
         # The columns of the rows just outside the top and bottom data
-        # edges include the corner pixels
+        # edges include the corner pixels. Each ring row or column is
+        # tested outward from the pixel nearest the aperture center,
+        # where the shape most likely crosses the data edge.
         cx0 = ixmin if ixmin > ix0 - 1 else ix0 - 1
         cx1 = ixmax_full if ixmax_full < ix1 + 1 else ix1 + 1
-        if iymin < iy0:
-            pymin = gymin + (iy0 - 1 - iymin) * dy
-            for ix in range(cx0, cx1):
-                pxmin = gxmin + (ix - ixmin) * dx
-                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
-                                     pixel_radius, norm) > 0.0:
-                    return True
-        if iy1 < iymax_full:
-            pymin = gymin + (iy1 - iymin) * dy
-            for ix in range(cx0, cx1):
-                pxmin = gxmin + (ix - ixmin) * dx
-                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
-                                     pixel_radius, norm) > 0.0:
-                    return True
-        if ixmin < ix0:
-            pxmin = gxmin + (ix0 - 1 - ixmin) * dx
-            for iy in range(iy0, iy1):
-                pymin = gymin + (iy - iymin) * dy
-                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
-                                     pixel_radius, norm) > 0.0:
-                    return True
-        if ix1 < ixmax_full:
-            pxmin = gxmin + (ix1 - ixmin) * dx
-            for iy in range(iy0, iy1):
-                pymin = gymin + (iy - iymin) * dy
-                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
-                                     pixel_radius, norm) > 0.0:
-                    return True
+        ixc = ixmin + <Py_ssize_t>(-gxmin / dx)
+        iyc = iymin + <Py_ssize_t>(-gymin / dy)
+        if iymin < iy0 and _ring_row(sp, iy0 - 1, cx0, cx1, ixc, gxmin,
+                                     gymin, dx, dy, pixel_radius, norm,
+                                     ixmin, iymin):
+            return True
+        if iy1 < iymax_full and _ring_row(sp, iy1, cx0, cx1, ixc, gxmin,
+                                          gymin, dx, dy, pixel_radius,
+                                          norm, ixmin, iymin):
+            return True
+        if ixmin < ix0 and _ring_column(sp, ix0 - 1, iy0, iy1, iyc, gxmin,
+                                        gymin, dx, dy, pixel_radius, norm,
+                                        ixmin, iymin):
+            return True
+        if ix1 < ixmax_full and _ring_column(sp, ix1, iy0, iy1, iyc, gxmin,
+                                             gymin, dx, dy, pixel_radius,
+                                             norm, ixmin, iymin):
+            return True
         return False
 
     # Sampled overlap: test every outside pixel of the unclipped

--- a/photutils/aperture/_batch_outside.pyx
+++ b/photutils/aperture/_batch_outside.pyx
@@ -1,0 +1,191 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: freethreading_compatible=True
+"""
+The outside-weight scan of the batch aperture photometry driver.
+
+``batch_aperture_sums`` reports, for each aperture whose bounding box
+is clipped by a data edge, whether the aperture has a nonzero-fraction
+pixel outside the data. The scan lives in its own extension module so
+that the per-shape pixel-overlap helpers of ``_batch_overlap.pxd``
+keep a single call site in the driver's translation unit: with more
+call sites the C compiler stops inlining the larger helpers into the
+driver's per-pixel loop, which measured up to 30% slower.
+
+The scan runs without the GIL and uses no global mutable state, so it
+is safe to call from multiple threads, including on free-threaded
+Python builds.
+"""
+
+from photutils.aperture._batch_overlap cimport (
+    _CIRCLE, _CIRCULAR_ANNULUS, _ELLIPSE, _ELLIPTICAL_ANNULUS, _RECTANGLE,
+    _RECTANGULAR_ANNULUS, _circle_pixel_frac, _circular_annulus_pixel_frac,
+    _ellipse_pixel_frac, _elliptical_annulus_pixel_frac, _polygon_pixel_frac,
+    _rect_pixel_frac, _rectangular_annulus_pixel_frac)
+
+__all__ = []
+
+
+cdef inline double _shape_pixel_frac(const _ShapeSpec *sp, double pxmin,
+                                     double pymin, double dx, double dy,
+                                     double pixel_radius,
+                                     double norm) noexcept nogil:
+    """
+    Return the overlap fraction of one pixel with the aperture shape.
+
+    This is the same dispatch on the shape code that the accumulation
+    loop of ``batch_aperture_sums`` carries inline over its local
+    variables. Keep the two in step.
+    """
+    if sp.shape_code == _CIRCLE:
+        return _circle_pixel_frac(pxmin, pymin, dx, dy, pixel_radius,
+                                  sp.r_out, sp.use_exact, sp.subpixels)
+    if sp.shape_code == _CIRCULAR_ANNULUS:
+        return _circular_annulus_pixel_frac(
+            pxmin, pymin, dx, dy, pixel_radius, sp.r_in, sp.r_out,
+            sp.use_exact, sp.subpixels)
+    if sp.shape_code == _ELLIPSE:
+        return _ellipse_pixel_frac(
+            pxmin, pymin, dx, dy, norm, sp.rx_out, sp.ry_out,
+            sp.cos_theta, sp.sin_theta, sp.use_exact, sp.subpixels)
+    if sp.shape_code == _ELLIPTICAL_ANNULUS:
+        return _elliptical_annulus_pixel_frac(
+            pxmin, pymin, dx, dy, norm, sp.rx_in, sp.ry_in, sp.rx_out,
+            sp.ry_out, sp.cos_theta, sp.sin_theta, sp.use_exact,
+            sp.subpixels)
+    if sp.shape_code == _RECTANGLE:
+        return _rect_pixel_frac(
+            pxmin, pymin, dx, dy, pixel_radius, sp.half_width_out,
+            sp.half_height_out, sp.cos_theta, sp.sin_theta,
+            sp.bbox_dx_out, sp.bbox_dy_out, sp.poly_x_out, sp.poly_y_out,
+            sp.buf_a_x, sp.buf_a_y, sp.buf_b_x, sp.buf_b_y, sp.use_exact,
+            sp.subpixels)
+    if sp.shape_code == _RECTANGULAR_ANNULUS:
+        return _rectangular_annulus_pixel_frac(
+            pxmin, pymin, dx, dy, pixel_radius, sp.half_width_in,
+            sp.half_height_in, sp.half_width_out, sp.half_height_out,
+            sp.cos_theta, sp.sin_theta, sp.bbox_dx_in, sp.bbox_dy_in,
+            sp.bbox_dx_out, sp.bbox_dy_out, sp.poly_x_in, sp.poly_y_in,
+            sp.poly_x_out, sp.poly_y_out, sp.buf_a_x, sp.buf_a_y,
+            sp.buf_b_x, sp.buf_b_y, sp.use_exact, sp.subpixels)
+    return _polygon_pixel_frac(
+        pxmin, pymin, dx, dy, pixel_radius, sp.poly_x, sp.poly_y,
+        sp.n_poly, sp.pedge_nx, sp.pedge_ny, sp.pedge_c,
+        sp.is_poly_convex, sp.pbuf_a_x, sp.pbuf_a_y, sp.pbuf_b_x,
+        sp.pbuf_b_y, sp.poly_buf_size, sp.use_exact, sp.subpixels)
+
+
+cdef bint outside_weight(const _ShapeSpec *sp, bint inside_any,
+                         double gxmin, double gymin, double dx, double dy,
+                         double pixel_radius, double norm,
+                         Py_ssize_t ixmin, Py_ssize_t iymin,
+                         Py_ssize_t ixmax_full, Py_ssize_t iymax_full,
+                         Py_ssize_t ix0, Py_ssize_t ix1, Py_ssize_t iy0,
+                         Py_ssize_t iy1) noexcept nogil:
+    """
+    Whether an aperture whose bounding box is clipped by a data edge
+    has a nonzero-fraction pixel outside the data.
+
+    For the exact overlap method, when the aperture has a
+    nonzero-fraction pixel inside the data, only the one-pixel ring
+    just outside the data edges (within the unclipped bounding box) is
+    tested. Every aperture shape is a connected region, so one with
+    positive area both inside and outside the data crosses the data
+    boundary at an interior point, and the ring pixel containing that
+    point has a positive exact overlap. This makes the cost of the test
+    scale with the data perimeter rather than with the (possibly
+    enormous) bounding-box area.
+
+    Otherwise every outside pixel is tested until one has a nonzero
+    fraction: the center and subpixel methods sample the shape at
+    pixel or subpixel centers, for which the ring argument does not
+    hold, and an aperture with no weight inside the data may lie
+    entirely in the clipped-away part of its bounding box (that scan
+    is short, because such a shape reaches the first rows of its own
+    bounding box).
+
+    Parameters
+    ----------
+    sp : const _ShapeSpec *
+        The aperture shape parameters.
+
+    inside_any : bint
+        Whether the aperture has a nonzero-fraction pixel inside the
+        data.
+
+    gxmin, gymin, dx, dy, pixel_radius, norm : double
+        The pixel grid of the source (see ``_source_grid_setup``).
+
+    ixmin, iymin, ixmax_full, iymax_full : Py_ssize_t
+        The unclipped bounding box (the maxima are exclusive).
+
+    ix0, ix1, iy0, iy1 : Py_ssize_t
+        The bounding box clipped to the data (the maxima are exclusive).
+
+    Returns
+    -------
+    result : bint
+        `True` if a pixel outside the data has a nonzero overlap
+        fraction.
+    """
+    cdef Py_ssize_t ix, iy, cx0, cx1
+    cdef double pxmin, pymin
+
+    if sp.use_exact and inside_any:
+        # The columns of the rows just outside the top and bottom data
+        # edges include the corner pixels
+        cx0 = ixmin if ixmin > ix0 - 1 else ix0 - 1
+        cx1 = ixmax_full if ixmax_full < ix1 + 1 else ix1 + 1
+        if iymin < iy0:
+            pymin = gymin + (iy0 - 1 - iymin) * dy
+            for ix in range(cx0, cx1):
+                pxmin = gxmin + (ix - ixmin) * dx
+                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
+                                     pixel_radius, norm) > 0.0:
+                    return True
+        if iy1 < iymax_full:
+            pymin = gymin + (iy1 - iymin) * dy
+            for ix in range(cx0, cx1):
+                pxmin = gxmin + (ix - ixmin) * dx
+                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
+                                     pixel_radius, norm) > 0.0:
+                    return True
+        if ixmin < ix0:
+            pxmin = gxmin + (ix0 - 1 - ixmin) * dx
+            for iy in range(iy0, iy1):
+                pymin = gymin + (iy - iymin) * dy
+                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
+                                     pixel_radius, norm) > 0.0:
+                    return True
+        if ix1 < ixmax_full:
+            pxmin = gxmin + (ix1 - ixmin) * dx
+            for iy in range(iy0, iy1):
+                pymin = gymin + (iy - iymin) * dy
+                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
+                                     pixel_radius, norm) > 0.0:
+                    return True
+        return False
+
+    # Sampled overlap: test every outside pixel of the unclipped
+    # bounding box, skipping the columns inside the data on the rows
+    # that overlap it
+    for iy in range(iymin, iymax_full):
+        pymin = gymin + (iy - iymin) * dy
+        if iy0 <= iy < iy1:
+            for ix in range(ixmin, ix0):
+                pxmin = gxmin + (ix - ixmin) * dx
+                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
+                                     pixel_radius, norm) > 0.0:
+                    return True
+            for ix in range(ix1, ixmax_full):
+                pxmin = gxmin + (ix - ixmin) * dx
+                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
+                                     pixel_radius, norm) > 0.0:
+                    return True
+        else:
+            for ix in range(ixmin, ixmax_full):
+                pxmin = gxmin + (ix - ixmin) * dx
+                if _shape_pixel_frac(sp, pxmin, pymin, dx, dy,
+                                     pixel_radius, norm) > 0.0:
+                    return True
+    return False

--- a/photutils/aperture/_batch_overlap.pxd
+++ b/photutils/aperture/_batch_overlap.pxd
@@ -87,12 +87,15 @@ cdef inline bint _resolve_seg_pixel(const Py_ssize_t *segmentation,
                                     Py_ssize_t *n_seg_px,
                                     Py_ssize_t *n_uncorr) noexcept nogil:
     """
-    Apply the segmentation masking method to a single unmasked pixel.
+    Apply the segmentation masking method to a single pixel.
 
     This is the segmentation-masking step shared by the per-pixel
     loops of ``_batch_photometry.batch_aperture_sums`` and
     ``_batch_stats.batch_aperture_gather``. The caller must invoke it
     only when a segmentation array is present and ``label`` is nonzero.
+    It is normally called on unmasked pixels, but a caller may also call
+    it on a masked pixel purely for its counter side effects, in which
+    case its return value is ignored.
 
     Parameters
     ----------

--- a/photutils/aperture/_batch_overlap.pxd
+++ b/photutils/aperture/_batch_overlap.pxd
@@ -75,7 +75,17 @@ cdef inline Py_ssize_t _round_half_away(double x) noexcept nogil:
     return <Py_ssize_t>ceil(x - 0.5)
 
 
-cdef inline bint _resolve_seg_pixel(const Py_ssize_t *segmentation,
+cdef enum:
+    # Outcomes of the segmentation masking method for a single pixel
+    # (see ``_classify_seg_pixel``)
+    _SEG_SOURCE = 0
+    _SEG_EXCLUDED = 1
+    _SEG_NEIGHBOR = 2
+    _SEG_CORRECTED = 3
+    _SEG_UNCORRECTED = 4
+
+
+cdef inline int _classify_seg_pixel(const Py_ssize_t *segmentation,
                                     const unsigned char *mask,
                                     Py_ssize_t nx_data, int seg_method,
                                     Py_ssize_t label,
@@ -83,19 +93,18 @@ cdef inline bint _resolve_seg_pixel(const Py_ssize_t *segmentation,
                                     Py_ssize_t ix0, Py_ssize_t ix1,
                                     Py_ssize_t iy0, Py_ssize_t iy1,
                                     Py_ssize_t ccx, Py_ssize_t ccy,
-                                    Py_ssize_t *six, Py_ssize_t *siy,
-                                    Py_ssize_t *n_seg_px,
-                                    Py_ssize_t *n_uncorr) noexcept nogil:
+                                    Py_ssize_t *six,
+                                    Py_ssize_t *siy) noexcept nogil:
     """
-    Apply the segmentation masking method to a single pixel.
+    Classify a single pixel under the segmentation masking method.
 
-    This is the segmentation-masking step shared by the per-pixel
-    loops of ``_batch_photometry.batch_aperture_sums`` and
-    ``_batch_stats.batch_aperture_gather``. The caller must invoke it
+    This is the segmentation-masking query shared by the per-pixel
+    loops of the aperture and segmentation batch drivers. It has no
+    side effects other than writing the mirror pixel coordinates of a
+    corrected pixel, so a caller counts or uses the outcome as it
+    needs (see the ``_resolve_seg_pixel`` and
+    ``_seg_pixel_contributes`` wrappers). The caller must invoke it
     only when a segmentation array is present and ``label`` is nonzero.
-    It is normally called on unmasked pixels, but a caller may also call
-    it on a masked pixel purely for its counter side effects, in which
-    case its return value is ignored.
 
     Parameters
     ----------
@@ -130,10 +139,108 @@ cdef inline bint _resolve_seg_pixel(const Py_ssize_t *segmentation,
         The rounded aperture center used by the method-3 mirror.
 
     six, siy : Py_ssize_t *
-        Output. The coordinates of the pixel whose value contributes.
-        Overwritten (with the mirror pixel) only by a successful
-        method-3 correction.
+        Output. Overwritten with the mirror pixel coordinates only for
+        a ``_SEG_CORRECTED`` outcome.
 
+    Returns
+    -------
+    code : int
+        One of the ``_SEG_*`` codes:
+
+        * ``_SEG_SOURCE``: not a neighbor-source pixel (or the method
+          is disabled); the pixel contributes its own value
+        * ``_SEG_EXCLUDED``: a background pixel excluded by method 2
+          (not a neighbor-source pixel)
+        * ``_SEG_NEIGHBOR``: a neighbor-source pixel excluded by method
+          1 or 2
+        * ``_SEG_CORRECTED``: a neighbor-source pixel replaced by the
+          mirror pixel written to ``(siy[0], six[0])`` (method 3)
+        * ``_SEG_UNCORRECTED``: a neighbor-source pixel whose mirror
+          pixel is unavailable (method 3); the pixel is excluded
+    """
+    cdef Py_ssize_t seg_val = segmentation[iy * nx_data + ix]
+    cdef Py_ssize_t xm, ym, mseg
+
+    if seg_method == 1:
+        if seg_val != 0 and seg_val != label:
+            return _SEG_NEIGHBOR
+    elif seg_method == 2:
+        if seg_val != label:
+            # Only neighbor-source pixels (not background pixels)
+            # count toward the neighbor-pixels flag.
+            return _SEG_NEIGHBOR if seg_val != 0 else _SEG_EXCLUDED
+    elif seg_method == 3:
+        if seg_val != 0 and seg_val != label:
+            # Neighbor pixel: replace its value with the pixel
+            # mirrored across the center, if that pixel is available.
+            xm = 2 * ccx - ix
+            ym = 2 * ccy - iy
+            if xm < ix0 or xm >= ix1 or ym < iy0 or ym >= iy1:
+                return _SEG_UNCORRECTED
+            mseg = segmentation[ym * nx_data + xm]
+            if mseg != 0 and mseg != label:
+                return _SEG_UNCORRECTED
+            if mask != NULL and mask[ym * nx_data + xm]:
+                return _SEG_UNCORRECTED
+            six[0] = xm
+            siy[0] = ym
+            return _SEG_CORRECTED
+    return _SEG_SOURCE
+
+
+cdef inline bint _seg_pixel_contributes(const Py_ssize_t *segmentation,
+                                        const unsigned char *mask,
+                                        Py_ssize_t nx_data,
+                                        int seg_method,
+                                        Py_ssize_t label,
+                                        Py_ssize_t ix, Py_ssize_t iy,
+                                        Py_ssize_t ix0, Py_ssize_t ix1,
+                                        Py_ssize_t iy0, Py_ssize_t iy1,
+                                        Py_ssize_t ccx, Py_ssize_t ccy,
+                                        Py_ssize_t *six,
+                                        Py_ssize_t *siy) noexcept nogil:
+    """
+    Whether a pixel contributes under the segmentation masking method.
+
+    This is the uncounted form of ``_resolve_seg_pixel`` for callers
+    that keep no neighbor-pixel flag counts. The parameters are those
+    of ``_classify_seg_pixel``.
+
+    Returns
+    -------
+    contributes : bint
+        `True` if the pixel contributes to the measurement (reading its
+        value from ``(siy[0], six[0])``); `False` if it is excluded.
+    """
+    cdef int code = _classify_seg_pixel(segmentation, mask, nx_data,
+                                        seg_method, label, ix, iy, ix0,
+                                        ix1, iy0, iy1, ccx, ccy, six, siy)
+    return code == _SEG_SOURCE or code == _SEG_CORRECTED
+
+
+cdef inline bint _resolve_seg_pixel(const Py_ssize_t *segmentation,
+                                    const unsigned char *mask,
+                                    Py_ssize_t nx_data, int seg_method,
+                                    Py_ssize_t label,
+                                    Py_ssize_t ix, Py_ssize_t iy,
+                                    Py_ssize_t ix0, Py_ssize_t ix1,
+                                    Py_ssize_t iy0, Py_ssize_t iy1,
+                                    Py_ssize_t ccx, Py_ssize_t ccy,
+                                    Py_ssize_t *six, Py_ssize_t *siy,
+                                    Py_ssize_t *n_seg_px,
+                                    Py_ssize_t *n_uncorr) noexcept nogil:
+    """
+    Apply the segmentation masking method to a single unmasked pixel,
+    counting the neighbor-pixel outcomes.
+
+    This is the counting form of ``_classify_seg_pixel`` used by the
+    per-pixel loops of ``_batch_photometry.batch_aperture_sums`` and
+    ``_batch_stats.batch_aperture_gather`` for their unmasked pixels.
+    The parameters are those of ``_classify_seg_pixel`` plus the two
+    counters.
+
+    Parameters
+    ----------
     n_seg_px : Py_ssize_t *
         In/out. Incremented when the pixel is excluded, restricted, or
         corrected due to a neighboring source.
@@ -148,40 +255,19 @@ cdef inline bint _resolve_seg_pixel(const Py_ssize_t *segmentation,
         `True` if the pixel contributes to the aperture (reading its
         value from ``(siy[0], six[0])``); `False` if it is excluded.
     """
-    cdef Py_ssize_t seg_val = segmentation[iy * nx_data + ix]
-    cdef Py_ssize_t xm, ym, mseg
-
-    if seg_method == 1:
-        if seg_val != 0 and seg_val != label:
-            n_seg_px[0] += 1
-            return False
-    elif seg_method == 2:
-        if seg_val != label:
-            # Only neighbor-source pixels (not background pixels)
-            # count toward the neighbor-pixels flag.
-            if seg_val != 0:
-                n_seg_px[0] += 1
-            return False
-    elif seg_method == 3:
-        if seg_val != 0 and seg_val != label:
-            # Neighbor pixel: replace its value with the pixel
-            # mirrored across the center.
-            n_seg_px[0] += 1
-            xm = 2 * ccx - ix
-            ym = 2 * ccy - iy
-            if xm < ix0 or xm >= ix1 or ym < iy0 or ym >= iy1:
-                n_uncorr[0] += 1
-                return False
-            mseg = segmentation[ym * nx_data + xm]
-            if mseg != 0 and mseg != label:
-                n_uncorr[0] += 1
-                return False
-            if mask != NULL and mask[ym * nx_data + xm]:
-                n_uncorr[0] += 1
-                return False
-            six[0] = xm
-            siy[0] = ym
-    return True
+    cdef int code = _classify_seg_pixel(segmentation, mask, nx_data,
+                                        seg_method, label, ix, iy, ix0,
+                                        ix1, iy0, iy1, ccx, ccy, six, siy)
+    if code == _SEG_SOURCE:
+        return True
+    if code == _SEG_EXCLUDED:
+        return False
+    n_seg_px[0] += 1
+    if code == _SEG_CORRECTED:
+        return True
+    if code == _SEG_UNCORRECTED:
+        n_uncorr[0] += 1
+    return False
 
 
 cdef inline bint _source_grid_setup(double cx, double cy,

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -62,10 +62,12 @@ FLAG_COL_SEG = 4
 FLAG_COL_UNCORRECTED = 5
 FLAG_COL_VALID = 6
 FLAG_COL_BBOX_CLIPPED = 7
+FLAG_COL_SEG_MASKED = 8
+FLAG_COL_UNCORRECTED_MASKED = 9
 
 # The total number of ``flag_counts`` columns. Every producer of a
 # per-source flag-count array must allocate this many columns
-N_FLAG_COLS = 8
+N_FLAG_COLS = 10
 
 
 def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
@@ -235,14 +237,25 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
           are non-finite in the data (masked or unmasked)
         * ``FLAG_COL_NONFINITE_ERROR``: the number of those pixels that
           are non-finite in the error (masked or unmasked)
-        * ``FLAG_COL_SEG``: the number of those pixels that were
-          excluded or corrected by the segmentation masking
-        * ``FLAG_COL_UNCORRECTED``: the number of those pixels that
-          could not be corrected by the segmentation masking
+        * ``FLAG_COL_SEG``: the number of those unmasked pixels that
+          were excluded or corrected by the segmentation masking
+        * ``FLAG_COL_UNCORRECTED``: the number of those unmasked pixels
+          that could not be corrected by the segmentation masking
         * ``FLAG_COL_VALID``: the number of contributing pixels
           (unmasked, finite, and not excluded by segmentation)
         * ``FLAG_COL_BBOX_CLIPPED``: a 0/1 indicator of whether the
           bounding box is clipped by a data edge
+        * ``FLAG_COL_SEG_MASKED``: the number of those masked pixels
+          that lie on a neighboring source
+        * ``FLAG_COL_UNCORRECTED_MASKED``: the number of those masked
+          pixels whose mirror pixel was also unavailable
+
+        Masked pixels are excluded before the segmentation masking is
+        applied, so they are counted in the ``FLAG_COL_SEG_MASKED``
+        and ``FLAG_COL_UNCORRECTED_MASKED`` columns instead of the
+        ``FLAG_COL_SEG`` and ``FLAG_COL_UNCORRECTED`` columns. This lets
+        callers that treat the mask and neighbor overlays independently
+        recover the full neighbor-pixel counts.
 
         The ``FLAG_COL_NONFINITE_DATA`` and ``FLAG_COL_NONFINITE_ERROR``
         columns are nonzero when non-finite data or error values
@@ -409,6 +422,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     cdef Py_ssize_t total = 0, spos = 0
     cdef Py_ssize_t n_pix, n_masked, n_nonfin, n_nonfin_err
     cdef Py_ssize_t n_seg_px, n_uncorr, n_valid, w_out
+    cdef Py_ssize_t n_seg_masked, n_unc_masked
     cdef Py_ssize_t ixmax_full, iymax_full
     cdef unsigned char mbits
 
@@ -464,6 +478,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             n_nonfin_err = 0
             n_seg_px = 0
             n_uncorr = 0
+            n_seg_masked = 0
+            n_unc_masked = 0
             n_valid = 0
             spos = starts[k]
             for iy in range(iy0, iy1):
@@ -524,11 +540,29 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
                     if has_mask:
                         mbits = mask[iy, ix]
-                        if mbits & 1:
-                            n_masked += 1
-                            continue
-                        if mbits & 2:
-                            n_nonfin += 1
+                        if mbits != 0:
+                            if mbits & 1:
+                                n_masked += 1
+                            elif mbits & 2:
+                                n_nonfin += 1
+                            # Masked pixels never reach the
+                            # segmentation branch below, so count
+                            # masked neighbor-segment pixels (and their
+                            # mirror availability) here for callers
+                            # that treat the mask and neighbor overlays
+                            # independently. The helper is called only
+                            # for its counter side effects. Its return
+                            # value and resolved coordinates are unused.
+                            if (has_seg and lbl != 0
+                                    and seg_method != 0):
+                                six = ix
+                                siy = iy
+                                _resolve_seg_pixel(
+                                    seg_ptr, mask_ptr, nx_data,
+                                    seg_method, lbl, ix, iy, ix0,
+                                    ix1, iy0, iy1, ccx, ccy, &six,
+                                    &siy, &n_seg_masked,
+                                    &n_unc_masked)
                             continue
                     six = ix
                     siy = iy
@@ -589,6 +623,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             fcounts[k, 5] = n_uncorr
             fcounts[k, 6] = n_valid
             fcounts[k, 7] = w_out
+            fcounts[k, 8] = n_seg_masked
+            fcounts[k, 9] = n_unc_masked
 
     return (sums_arr, vars_arr, areas_arr, overlap_arr.view(bool),
             starts_arr, sum_values_arr, sum_fracs_arr, sum_errsq_arr,

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -19,6 +19,8 @@ free-threaded Python builds.
 
 import numpy as np
 
+from photutils.aperture._batch_results import BatchApertureSums
+
 from photutils.aperture._batch_overlap cimport (
     _CIRCLE, _CIRCULAR_ANNULUS, _ELLIPSE, _ELLIPTICAL_ANNULUS, _POLYGON,
     _RECTANGLE, _RECTANGULAR_ANNULUS, _circle_pixel_frac,
@@ -258,6 +260,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
     Returns
     -------
+    result : `~photutils.aperture._batch_results.BatchApertureSums`
+        A named tuple with the following fields (in order).
+
     sums : 1D ndarray of float64
         The aperture sums. NaN where the aperture bounding box does not
         overlap the data.
@@ -778,6 +783,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             fcounts[k, 8] = n_seg_masked
             fcounts[k, 9] = n_unc_masked
 
-    return (sums_arr, vars_arr, areas_arr, overlap_arr.view(bool),
-            starts_arr, sum_values_arr, sum_fracs_arr, sum_errsq_arr,
-            scounts_arr, fcounts_arr, wout_arr)
+    return BatchApertureSums(
+        sums=sums_arr, sum_vars=vars_arr, areas=areas_arr,
+        overlap=overlap_arr.view(bool), starts=starts_arr,
+        sum_values=sum_values_arr, sum_fracs=sum_fracs_arr,
+        sum_errsq=sum_errsq_arr, sum_counts=scounts_arr,
+        flag_counts=fcounts_arr, weights_out=wout_arr)

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -23,11 +23,12 @@ from photutils.aperture._batch_results import BatchApertureSums
 
 from photutils.aperture._batch_overlap cimport (
     _CIRCLE, _CIRCULAR_ANNULUS, _ELLIPSE, _ELLIPTICAL_ANNULUS, _POLYGON,
-    _RECTANGLE, _RECTANGULAR_ANNULUS, _circle_pixel_frac,
-    _circular_annulus_pixel_frac, _ellipse_pixel_frac,
-    _elliptical_annulus_pixel_frac, _polygon_pixel_frac,
-    _presize_packed_offsets, _rect_pixel_frac, _rectangular_annulus_pixel_frac,
-    _resolve_seg_pixel, _round_half_away, _source_grid_setup)
+    _RECTANGLE, _RECTANGULAR_ANNULUS, _SEG_CORRECTED, _SEG_NEIGHBOR,
+    _SEG_UNCORRECTED, _circle_pixel_frac, _circular_annulus_pixel_frac,
+    _classify_seg_pixel, _ellipse_pixel_frac, _elliptical_annulus_pixel_frac,
+    _polygon_pixel_frac, _presize_packed_offsets, _rect_pixel_frac,
+    _rectangular_annulus_pixel_frac, _resolve_seg_pixel, _round_half_away,
+    _source_grid_setup)
 from photutils.geometry._polygon_overlap cimport (convex_edge_normals,
                                                   polygon_work_partition,
                                                   polygon_work_size)
@@ -520,6 +521,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     cdef Py_ssize_t n_seg_masked, n_unc_masked
     cdef Py_ssize_t ixmax_full, iymax_full
     cdef unsigned char mbits
+    cdef int pix_class
 
     # Pass 1 (only when emitting the packed member buffers): size and
     # offset the packed buffers from the per-source clipped bounding-box
@@ -718,19 +720,20 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                             # masked neighbor-segment pixels (and their
                             # mirror availability) here for callers
                             # that treat the mask and neighbor overlays
-                            # independently. The helper is called only
-                            # for its counter side effects. Its return
-                            # value and resolved coordinates are unused.
+                            # independently.
                             if (has_seg and lbl != 0
                                     and seg_method != 0):
-                                six = ix
-                                siy = iy
-                                _resolve_seg_pixel(
+                                pix_class = _classify_seg_pixel(
                                     seg_ptr, mask_ptr, nx_data,
                                     seg_method, lbl, ix, iy, ix0,
                                     ix1, iy0, iy1, ccx, ccy, &six,
-                                    &siy, &n_seg_masked,
-                                    &n_unc_masked)
+                                    &siy)
+                                if pix_class in (_SEG_NEIGHBOR,
+                                                 _SEG_CORRECTED,
+                                                 _SEG_UNCORRECTED):
+                                    n_seg_masked += 1
+                                    if pix_class == _SEG_UNCORRECTED:
+                                        n_unc_masked += 1
                             continue
                     six = ix
                     siy = iy

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -39,6 +39,7 @@ cdef extern from "math.h" nogil:
     double cos(double x)
     double fabs(double x)
     double ceil(double x)
+    double sqrt(double x)
     bint isfinite(double x)
 
 # Python-level aliases of the shape codes (the ``cdef enum`` is shared
@@ -70,6 +71,65 @@ FLAG_COL_UNCORRECTED_MASKED = 9
 N_FLAG_COLS = 10
 
 
+cdef int _check_params(int shape_code, const double[::1] params,
+                       const double[:, ::1] params_per_source,
+                       Py_ssize_t n_src, int emit_sum) except -1:
+    """
+    Validate the shared and per-source aperture shape parameters.
+
+    Exactly one of ``params`` and ``params_per_source`` must be input.
+    This is kept out of ``batch_aperture_sums`` so that its error
+    handling stays out of that function's per-pixel loop.
+
+    Parameters
+    ----------
+    shape_code : int
+        The aperture shape code (see the module-level ``SHAPE_*``
+        constants).
+
+    params : const double[::1]
+        The shared aperture shape parameters, or `None`.
+
+    params_per_source : const double[:, ::1]
+        The per-source aperture shape parameters, or `None`.
+
+    n_src : Py_ssize_t
+        The number of source positions.
+
+    emit_sum : int
+        Whether the packed per-pixel member buffers are emitted.
+
+    Returns
+    -------
+    result : int
+        Zero. A `ValueError` is raised if the parameters are invalid.
+    """
+    if params_per_source is None:
+        if params is None:
+            msg = 'params must be given when params_per_source is None'
+            raise ValueError(msg)
+        return 0
+
+    if params is not None:
+        msg = 'give params or params_per_source, not both'
+        raise ValueError(msg)
+    if shape_code not in (_CIRCLE, _ELLIPSE):
+        msg = 'params_per_source supports only circle and ellipse shapes'
+        raise ValueError(msg)
+    if emit_sum:
+        msg = 'params_per_source does not support emit_sum'
+        raise ValueError(msg)
+    if params_per_source.shape[0] != n_src:
+        msg = 'params_per_source must have one row per position'
+        raise ValueError(msg)
+    if ((shape_code == _CIRCLE and params_per_source.shape[1] != 1)
+            or (shape_code == _ELLIPSE
+                and params_per_source.shape[1] != 3)):
+        msg = 'params_per_source has the wrong column count'
+        raise ValueError(msg)
+    return 0
+
+
 def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                         const unsigned char[:, ::1] mask,
                         const double[:, ::1] positions, int shape_code,
@@ -78,7 +138,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                         int use_exact, int subpixels,
                         const Py_ssize_t[:, ::1] segmentation=None,
                         const Py_ssize_t[::1] labels=None, int seg_method=0,
-                        const double[::1] local_bkg=None, int emit_sum=0):
+                        const double[::1] local_bkg=None, int emit_sum=0,
+                        const double[:, ::1] params_per_source=None):
     """
     Compute aperture sums for many source positions in a single call.
 
@@ -116,8 +177,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         2=ellipse, 3=elliptical annulus, 4=rectangle, 5=rectangular
         annulus, 6=polygon (see the module-level ``SHAPE_*`` constants).
 
-    params : 1D ndarray of float64 (C-contiguous)
-        The aperture shape parameters:
+    params : 1D ndarray of float64 (C-contiguous) or `None`
+        The aperture shape parameters, shared by all source positions.
+        Must be `None` if ``params_per_source`` is input:
 
         * circle: ``(r,)``
         * circular annulus: ``(r_in, r_out)``
@@ -133,7 +195,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
     ext_x, ext_y : float
         The half-extents of the aperture minimal bounding box in the x
-        and y directions (i.e., ``Aperture._xy_extents``).
+        and y directions (i.e., ``Aperture._xy_extents``). These values
+        are ignored (and recomputed for each source) if
+        ``params_per_source`` is input.
 
     off_x, off_y : float
         The (x, y) offset of the bounding-box center from each source
@@ -182,6 +246,15 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         needed to recompute the aperture sum, variance, and area after
         per-source sigma clipping. When zero (default), those four
         outputs are empty arrays.
+
+    params_per_source : 2D ndarray of float64 (C-contiguous) or `None`
+        The per-source aperture shape parameters with shape
+        ``(n_sources, k)``, used instead of the shared ``params``
+        vector (which must then be `None`). Only the circle (``k`` =
+        1, ``(r,)``) and ellipse (``k`` = 3, ``(a, b, theta)``) shapes
+        are supported, and ``emit_sum`` must be zero. The bounding-box
+        half-extents are computed from each source's own parameters, so
+        the ``ext_x`` and ``ext_y`` inputs are ignored.
 
     Returns
     -------
@@ -264,6 +337,15 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         contributions are detected from the accumulated sums as a 0/1
         indicator. Rows are all zero where the aperture bounding box
         does not overlap the data.
+
+    weights_out : 1D ndarray of uint8
+        A per-source 0/1 indicator of whether the aperture has one
+        or more nonzero-fraction pixels outside the data. This is
+        the precise outside-weight test, computed only for the
+        sources whose bounding box is clipped by a data edge (the
+        ``FLAG_COL_BBOX_CLIPPED`` column). It is exactly zero for
+        unclipped sources and for sources whose bounding box does not
+        overlap the data at all.
     """
     cdef Py_ssize_t n_src = positions.shape[0]
     cdef Py_ssize_t ny_data = data.shape[0]
@@ -275,12 +357,14 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     overlap_arr = np.zeros(n_src, dtype=np.uint8)
     starts_arr = np.zeros(n_src, dtype=np.intp)
     fcounts_arr = np.zeros((n_src, N_FLAG_COLS), dtype=np.intp)
+    wout_arr = np.zeros(n_src, dtype=np.uint8)
     cdef double[::1] sums = sums_arr
     cdef double[::1] sum_vars = vars_arr
     cdef double[::1] areas = areas_arr
     cdef unsigned char[::1] overlap = overlap_arr
     cdef Py_ssize_t[::1] starts = starts_arr
     cdef Py_ssize_t[:, ::1] fcounts = fcounts_arr
+    cdef unsigned char[::1] weights_out = wout_arr
 
     cdef bint has_error = error is not None
     cdef bint has_mask = mask is not None
@@ -335,83 +419,88 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     cdef double *pedge_ny = NULL
     cdef double *pedge_c = NULL
 
-    if shape_code == _CIRCLE:
-        r_out = params[0]
-    elif shape_code == _CIRCULAR_ANNULUS:
-        r_in = params[0]
-        r_out = params[1]
-    elif shape_code == _ELLIPSE:
-        rx_out = params[0]
-        ry_out = params[1]
-        theta = params[2]
-        cos_theta = cos(theta)
-        sin_theta = sin(theta)
-    elif shape_code == _ELLIPTICAL_ANNULUS:
-        rx_in = params[0]
-        ry_in = params[1]
-        rx_out = params[2]
-        ry_out = params[3]
-        theta = params[4]
-        cos_theta = cos(theta)
-        sin_theta = sin(theta)
-    elif shape_code == _RECTANGLE or shape_code == _RECTANGULAR_ANNULUS:
-        if shape_code == _RECTANGLE:
-            half_width_out = 0.5 * params[0]
-            half_height_out = 0.5 * params[1]
-            theta = params[2]
-        else:
-            half_width_in = 0.5 * params[0]
-            half_height_in = 0.5 * params[1]
-            half_width_out = 0.5 * params[2]
-            half_height_out = 0.5 * params[3]
-            theta = params[4]
+    cdef bint has_psrc = params_per_source is not None
+    _check_params(shape_code, params, params_per_source, n_src, emit_sum)
 
-        cos_theta = cos(theta)
-        sin_theta = sin(theta)
-        rect_vertices(half_width_out, half_height_out, cos_theta,
-                      sin_theta, poly_x_out, poly_y_out)
-        bbox_dx_out = (half_width_out * fabs(cos_theta)
-                       + half_height_out * fabs(sin_theta))
-        bbox_dy_out = (half_width_out * fabs(sin_theta)
-                       + half_height_out * fabs(cos_theta))
-        if shape_code == _RECTANGULAR_ANNULUS:
-            rect_vertices(half_width_in, half_height_in, cos_theta,
-                          sin_theta, poly_x_in, poly_y_in)
-            bbox_dx_in = (half_width_in * fabs(cos_theta)
-                          + half_height_in * fabs(sin_theta))
-            bbox_dy_in = (half_width_in * fabs(sin_theta)
-                          + half_height_in * fabs(cos_theta))
-    elif shape_code == _POLYGON:
-        # ``params`` holds the flattened counter-clockwise vertex
-        # offsets (x0, y0, x1, y1, ...).
-        n_poly = params.shape[0] // 2
-        if n_poly < 3 or 2 * n_poly != params.shape[0]:
-            msg = ('polygon params must be the flattened (x, y) offsets '
-                   'of at least 3 vertices')
+    if not has_psrc:
+        if shape_code == _CIRCLE:
+            r_out = params[0]
+        elif shape_code == _CIRCULAR_ANNULUS:
+            r_in = params[0]
+            r_out = params[1]
+        elif shape_code == _ELLIPSE:
+            rx_out = params[0]
+            ry_out = params[1]
+            theta = params[2]
+            cos_theta = cos(theta)
+            sin_theta = sin(theta)
+        elif shape_code == _ELLIPTICAL_ANNULUS:
+            rx_in = params[0]
+            ry_in = params[1]
+            rx_out = params[2]
+            ry_out = params[3]
+            theta = params[4]
+            cos_theta = cos(theta)
+            sin_theta = sin(theta)
+        elif shape_code == _RECTANGLE or shape_code == _RECTANGULAR_ANNULUS:
+            if shape_code == _RECTANGLE:
+                half_width_out = 0.5 * params[0]
+                half_height_out = 0.5 * params[1]
+                theta = params[2]
+            else:
+                half_width_in = 0.5 * params[0]
+                half_height_in = 0.5 * params[1]
+                half_width_out = 0.5 * params[2]
+                half_height_out = 0.5 * params[3]
+                theta = params[4]
+
+            cos_theta = cos(theta)
+            sin_theta = sin(theta)
+            rect_vertices(half_width_out, half_height_out, cos_theta,
+                          sin_theta, poly_x_out, poly_y_out)
+            bbox_dx_out = (half_width_out * fabs(cos_theta)
+                           + half_height_out * fabs(sin_theta))
+            bbox_dy_out = (half_width_out * fabs(sin_theta)
+                           + half_height_out * fabs(cos_theta))
+            if shape_code == _RECTANGULAR_ANNULUS:
+                rect_vertices(half_width_in, half_height_in, cos_theta,
+                              sin_theta, poly_x_in, poly_y_in)
+                bbox_dx_in = (half_width_in * fabs(cos_theta)
+                              + half_height_in * fabs(sin_theta))
+                bbox_dy_in = (half_width_in * fabs(sin_theta)
+                              + half_height_in * fabs(cos_theta))
+        elif shape_code == _POLYGON:
+            # ``params`` holds the flattened counter-clockwise vertex
+            # offsets (x0, y0, x1, y1, ...).
+            n_poly = params.shape[0] // 2
+            if n_poly < 3 or 2 * n_poly != params.shape[0]:
+                msg = ('polygon params must be the flattened (x, y) offsets '
+                       'of at least 3 vertices')
+                raise ValueError(msg)
+
+            # Single numpy block (kept alive by ``poly_work``) whose sizing
+            # and layout are shared with ``polygon_overlap_grid`` via
+            # ``polygon_work_size``/``polygon_work_partition``.
+            poly_work = np.empty(polygon_work_size(n_poly, &poly_buf_size),
+                                 dtype=np.float64)
+            polygon_work_partition(&poly_work[0], n_poly, poly_buf_size,
+                                   &poly_x, &poly_y, &pbuf_a_x, &pbuf_a_y,
+                                   &pbuf_b_x, &pbuf_b_y, &pedge_nx, &pedge_ny,
+                                   &pedge_c)
+            for pk in range(n_poly):
+                poly_x[pk] = params[2 * pk]
+                poly_y[pk] = params[2 * pk + 1]
+
+            # One-time convexity test; convex polygons use an
+            # interior/exterior fast path in ``_polygon_pixel_frac``.
+            is_poly_convex = convex_edge_normals(poly_x, poly_y, n_poly,
+                                                 pedge_nx, pedge_ny, pedge_c)
+        else:
+            msg = f'Invalid shape_code: {shape_code}'
             raise ValueError(msg)
 
-        # Single numpy block (kept alive by ``poly_work``) whose sizing
-        # and layout are shared with ``polygon_overlap_grid`` via
-        # ``polygon_work_size``/``polygon_work_partition``.
-        poly_work = np.empty(polygon_work_size(n_poly, &poly_buf_size),
-                             dtype=np.float64)
-        polygon_work_partition(&poly_work[0], n_poly, poly_buf_size,
-                               &poly_x, &poly_y, &pbuf_a_x, &pbuf_a_y,
-                               &pbuf_b_x, &pbuf_b_y, &pedge_nx, &pedge_ny,
-                               &pedge_c)
-        for pk in range(n_poly):
-            poly_x[pk] = params[2 * pk]
-            poly_y[pk] = params[2 * pk + 1]
-
-        # One-time convexity test; convex polygons use an
-        # interior/exterior fast path in ``_polygon_pixel_frac``.
-        is_poly_convex = convex_edge_normals(poly_x, poly_y, n_poly,
-                                             pedge_nx, pedge_ny, pedge_c)
-    else:
-        msg = f'Invalid shape_code: {shape_code}'
-        raise ValueError(msg)
-
     cdef Py_ssize_t k, ix, iy, ix0, ix1, iy0, iy1
+    cdef Py_ssize_t sx0, sx1, sy0, sy1
     cdef Py_ssize_t ixmin, iymin
     cdef Py_ssize_t six, siy, ccx = 0, ccy = 0
     cdef double cx, cy, lbk = 0.0
@@ -421,7 +510,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     cdef double errsq = 0.0
     cdef Py_ssize_t total = 0, spos = 0
     cdef Py_ssize_t n_pix, n_masked, n_nonfin, n_nonfin_err
-    cdef Py_ssize_t n_seg_px, n_uncorr, n_valid, w_out
+    cdef Py_ssize_t n_seg_px, n_uncorr, n_valid, clipped
     cdef Py_ssize_t n_seg_masked, n_unc_masked
     cdef Py_ssize_t ixmax_full, iymax_full
     cdef unsigned char mbits
@@ -450,6 +539,26 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         for k in range(n_src):
             cx = positions[k, 0]
             cy = positions[k, 1]
+
+            # Per-source shape parameters and bounding-box half-extents
+            if has_psrc:
+                if shape_code == _CIRCLE:
+                    r_out = params_per_source[k, 0]
+                    ext_x = r_out
+                    ext_y = r_out
+                else:
+                    rx_out = params_per_source[k, 0]
+                    ry_out = params_per_source[k, 1]
+                    theta = params_per_source[k, 2]
+                    cos_theta = cos(theta)
+                    sin_theta = sin(theta)
+                    ext_x = sqrt(rx_out * rx_out * cos_theta
+                                 * cos_theta + ry_out * ry_out
+                                 * sin_theta * sin_theta)
+                    ext_y = sqrt(rx_out * rx_out * sin_theta
+                                 * sin_theta + ry_out * ry_out
+                                 * cos_theta * cos_theta)
+
             if has_bkg:
                 lbk = local_bkg[k]
             if has_seg:
@@ -469,6 +578,26 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                 continue
             overlap[k] = 1
 
+            # Whether the bounding box is clipped by a data edge. Only
+            # these sources can have aperture weights outside the data,
+            # so only for them is the pixel loop widened below to the
+            # full (unclipped) bounding box.
+            ixmax_full = <Py_ssize_t>ceil(cx + off_x + ext_x + 0.5)
+            iymax_full = <Py_ssize_t>ceil(cy + off_y + ext_y + 0.5)
+            if (ixmin < ix0 or ixmax_full > ix1
+                    or iymin < iy0 or iymax_full > iy1):
+                clipped = 1  # bounding box clipped by data edge
+                sx0 = ixmin
+                sx1 = ixmax_full
+                sy0 = iymin
+                sy1 = iymax_full
+            else:
+                clipped = 0  # bounding box fully inside data
+                sx0 = ix0
+                sx1 = ix1
+                sy0 = iy0
+                sy1 = iy1
+
             sum_val = 0.0
             var_val = 0.0
             area_val = 0.0
@@ -482,9 +611,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             n_unc_masked = 0
             n_valid = 0
             spos = starts[k]
-            for iy in range(iy0, iy1):
+            for iy in range(sy0, sy1):
                 pymin = gymin + (iy - iymin) * dy
-                for ix in range(ix0, ix1):
+                for ix in range(sx0, sx1):
                     pxmin = gxmin + (ix - ixmin) * dx
 
                     if shape_code == _CIRCLE:
@@ -535,6 +664,18 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                     # overlap functions clamp such fractions to zero, so
                     # only strictly positive fractions contribute here.
                     if frac <= 0.0:
+                        continue
+
+                    # For a clipped bounding box, the pixel loop
+                    # also covers the pixels outside the data. Such
+                    # a pixel with a nonzero fraction is the precise
+                    # outside-weight test; it contributes to nothing
+                    # else. A clipped bounding box does not by itself
+                    # imply nonzero outside weights, because the
+                    # aperture may not reach into the clipped-away rows
+                    # or columns.
+                    if clipped and not (iy0 <= iy < iy1 and ix0 <= ix < ix1):
+                        weights_out[k] = 1
                         continue
                     n_pix += 1
 
@@ -597,18 +738,6 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             if has_error and not isfinite(var_val):
                 n_nonfin_err += 1
 
-            # Whether the bounding box is clipped by a data edge. The
-            # caller resolves this to the precise outside-weight test
-            # (nonzero aperture weights outside the data) only for
-            # these sources; unclipped interior sources are exactly 0.
-            ixmax_full = <Py_ssize_t>ceil(cx + off_x + ext_x + 0.5)
-            iymax_full = <Py_ssize_t>ceil(cy + off_y + ext_y + 0.5)
-            if (ixmin < ix0 or ixmax_full > ix1
-                    or iymin < iy0 or iymax_full > iy1):
-                w_out = 1  # bounding box clipped by data edge
-            else:
-                w_out = 0  # bounding box fully inside data
-
             sums[k] = sum_val
             areas[k] = area_val
             if has_error:
@@ -622,10 +751,10 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             fcounts[k, 4] = n_seg_px
             fcounts[k, 5] = n_uncorr
             fcounts[k, 6] = n_valid
-            fcounts[k, 7] = w_out
+            fcounts[k, 7] = clipped
             fcounts[k, 8] = n_seg_masked
             fcounts[k, 9] = n_unc_masked
 
     return (sums_arr, vars_arr, areas_arr, overlap_arr.view(bool),
             starts_arr, sum_values_arr, sum_fracs_arr, sum_errsq_arr,
-            scounts_arr, fcounts_arr)
+            scounts_arr, fcounts_arr, wout_arr)

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -501,6 +501,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
     cdef Py_ssize_t k, ix, iy, ix0, ix1, iy0, iy1
     cdef Py_ssize_t sx0, sx1, sy0, sy1
+    cdef bint outside, found_out
     cdef Py_ssize_t ixmin, iymin
     cdef Py_ssize_t six, siy, ccx = 0, ccy = 0
     cdef double cx, cy, lbk = 0.0
@@ -611,9 +612,29 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             n_unc_masked = 0
             n_valid = 0
             spos = starts[k]
+            found_out = 0
             for iy in range(sy0, sy1):
+                # Once the outside-weight test has been answered, the
+                # pixels outside the data can no longer change any
+                # result, so the remaining rows are narrowed (or
+                # skipped entirely) back to the part of the bounding
+                # box that lies inside the data.
+                if clipped and found_out:
+                    if iy < iy0 or iy >= iy1:
+                        continue
+                    sx0 = ix0
+                    sx1 = ix1
+
                 pymin = gymin + (iy - iymin) * dy
                 for ix in range(sx0, sx1):
+                    # A pixel outside the data contributes to nothing
+                    # but the outside-weight test, so it costs only
+                    # this test once that test has been answered.
+                    outside = clipped and not (iy0 <= iy < iy1
+                                               and ix0 <= ix < ix1)
+                    if outside and found_out:
+                        continue
+
                     pxmin = gxmin + (ix - ixmin) * dx
 
                     if shape_code == _CIRCLE:
@@ -657,6 +678,18 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                             pbuf_b_x, pbuf_b_y, poly_buf_size, use_exact,
                             subpixels)
 
+                    # A nonzero fraction outside the data answers the
+                    # precise outside-weight test. A clipped bounding
+                    # box does not by itself imply nonzero outside
+                    # weights, because the aperture may not reach into
+                    # the clipped-away rows or columns. The pixel is
+                    # then skipped: its (out-of-range) coordinates must
+                    # never reach the data accesses below.
+                    if outside:
+                        if frac > 0.0:
+                            found_out = 1
+                        continue
+
                     # Annulus fractions are a difference of two shapes,
                     # so floating-point noise can leave a boundary
                     # pixel's fraction a tiny negative value. Both the
@@ -666,17 +699,6 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                     if frac <= 0.0:
                         continue
 
-                    # For a clipped bounding box, the pixel loop
-                    # also covers the pixels outside the data. Such
-                    # a pixel with a nonzero fraction is the precise
-                    # outside-weight test; it contributes to nothing
-                    # else. A clipped bounding box does not by itself
-                    # imply nonzero outside weights, because the
-                    # aperture may not reach into the clipped-away rows
-                    # or columns.
-                    if clipped and not (iy0 <= iy < iy1 and ix0 <= ix < ix1):
-                        weights_out[k] = 1
-                        continue
                     n_pix += 1
 
                     if has_mask:
@@ -738,6 +760,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             if has_error and not isfinite(var_val):
                 n_nonfin_err += 1
 
+            weights_out[k] = found_out
             sums[k] = sum_val
             areas[k] = area_val
             if has_error:

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -21,6 +21,7 @@ import numpy as np
 
 from photutils.aperture._batch_results import BatchApertureSums
 
+from photutils.aperture._batch_outside cimport _ShapeSpec, outside_weight
 from photutils.aperture._batch_overlap cimport (
     _CIRCLE, _CIRCULAR_ANNULUS, _ELLIPSE, _ELLIPTICAL_ANNULUS, _POLYGON,
     _RECTANGLE, _RECTANGULAR_ANNULUS, _SEG_CORRECTED, _SEG_NEIGHBOR,
@@ -351,7 +352,11 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         sources whose bounding box is clipped by a data edge (the
         ``FLAG_COL_BBOX_CLIPPED`` column). It is exactly zero for
         unclipped sources and for sources whose bounding box does not
-        overlap the data at all.
+        overlap the data at all. For the exact overlap method, an
+        aperture with a nonzero-fraction pixel inside the data is
+        tested only on the ring of pixels just outside the data edges
+        (see ``_batch_outside.outside_weight``), which is equivalent
+        because every aperture shape is a connected region.
     """
     cdef Py_ssize_t n_src = positions.shape[0]
     cdef Py_ssize_t ny_data = data.shape[0]
@@ -505,9 +510,46 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             msg = f'Invalid shape_code: {shape_code}'
             raise ValueError(msg)
 
+    # The shape parameters and scratch buffers as seen by the
+    # outside-weight scan (off the hot path). The per-source shape
+    # parameters, if any, are copied in before each scan.
+    cdef _ShapeSpec sp
+    sp.shape_code = shape_code
+    sp.use_exact = use_exact
+    sp.subpixels = subpixels
+    sp.r_in = r_in
+    sp.rx_in = rx_in
+    sp.ry_in = ry_in
+    sp.half_width_in = half_width_in
+    sp.half_height_in = half_height_in
+    sp.half_width_out = half_width_out
+    sp.half_height_out = half_height_out
+    sp.bbox_dx_in = bbox_dx_in
+    sp.bbox_dy_in = bbox_dy_in
+    sp.bbox_dx_out = bbox_dx_out
+    sp.bbox_dy_out = bbox_dy_out
+    sp.poly_x_in = poly_x_in
+    sp.poly_y_in = poly_y_in
+    sp.poly_x_out = poly_x_out
+    sp.poly_y_out = poly_y_out
+    sp.buf_a_x = buf_a_x
+    sp.buf_a_y = buf_a_y
+    sp.buf_b_x = buf_b_x
+    sp.buf_b_y = buf_b_y
+    sp.poly_x = poly_x
+    sp.poly_y = poly_y
+    sp.n_poly = n_poly
+    sp.poly_buf_size = poly_buf_size
+    sp.is_poly_convex = is_poly_convex
+    sp.pedge_nx = pedge_nx
+    sp.pedge_ny = pedge_ny
+    sp.pedge_c = pedge_c
+    sp.pbuf_a_x = pbuf_a_x
+    sp.pbuf_a_y = pbuf_a_y
+    sp.pbuf_b_x = pbuf_b_x
+    sp.pbuf_b_y = pbuf_b_y
+
     cdef Py_ssize_t k, ix, iy, ix0, ix1, iy0, iy1
-    cdef Py_ssize_t sx0, sx1, sy0, sy1
-    cdef bint outside, found_out
     cdef Py_ssize_t ixmin, iymin
     cdef Py_ssize_t six, siy, ccx = 0, ccy = 0
     cdef double cx, cy, lbk = 0.0
@@ -588,23 +630,14 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
             # Whether the bounding box is clipped by a data edge. Only
             # these sources can have aperture weights outside the data,
-            # so only for them is the pixel loop widened below to the
-            # full (unclipped) bounding box.
+            # which is tested separately after the accumulation loop.
             ixmax_full = <Py_ssize_t>ceil(cx + off_x + ext_x + 0.5)
             iymax_full = <Py_ssize_t>ceil(cy + off_y + ext_y + 0.5)
             if (ixmin < ix0 or ixmax_full > ix1
                     or iymin < iy0 or iymax_full > iy1):
                 clipped = 1  # bounding box clipped by data edge
-                sx0 = ixmin
-                sx1 = ixmax_full
-                sy0 = iymin
-                sy1 = iymax_full
             else:
                 clipped = 0  # bounding box fully inside data
-                sx0 = ix0
-                sx1 = ix1
-                sy0 = iy0
-                sy1 = iy1
 
             sum_val = 0.0
             var_val = 0.0
@@ -619,31 +652,17 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             n_unc_masked = 0
             n_valid = 0
             spos = starts[k]
-            found_out = 0
-            for iy in range(sy0, sy1):
-                # Once the outside-weight test has been answered, the
-                # pixels outside the data can no longer change any
-                # result, so the remaining rows are narrowed (or
-                # skipped entirely) back to the part of the bounding
-                # box that lies inside the data.
-                if clipped and found_out:
-                    if iy < iy0 or iy >= iy1:
-                        continue
-                    sx0 = ix0
-                    sx1 = ix1
-
+            for iy in range(iy0, iy1):
                 pymin = gymin + (iy - iymin) * dy
-                for ix in range(sx0, sx1):
-                    # A pixel outside the data contributes to nothing
-                    # but the outside-weight test, so it costs only
-                    # this test once that test has been answered.
-                    outside = clipped and not (iy0 <= iy < iy1
-                                               and ix0 <= ix < ix1)
-                    if outside and found_out:
-                        continue
-
+                for ix in range(ix0, ix1):
                     pxmin = gxmin + (ix - ixmin) * dx
 
+                    # The shape dispatch is inlined over the local
+                    # variables here; the outside-weight scan carries
+                    # the same dispatch in ``_batch_outside``, kept in
+                    # a separate extension module so that each shape
+                    # helper has a single call site in this one (see
+                    # that module's docstring)
                     if shape_code == _CIRCLE:
                         frac = _circle_pixel_frac(
                             pxmin, pymin, dx, dy, pixel_radius, r_out,
@@ -684,18 +703,6 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                             pedge_c, is_poly_convex, pbuf_a_x, pbuf_a_y,
                             pbuf_b_x, pbuf_b_y, poly_buf_size, use_exact,
                             subpixels)
-
-                    # A nonzero fraction outside the data answers the
-                    # precise outside-weight test. A clipped bounding
-                    # box does not by itself imply nonzero outside
-                    # weights, because the aperture may not reach into
-                    # the clipped-away rows or columns. The pixel is
-                    # then skipped: its (out-of-range) coordinates must
-                    # never reach the data accesses below.
-                    if outside:
-                        if frac > 0.0:
-                            found_out = 1
-                        continue
 
                     # Annulus fractions are a difference of two shapes,
                     # so floating-point noise can leave a boundary
@@ -768,7 +775,17 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             if has_error and not isfinite(var_val):
                 n_nonfin_err += 1
 
-            weights_out[k] = found_out
+            if clipped:
+                # The shape parameters that can vary per source
+                sp.r_out = r_out
+                sp.rx_out = rx_out
+                sp.ry_out = ry_out
+                sp.cos_theta = cos_theta
+                sp.sin_theta = sin_theta
+                weights_out[k] = outside_weight(
+                    &sp, n_pix > 0, gxmin, gymin, dx, dy, pixel_radius,
+                    norm, ixmin, iymin, ixmax_full, iymax_full, ix0, ix1,
+                    iy0, iy1)
             sums[k] = sum_val
             areas[k] = area_val
             if has_error:

--- a/photutils/aperture/_batch_results.py
+++ b/photutils/aperture/_batch_results.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Result containers of the batch aperture Cython drivers.
+"""
+
+from typing import NamedTuple
+
+import numpy as np
+
+__all__ = []
+
+
+class BatchApertureSums(NamedTuple):
+    """
+    The per-source results of ``batch_aperture_sums`` (see its
+    docstring for the full description of each field).
+
+    The fields are the driver's return values in order, so the result
+    can also be unpacked or indexed as a plain tuple.
+    """
+
+    sums: np.ndarray
+    """The aperture sums (NaN where the bounding box does not overlap
+    the data)."""
+
+    sum_vars: np.ndarray
+    """The aperture sum variances (NaN if ``error`` is `None`)."""
+
+    areas: np.ndarray
+    """The aperture areas within the data."""
+
+    overlap: np.ndarray
+    """Whether the aperture bounding box overlaps the data (bool)."""
+
+    starts: np.ndarray
+    """The start offset of each source in the packed per-pixel
+    buffers."""
+
+    sum_values: np.ndarray
+    """The packed per-pixel background-subtracted values (empty unless
+    ``emit_sum`` is nonzero)."""
+
+    sum_fracs: np.ndarray
+    """The packed per-pixel overlap fractions (empty unless
+    ``emit_sum`` is nonzero)."""
+
+    sum_errsq: np.ndarray
+    """The packed per-pixel error variances (empty unless
+    ``emit_sum`` is nonzero)."""
+
+    sum_counts: np.ndarray
+    """The number of packed per-pixel entries of each source (empty
+    unless ``emit_sum`` is nonzero)."""
+
+    flag_counts: np.ndarray
+    """The ``(n_sources, N_FLAG_COLS)`` per-source flag counts (see the
+    ``FLAG_COL_*`` constants)."""
+
+    weights_out: np.ndarray
+    """The per-source 0/1 indicator of nonzero aperture weights outside
+    the data (uint8)."""

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -37,7 +37,7 @@ from photutils.geometry._polygon_overlap cimport (convex_edge_normals,
 from photutils.geometry.rectangle_overlap cimport rect_vertices
 
 __all__ = ['batch_aperture_gather', 'batch_moments', 'batch_sort_values',
-           'batch_order_stats', 'batch_mean_var', 'batch_mad',
+           'batch_order_stats', 'batch_minmax', 'batch_mean_var', 'batch_mad',
            'batch_biweight', 'batch_gini', 'batch_sigma_clip_center',
            'batch_sigma_clip_stats', 'batch_sigma_clip_sum']
 
@@ -1035,6 +1035,59 @@ def batch_order_stats(const double[::1] sorted_values,
             median[k] = _median_sorted(&sorted_values[start], count)
 
     return (vmin_arr, vmax_arr, median_arr)
+
+
+def batch_minmax(const double[::1] values,
+                 const Py_ssize_t[::1] starts,
+                 const Py_ssize_t[::1] counts):
+    """
+    Reduce a packed value buffer to the per-source minimum and maximum.
+
+    Unlike `batch_order_stats`, this does not need (or produce) the
+    sorted values, so it is the cheaper way to get only the extremes.
+    The conventions match `numpy.min` and `numpy.max`. Sources with no
+    pixels (``counts[k] == 0``) are set to NaN.
+
+    Parameters
+    ----------
+    values : 1D ndarray of float64
+        The packed pixel values (see ``batch_aperture_gather``). All
+        values are assumed finite.
+
+    starts, counts : 1D ndarray of intp
+        The per-source start offset and pixel count.
+
+    Returns
+    -------
+    vmin, vmax : 1D ndarray of float64
+        The per-source minimum and maximum, each of shape
+        ``(n_sources,)``.
+    """
+    cdef Py_ssize_t n_src = starts.shape[0]
+    vmin_arr = np.full(n_src, np.nan, dtype=np.float64)
+    vmax_arr = np.full(n_src, np.nan, dtype=np.float64)
+    cdef double[::1] vmin = vmin_arr
+    cdef double[::1] vmax = vmax_arr
+    cdef Py_ssize_t k, i, start, count
+    cdef double v, lo, hi
+
+    with nogil:
+        for k in range(n_src):
+            count = counts[k]
+            if count == 0:
+                continue
+            start = starts[k]
+            lo = values[start]
+            hi = lo
+            for i in range(start + 1, start + count):
+                v = values[i]
+                if v < lo:
+                    lo = v
+                elif v > hi:
+                    hi = v
+            vmin[k] = lo
+            vmax[k] = hi
+    return vmin_arr, vmax_arr
 
 
 def batch_mean_var(const double[::1] values,

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -25,11 +25,12 @@ from photutils.aperture._batch_photometry import N_FLAG_COLS
 
 from photutils.aperture._batch_overlap cimport (
     _CIRCLE, _CIRCULAR_ANNULUS, _ELLIPSE, _ELLIPTICAL_ANNULUS, _POLYGON,
-    _RECTANGLE, _RECTANGULAR_ANNULUS, _circle_pixel_frac,
-    _circular_annulus_pixel_frac, _ellipse_pixel_frac,
-    _elliptical_annulus_pixel_frac, _polygon_pixel_frac,
-    _presize_packed_offsets, _rect_pixel_frac, _rectangular_annulus_pixel_frac,
-    _resolve_seg_pixel, _round_half_away, _source_grid_setup)
+    _RECTANGLE, _RECTANGULAR_ANNULUS, _SEG_CORRECTED, _SEG_NEIGHBOR,
+    _SEG_UNCORRECTED, _circle_pixel_frac, _circular_annulus_pixel_frac,
+    _classify_seg_pixel, _ellipse_pixel_frac, _elliptical_annulus_pixel_frac,
+    _polygon_pixel_frac, _presize_packed_offsets, _rect_pixel_frac,
+    _rectangular_annulus_pixel_frac, _resolve_seg_pixel, _round_half_away,
+    _source_grid_setup)
 from photutils.geometry._polygon_overlap cimport (convex_edge_normals,
                                                   polygon_work_partition,
                                                   polygon_work_size)
@@ -510,6 +511,7 @@ def batch_aperture_gather(const double[:, ::1] data,
     cdef Py_ssize_t n_seg_masked, n_unc_masked
     cdef Py_ssize_t ixmax_full, iymax_full
     cdef unsigned char mbits
+    cdef int pix_class
 
     # Pass 1: size and offset the packed value buffer from the
     # per-source clipped bounding-box areas (an upper bound on the
@@ -619,18 +621,19 @@ def batch_aperture_gather(const double[:, ::1] data,
                             # masked neighbor-segment pixels (and their
                             # mirror availability) here for callers
                             # that treat the mask and neighbor overlays
-                            # independently. The helper is called only
-                            # for its counter side effects. Its return
-                            # value and resolved coordinates are unused.
+                            # independently.
                             if (has_seg and lbl != 0 and seg_method != 0):
-                                six = ix
-                                siy = iy
-                                _resolve_seg_pixel(
+                                pix_class = _classify_seg_pixel(
                                     seg_ptr, mask_ptr, nx_data,
                                     seg_method, lbl, ix, iy, ix0,
                                     ix1, iy0, iy1, ccx, ccy, &six,
-                                    &siy, &n_seg_masked,
-                                    &n_unc_masked)
+                                    &siy)
+                                if pix_class in (_SEG_NEIGHBOR,
+                                                 _SEG_CORRECTED,
+                                                 _SEG_UNCORRECTED):
+                                    n_seg_masked += 1
+                                    if pix_class == _SEG_UNCORRECTED:
+                                        n_unc_masked += 1
                             continue
                     six = ix
                     siy = iy

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -116,12 +116,21 @@ cdef void _introsort(double *a, Py_ssize_t lo, Py_ssize_t hi,
                      int depth) noexcept nogil:
     """
     Sort ``a[lo:hi]`` ascending in place by introsort: median-of-three
-    quicksort with Hoare partitioning, heapsort when the recursion
-    depth budget is exhausted, and insertion sort for short ranges.
-    The smaller partition is recursed into and the larger is looped
-    over, which bounds the recursion depth by log2(n).
+    quicksort with Bentley-McIlroy three-way partitioning, heapsort
+    when the recursion depth budget is exhausted, and insertion sort
+    for short ranges.
+
+    The three-way partition keeps the two scanning indices of a Hoare
+    partition (so distinct keys sort as fast) but parks the elements
+    equal to the pivot at the ends of the range and swaps them into
+    the middle afterwards, so runs of equal values (e.g., quantized or
+    constant pixel values) are excluded from further sorting instead
+    of degrading to the quadratic-swap behavior of a two-way
+    partition. The smaller of the two remaining partitions is recursed
+    into and the larger is looped over, which bounds the recursion
+    depth by log2(n).
     """
-    cdef Py_ssize_t i, j, mid
+    cdef Py_ssize_t i, j, k, p, q, mid, last
     cdef double pivot, v
     while hi - lo > 16:
         if depth == 0:
@@ -129,44 +138,86 @@ cdef void _introsort(double *a, Py_ssize_t lo, Py_ssize_t hi,
             return
         depth -= 1
 
-        # Median of three, leaving a[lo] <= a[mid] <= a[hi - 1] so that
-        # the ends of the range are sentinels for the scans below
+        # Median of three, moved to a[lo] as the pivot
+        last = hi - 1
         mid = lo + (hi - lo) // 2
         if a[mid] < a[lo]:
             v = a[mid]
             a[mid] = a[lo]
             a[lo] = v
-        if a[hi - 1] < a[lo]:
-            v = a[hi - 1]
-            a[hi - 1] = a[lo]
+        if a[last] < a[lo]:
+            v = a[last]
+            a[last] = a[lo]
             a[lo] = v
-        if a[hi - 1] < a[mid]:
-            v = a[hi - 1]
-            a[hi - 1] = a[mid]
+        if a[last] < a[mid]:
+            v = a[last]
+            a[last] = a[mid]
             a[mid] = v
         pivot = a[mid]
+        a[mid] = a[lo]
+        a[lo] = pivot
 
-        # Hoare partition: afterwards a[lo:j + 1] <= pivot <= a[j + 1:hi]
+        # Bentley-McIlroy partition: a[lo + 1:p + 1] and a[q:hi] hold
+        # the elements equal to the pivot found so far
         i = lo
-        j = hi - 1
+        j = hi
+        p = lo
+        q = hi
         while True:
             i += 1
             while a[i] < pivot:
+                if i == last:
+                    break
                 i += 1
             j -= 1
             while pivot < a[j]:
+                if j == lo:
+                    break
                 j -= 1
+            if i == j and a[i] == pivot:
+                p += 1
+                v = a[p]
+                a[p] = a[i]
+                a[i] = v
             if i >= j:
                 break
             v = a[i]
             a[i] = a[j]
             a[j] = v
+            if a[i] == pivot:
+                p += 1
+                v = a[p]
+                a[p] = a[i]
+                a[i] = v
+            if a[j] == pivot:
+                q -= 1
+                v = a[q]
+                a[q] = a[j]
+                a[j] = v
 
-        if j + 1 - lo < hi - (j + 1):
+        # Swap the parked equal elements into the middle, giving
+        # a[lo:j + 1] < pivot, a[j + 1:i] == pivot, a[i:hi] > pivot
+        i = j + 1
+        k = lo
+        while k <= p:
+            v = a[k]
+            a[k] = a[j]
+            a[j] = v
+            k += 1
+            j -= 1
+        k = last
+        while k >= q:
+            v = a[k]
+            a[k] = a[i]
+            a[i] = v
+            k -= 1
+            i += 1
+
+        if j + 1 - lo < hi - i:
             _introsort(a, lo, j + 1, depth)
-            lo = j + 1
+            lo = i
         else:
-            _introsort(a, j + 1, hi, depth)
+            _introsort(a, i, hi, depth)
             hi = j + 1
     _insertion_sort(a, lo, hi)
 

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -357,14 +357,18 @@ def batch_aperture_gather(const double[:, ::1] data,
           are non-finite in the data (masked or unmasked)
         * ``FLAG_COL_NONFINITE_ERROR``: always zero (this function does
           not read error values)
-        * ``FLAG_COL_SEG``: the number of those pixels that were
-          excluded or corrected by the segmentation masking
-        * ``FLAG_COL_UNCORRECTED``: the number of those pixels that
-          could not be corrected by the segmentation masking
+        * ``FLAG_COL_SEG``: the number of those unmasked pixels that
+          were excluded or corrected by the segmentation masking
+        * ``FLAG_COL_UNCORRECTED``: the number of those unmasked pixels
+          that could not be corrected by the segmentation masking
         * ``FLAG_COL_VALID``: the number of contributing pixels
           (unmasked, finite, and not excluded by segmentation)
         * ``FLAG_COL_BBOX_CLIPPED``: a 0/1 indicator of whether the
           bounding box is clipped by a data edge
+        * ``FLAG_COL_SEG_MASKED``: the number of those masked pixels
+          that lie on a neighboring source
+        * ``FLAG_COL_UNCORRECTED_MASKED``: the number of those masked
+          pixels whose mirror pixel was also unavailable
         Rows are all zero where the aperture bounding box does not
         overlap the data.
     """
@@ -503,6 +507,7 @@ def batch_aperture_gather(const double[:, ::1] data,
     cdef double pxmin, pymin, cfrac
     cdef Py_ssize_t total = 0, pos
     cdef Py_ssize_t n_pix, n_masked, n_nonfin, n_seg_px, n_uncorr, w_out
+    cdef Py_ssize_t n_seg_masked, n_unc_masked
     cdef Py_ssize_t ixmax_full, iymax_full
     cdef unsigned char mbits
 
@@ -555,6 +560,8 @@ def batch_aperture_gather(const double[:, ::1] data,
             n_nonfin = 0
             n_seg_px = 0
             n_uncorr = 0
+            n_seg_masked = 0
+            n_unc_masked = 0
             pos = starts[k]
             for iy in range(iy0, iy1):
                 pymin = gymin + (iy - iymin) * dy
@@ -602,11 +609,28 @@ def batch_aperture_gather(const double[:, ::1] data,
 
                     if has_mask:
                         mbits = mask[iy, ix]
-                        if mbits & 1:
-                            n_masked += 1
-                            continue
-                        if mbits & 2:
-                            n_nonfin += 1
+                        if mbits != 0:
+                            if mbits & 1:
+                                n_masked += 1
+                            elif mbits & 2:
+                                n_nonfin += 1
+                            # Masked pixels never reach the
+                            # segmentation branch below, so count
+                            # masked neighbor-segment pixels (and their
+                            # mirror availability) here for callers
+                            # that treat the mask and neighbor overlays
+                            # independently. The helper is called only
+                            # for its counter side effects. Its return
+                            # value and resolved coordinates are unused.
+                            if (has_seg and lbl != 0 and seg_method != 0):
+                                six = ix
+                                siy = iy
+                                _resolve_seg_pixel(
+                                    seg_ptr, mask_ptr, nx_data,
+                                    seg_method, lbl, ix, iy, ix0,
+                                    ix1, iy0, iy1, ccx, ccy, &six,
+                                    &siy, &n_seg_masked,
+                                    &n_unc_masked)
                             continue
                     six = ix
                     siy = iy
@@ -642,6 +666,8 @@ def batch_aperture_gather(const double[:, ::1] data,
             fcounts[k, 5] = n_uncorr
             fcounts[k, 6] = counts[k]
             fcounts[k, 7] = w_out
+            fcounts[k, 8] = n_seg_masked
+            fcounts[k, 9] = n_unc_masked
 
     return (values_arr, lx_arr, ly_arr, starts_arr, counts_arr,
             overlap_arr.view(bool), fcounts_arr)

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -50,24 +50,162 @@ cdef extern from "math.h" nogil:
     double ceil(double x)
     const double NAN
 
-cdef extern from "stdlib.h" nogil:
-    void qsort(void *base, size_t nmemb, size_t size,
-               int (*compar)(const void *, const void *))
-
 # Scale factor that converts the median absolute deviation to a robust
 # estimate of the standard deviation (1 / scipy.stats.norm.ppf(0.75)).
 # This must match ``astropy.stats.mad_std``.
 cdef double _MAD_STD_SCALE = 1.482602218505602
 
 
-cdef int _cmp_double(const void *a, const void *b) noexcept nogil:
-    cdef double da = (<const double *>a)[0]
-    cdef double db = (<const double *>b)[0]
-    if da < db:
-        return -1
-    if da > db:
-        return 1
-    return 0
+cdef inline void _insertion_sort(double *a, Py_ssize_t lo,
+                                 Py_ssize_t hi) noexcept nogil:
+    """
+    Sort ``a[lo:hi]`` ascending in place by insertion (for short
+    ranges).
+    """
+    cdef Py_ssize_t i, j
+    cdef double v
+    for i in range(lo + 1, hi):
+        v = a[i]
+        j = i
+        while j > lo and v < a[j - 1]:
+            a[j] = a[j - 1]
+            j -= 1
+        a[j] = v
+
+
+cdef void _heapsort(double *a, Py_ssize_t lo, Py_ssize_t hi) noexcept nogil:
+    """
+    Sort ``a[lo:hi]`` ascending in place by heapsort (the introsort
+    fallback that bounds the worst case at O(n log n)).
+    """
+    cdef Py_ssize_t n = hi - lo
+    cdef Py_ssize_t start, root, child, end
+    cdef double v
+    # Build the max-heap, then repeatedly move the maximum to the end
+    start = n // 2 - 1
+    end = n
+    while True:
+        if start >= 0:
+            root = start
+            start -= 1
+        else:
+            end -= 1
+            if end == 0:
+                return
+            v = a[lo + end]
+            a[lo + end] = a[lo]
+            a[lo] = v
+            root = 0
+        # Sift the root down within the heap [0, end)
+        while True:
+            child = 2 * root + 1
+            if child >= end:
+                break
+            if child + 1 < end and a[lo + child] < a[lo + child + 1]:
+                child += 1
+            if a[lo + root] < a[lo + child]:
+                v = a[lo + root]
+                a[lo + root] = a[lo + child]
+                a[lo + child] = v
+                root = child
+            else:
+                break
+
+
+cdef void _introsort(double *a, Py_ssize_t lo, Py_ssize_t hi,
+                     int depth) noexcept nogil:
+    """
+    Sort ``a[lo:hi]`` ascending in place by introsort: median-of-three
+    quicksort with Hoare partitioning, heapsort when the recursion
+    depth budget is exhausted, and insertion sort for short ranges.
+    The smaller partition is recursed into and the larger is looped
+    over, which bounds the recursion depth by log2(n).
+    """
+    cdef Py_ssize_t i, j, mid
+    cdef double pivot, v
+    while hi - lo > 16:
+        if depth == 0:
+            _heapsort(a, lo, hi)
+            return
+        depth -= 1
+
+        # Median of three, leaving a[lo] <= a[mid] <= a[hi - 1] so that
+        # the ends of the range are sentinels for the scans below
+        mid = lo + (hi - lo) // 2
+        if a[mid] < a[lo]:
+            v = a[mid]
+            a[mid] = a[lo]
+            a[lo] = v
+        if a[hi - 1] < a[lo]:
+            v = a[hi - 1]
+            a[hi - 1] = a[lo]
+            a[lo] = v
+        if a[hi - 1] < a[mid]:
+            v = a[hi - 1]
+            a[hi - 1] = a[mid]
+            a[mid] = v
+        pivot = a[mid]
+
+        # Hoare partition: afterwards a[lo:j + 1] <= pivot <= a[j + 1:hi]
+        i = lo
+        j = hi - 1
+        while True:
+            i += 1
+            while a[i] < pivot:
+                i += 1
+            j -= 1
+            while pivot < a[j]:
+                j -= 1
+            if i >= j:
+                break
+            v = a[i]
+            a[i] = a[j]
+            a[j] = v
+
+        if j + 1 - lo < hi - (j + 1):
+            _introsort(a, lo, j + 1, depth)
+            lo = j + 1
+        else:
+            _introsort(a, j + 1, hi, depth)
+            hi = j + 1
+    _insertion_sort(a, lo, hi)
+
+
+def _heapsort_values(double[::1] values):
+    """
+    Sort a 1D float64 array in place with the heapsort fallback of
+    ``_sort_doubles``.
+
+    The fallback runs only when the introsort recursion budget is
+    exhausted, which no ordinary input reaches, so this entry point
+    exists for the tests.
+
+    Parameters
+    ----------
+    values : 1D ndarray of float64 (C-contiguous, writeable)
+        The values to sort in place.
+    """
+    if values.shape[0] > 1:
+        _heapsort(&values[0], 0, values.shape[0])
+
+
+cdef inline void _sort_doubles(double *a, Py_ssize_t n) noexcept nogil:
+    """
+    Sort ``n`` finite doubles ascending in place.
+
+    This replaces the C library ``qsort`` (whose comparison callback
+    cannot be inlined and costs an indirect call per comparison) with
+    an introsort whose comparisons compile to plain branches. The
+    values must be finite: the ordering of NaN values is unspecified.
+    """
+    cdef int depth = 0
+    cdef Py_ssize_t m = n
+    if n < 2:
+        return
+    while m > 1:
+        m >>= 1
+        depth += 1
+    _introsort(a, 0, n, 2 * depth)
 
 
 cdef inline double _median_sorted(double *s, Py_ssize_t n) noexcept nogil:
@@ -179,7 +317,7 @@ cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
             med2 = _median_sorted(&s[lo], cnt)
             for i in range(lo, hi):
                 work[i] = fabs(s[i] - med2)
-            qsort(&work[lo], <size_t>cnt, sizeof(double), &_cmp_double)
+            _sort_doubles(&work[lo], cnt)
             mad2 = _median_sorted(&work[lo], cnt)
 
         # Center.
@@ -223,7 +361,7 @@ cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
             med2 = _median_sorted(&s[lo], cnt)
             for i in range(lo, hi):
                 work[i] = fabs(s[i] - med2)
-            qsort(&work[lo], <size_t>cnt, sizeof(double), &_cmp_double)
+            _sort_doubles(&work[lo], cnt)
             std = _median_sorted(&work[lo], cnt) * _MAD_STD_SCALE
 
         minv = cen - std * sigma_lower
@@ -797,7 +935,7 @@ def batch_sort_values(const double[::1] values,
             start = starts[k]
             for i in range(count):
                 out[start + i] = values[start + i]
-            qsort(&out[start], <size_t>count, sizeof(double), &_cmp_double)
+            _sort_doubles(&out[start], count)
 
     return out_arr
 
@@ -952,7 +1090,7 @@ def batch_mad(const double[::1] sorted_values,
             med = _median_sorted(&sorted_values[start], count)
             for i in range(count):
                 w[i] = fabs(sorted_values[start + i] - med)
-            qsort(&w[0], <size_t>count, sizeof(double), &_cmp_double)
+            _sort_doubles(&w[0], count)
             mad[k] = _median_sorted(&w[0], count)
 
     return mad_arr
@@ -1095,7 +1233,7 @@ def batch_gini(const double[::1] values,
 
             for i in range(count):
                 w[i] = fabs(values[start + i])
-            qsort(&w[0], <size_t>count, sizeof(double), &_cmp_double)
+            _sort_doubles(&w[0], count)
             gsum = 0.0
             for i in range(count):
                 gsum += w[i]
@@ -1204,7 +1342,7 @@ def batch_sigma_clip_center(const double[::1] values,
             start = starts[k]
             for i in range(count):
                 s[i] = values[start + i]
-            qsort(&s[0], <size_t>count, sizeof(double), &_cmp_double)
+            _sort_doubles(&s[0], count)
             _sigma_clip_bounds(&s[0], &w[0], count, sigma_lower, sigma_upper,
                                maxiters, cenfunc_code, stdfunc_code,
                                &minv, &maxv)
@@ -1313,7 +1451,7 @@ def batch_sigma_clip_sum(const double[::1] sum_values,
             start = starts[k]
             for i in range(count):
                 s[i] = sum_values[start + i]
-            qsort(&s[0], <size_t>count, sizeof(double), &_cmp_double)
+            _sort_doubles(&s[0], count)
             _sigma_clip_bounds(&s[0], &w[0], count, sigma_lower, sigma_upper,
                                maxiters, cenfunc_code, stdfunc_code,
                                &minv, &maxv)
@@ -1458,10 +1596,9 @@ def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
     (`astropy.stats.biweight_scale`) are also computed.
 
     Each row must be ascending-sorted with any NaN values placed last,
-    as done by `numpy.sort`. Sorting is delegated to the caller because
-    ``numpy.sort`` is much faster than a comparator-based C ``qsort``
-    for the large rows this function is designed for. The input array is
-    not modified.
+    as done by `numpy.sort`. Sorting is delegated to the caller, whose
+    ``numpy.sort`` places the NaN values last for the large rows this
+    function is designed for. The input array is not modified.
 
     The rows are typically the flattened pixels of the boxes of a
     regular grid (e.g., the `~photutils.background.Background2D`
@@ -1601,7 +1738,7 @@ def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
                 # Unscaled MAD about the median of the survivors
                 for i in range(lo, hi):
                     w[i - lo] = fabs(s[i] - med)
-                qsort(&w[0], <size_t>cnt, sizeof(double), &_cmp_double)
+                _sort_doubles(&w[0], cnt)
                 madk = _median_sorted(&w[0], cnt)
 
                 if compute_mad:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -1046,6 +1046,11 @@ class PixelAperture(Aperture):
                 float(ext_x), float(ext_y), float(off_x), float(off_y),
                 use_exact, subpixels, seg_arr, src_labels, seg_code)
 
+        # The driver results are indexed by position: index 9 is the
+        # per-source flag counts. The per-source outside-weight
+        # indicator (index 10) is not used here, because the aperture
+        # flags resolve the clipped bounding boxes with
+        # ``_resolve_outside_weights``.
         n_chunks = min(n_threads, positions.shape[0])
         if n_chunks > 1:
             # Row slices of the C-contiguous positions and labels
@@ -1063,10 +1068,11 @@ class PixelAperture(Aperture):
             sum_var = np.concatenate([result[1] for result in results])
             area = np.concatenate([result[2] for result in results])
             overlap = np.concatenate([result[3] for result in results])
-            fcounts = np.concatenate([result[-1] for result in results])
+            fcounts = np.concatenate([result[9] for result in results])
         else:
-            sums, sum_var, area, overlap, *_, fcounts = run_sums(
-                positions, labels_arr)
+            result = run_sums(positions, labels_arr)
+            sums, sum_var, area, overlap = result[:4]
+            fcounts = result[9]
 
         if error is None:
             # Match the mask-based path, which returns an all-NaN error

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -1046,11 +1046,9 @@ class PixelAperture(Aperture):
                 float(ext_x), float(ext_y), float(off_x), float(off_y),
                 use_exact, subpixels, seg_arr, src_labels, seg_code)
 
-        # The driver results are indexed by position: index 9 is the
-        # per-source flag counts. The per-source outside-weight
-        # indicator (index 10) is not used here, because the aperture
-        # flags resolve the clipped bounding boxes with
-        # ``_resolve_outside_weights``.
+        # The per-source outside-weight indicator of the driver is not
+        # used here, because the aperture flags resolve the clipped
+        # bounding boxes with ``_resolve_outside_weights``.
         n_chunks = min(n_threads, positions.shape[0])
         if n_chunks > 1:
             # Row slices of the C-contiguous positions and labels
@@ -1064,15 +1062,19 @@ class PixelAperture(Aperture):
             with ThreadPoolExecutor(max_workers=n_chunks) as executor:
                 results = list(executor.map(run_sums, pos_chunks,
                                             labels_chunks))
-            sums = np.concatenate([result[0] for result in results])
-            sum_var = np.concatenate([result[1] for result in results])
-            area = np.concatenate([result[2] for result in results])
-            overlap = np.concatenate([result[3] for result in results])
-            fcounts = np.concatenate([result[9] for result in results])
+            sums = np.concatenate([result.sums for result in results])
+            sum_var = np.concatenate([result.sum_vars for result in results])
+            area = np.concatenate([result.areas for result in results])
+            overlap = np.concatenate([result.overlap for result in results])
+            fcounts = np.concatenate([result.flag_counts
+                                      for result in results])
         else:
             result = run_sums(positions, labels_arr)
-            sums, sum_var, area, overlap = result[:4]
-            fcounts = result[9]
+            sums = result.sums
+            sum_var = result.sum_vars
+            area = result.areas
+            overlap = result.overlap
+            fcounts = result.flag_counts
 
         if error is None:
             # Match the mask-based path, which returns an all-NaN error

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -29,7 +29,8 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
 from photutils.aperture._batch_stats import (batch_aperture_gather,
                                              batch_biweight, batch_gini,
                                              batch_mad, batch_mean_var,
-                                             batch_moments, batch_order_stats,
+                                             batch_minmax, batch_moments,
+                                             batch_order_stats,
                                              batch_sigma_clip_center,
                                              batch_sigma_clip_sum,
                                              batch_sort_values)
@@ -346,8 +347,8 @@ class ApertureStats:
     # index the packed buffer per source and fail or corrupt it.
     _NON_SLICEABLE_CACHES = frozenset({
         '_batch_inputs', '_fast_gather', '_fast_sum', '_sorted_values',
-        '_order_stats', '_mean_var', '_mad', '_biweight', '_gini',
-        '_fast_cutouts_center'})
+        '_order_stats', '_minmax', '_mean_var', '_mad', '_biweight',
+        '_gini', '_fast_cutouts_center'})
 
     def __init__(self, data, aperture, *, error=None, mask=None, wcs=None,
                  sigma_clip=None, sum_method='exact', subpixels=5, ddof=0,
@@ -1294,6 +1295,28 @@ class ApertureStats:
         values, starts, counts = sorted_values
         return self._threaded_reduction(batch_order_stats, (values,),
                                         starts, counts)
+
+    @cached_property
+    def _minmax(self):
+        """
+        The per-source ``(min, max)`` arrays, or `None`.
+
+        Reduced directly from the packed center buffer when no sorted
+        buffer exists yet, so that ``min`` and ``max`` alone do not
+        pay for the per-source sort. The sorted buffer is used when
+        it is already cached, or when sigma clipping is applied (the
+        clipping kernel produces the sorted surviving values, which
+        define the extremes). `None` when the fast path is unavailable.
+        """
+        gather = self._fast_gather
+        if gather is None:
+            return None
+        if (gather.sorted_values is not None
+                or '_sorted_values' in self.__dict__):
+            vmin, vmax, _ = self._order_stats
+            return vmin, vmax
+        return self._threaded_reduction(batch_minmax, (gather.values,),
+                                        gather.starts, gather.counts)
 
     @cached_property
     def _mean_var(self):
@@ -2599,7 +2622,7 @@ class ApertureStats:
         """
         The minimum of the unmasked pixel values within the aperture.
         """
-        fast = None if self._order_stats is None else self._order_stats[0]
+        fast = None if self._minmax is None else self._minmax[0]
         return self._finalize_value_stat(fast, np.min)
 
     @cached_property
@@ -2607,7 +2630,7 @@ class ApertureStats:
         """
         The maximum of the unmasked pixel values within the aperture.
         """
-        fast = None if self._order_stats is None else self._order_stats[1]
+        fast = None if self._minmax is None else self._minmax[1]
         return self._finalize_value_stat(fast, np.max)
 
     @cached_property

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1010,8 +1010,10 @@ class ApertureStats:
         emit_sum = 1 if clip_spec is not None else 0
 
         def sum_chunk(pos, bkg, labels):
+            # The gather path derives its outside-weight flag elsewhere,
+            # so the driver's per-source indicator is discarded here.
             (sums, sum_var, area, overlap, starts, sum_values, sum_fracs,
-             sum_errsq, scounts, flag_counts) = batch_aperture_sums(
+             sum_errsq, scounts, flag_counts, _) = batch_aperture_sums(
                 data, error, mask, pos, shape_code, params, ext_x, ext_y,
                 off_x, off_y, sum_use_exact, sum_subpixels, seg_arr,
                 labels, seg_code, bkg, emit_sum)

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -24,7 +24,7 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_NONFINITE_ERROR,
                                                   FLAG_COL_SEG,
                                                   FLAG_COL_UNCORRECTED,
-                                                  FLAG_COL_VALID,
+                                                  FLAG_COL_VALID, N_FLAG_COLS,
                                                   batch_aperture_sums)
 from photutils.aperture._batch_stats import (batch_aperture_gather,
                                              batch_biweight, batch_gini,
@@ -1496,7 +1496,7 @@ class ApertureStats:
                 zip(self._data_cutouts, aperture_masks,
                     self._overlap_slices, strict=True)):
 
-            fc_row = np.zeros(8, dtype=np.intp)
+            fc_row = np.zeros(N_FLAG_COLS, dtype=np.intp)
             n_clipped_ = 0
 
             slc_large, slc_small = slices

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1011,12 +1011,16 @@ class ApertureStats:
 
         def sum_chunk(pos, bkg, labels):
             # The gather path derives its outside-weight flag elsewhere,
-            # so the driver's per-source indicator is discarded here.
-            (sums, sum_var, area, overlap, starts, sum_values, sum_fracs,
-             sum_errsq, scounts, flag_counts, _) = batch_aperture_sums(
+            # so the driver's per-source indicator is not used here.
+            result = batch_aperture_sums(
                 data, error, mask, pos, shape_code, params, ext_x, ext_y,
                 off_x, off_y, sum_use_exact, sum_subpixels, seg_arr,
                 labels, seg_code, bkg, emit_sum)
+            (sums, sum_var, area, overlap, starts, sum_values, sum_fracs,
+             sum_errsq, scounts, flag_counts) = (
+                result.sums, result.sum_vars, result.areas, result.overlap,
+                result.starts, result.sum_values, result.sum_fracs,
+                result.sum_errsq, result.sum_counts, result.flag_counts)
             gather = _BatchGather(starts=starts, sum_aper=sums,
                                   var_aper=sum_var, sum_area=area,
                                   overlap=overlap, sum_values=sum_values,

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1301,18 +1301,16 @@ class ApertureStats:
         """
         The per-source ``(min, max)`` arrays, or `None`.
 
-        Reduced directly from the packed center buffer when no sorted
-        buffer exists yet, so that ``min`` and ``max`` alone do not
-        pay for the per-source sort. The sorted buffer is used when
-        it is already cached, or when sigma clipping is applied (the
-        clipping kernel produces the sorted surviving values, which
-        define the extremes). `None` when the fast path is unavailable.
+        Reduced directly from the packed center buffer, so that ``min``
+        and ``max`` do not pay for the per-source sort. When sigma
+        clipping is applied, the clipping kernel's sorted surviving
+        values define the extremes, so the order statistics are used
+        instead. `None` when the fast path is unavailable.
         """
         gather = self._fast_gather
         if gather is None:
             return None
-        if (gather.sorted_values is not None
-                or '_sorted_values' in self.__dict__):
+        if gather.sorted_values is not None:
             vmin, vmax, _ = self._order_stats
             return vmin, vmax
         return self._threaded_reduction(batch_minmax, (gather.values,),

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -37,7 +37,7 @@ def _sums_fcounts(data, positions, radius, *, error=None, mask=None,
         np.ascontiguousarray(data, dtype=np.float64), error, mask,
         positions, SHAPE_CIRCLE, params, radius, radius, 0.0, 0.0,
         use_exact, subpixels, segmentation, labels, seg_method)
-    return result[9]
+    return result.flag_counts
 
 
 def _gather_fcounts(data, positions, radius, *, mask=None,

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -37,7 +37,7 @@ def _sums_fcounts(data, positions, radius, *, error=None, mask=None,
         np.ascontiguousarray(data, dtype=np.float64), error, mask,
         positions, SHAPE_CIRCLE, params, radius, radius, 0.0, 0.0,
         use_exact, subpixels, segmentation, labels, seg_method)
-    return result[-1]
+    return result[9]
 
 
 def _gather_fcounts(data, positions, radius, *, mask=None,

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -14,8 +14,11 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_NONFINITE_DATA,
                                                   FLAG_COL_NONFINITE_ERROR,
                                                   FLAG_COL_SEG,
+                                                  FLAG_COL_SEG_MASKED,
                                                   FLAG_COL_UNCORRECTED,
-                                                  FLAG_COL_VALID, SHAPE_CIRCLE,
+                                                  FLAG_COL_UNCORRECTED_MASKED,
+                                                  FLAG_COL_VALID, N_FLAG_COLS,
+                                                  SHAPE_CIRCLE,
                                                   batch_aperture_sums)
 from photutils.aperture._batch_stats import batch_aperture_gather
 from photutils.aperture.tests.conftest import UNIT_SHAPE
@@ -301,3 +304,62 @@ class TestSegmentationCounts:
                            segmentation=segm, labels=labels, seg_method=3)[0]
         assert fc[FLAG_COL_SEG] == 1
         assert fc[FLAG_COL_UNCORRECTED] == 1
+
+
+class TestSegMaskedCounts:
+    """
+    Tests for the masked neighbor-segment pixel counts.
+
+    Masked pixels never reach the segmentation branch of the per-pixel
+    loop, so they are counted in separate columns for callers that
+    treat the mask and neighbor overlays independently.
+    """
+
+    @staticmethod
+    def _inputs():
+        """
+        Return the data, mask, segmentation, and labels of a source with
+        one unmasked and one masked neighbor-segment pixel.
+        """
+        data = np.ones((11, 11))
+        segm = np.zeros((11, 11), dtype=np.intp)
+        segm[4:7, 4:7] = 1
+        segm[5, 8] = 2  # neighbor pixel, unmasked
+        # Neighbor pixel that is masked. Its mirror across the center is
+        # (5, 8), which is also a neighbor, so neither pixel can be
+        # corrected by the 'correct' method.
+        segm[5, 2] = 2
+        mask = np.zeros((11, 11), dtype=np.uint8)
+        mask[5, 2] = 1
+        labels = np.array([1], dtype=np.intp)
+        return data, mask, segm, labels
+
+    def test_n_flag_cols(self):
+        """
+        Test the flag-count column layout.
+        """
+        assert FLAG_COL_SEG_MASKED == 8
+        assert FLAG_COL_UNCORRECTED_MASKED == 9
+        assert N_FLAG_COLS == 10
+
+    @pytest.mark.parametrize('func', [_sums_fcounts, _gather_fcounts])
+    @pytest.mark.parametrize(('seg_method', 'n_seg', 'n_uncorr',
+                              'n_seg_masked', 'n_uncorr_masked'),
+                             [(3, 1, 1, 1, 1),
+                              (1, 1, 0, 1, 0),
+                              (0, 0, 0, 0, 0)])
+    def test_seg_masked_columns(self, func, seg_method, n_seg, n_uncorr,
+                                n_seg_masked, n_uncorr_masked):
+        """
+        Test that masked neighbor-segment pixels are counted separately
+        from the unmasked ones by both batch drivers.
+        """
+        data, mask, segm, labels = self._inputs()
+        fc = func(data, (5.0, 5.0), 4.0, mask=mask, segmentation=segm,
+                  labels=labels, seg_method=seg_method)[0]
+        assert fc.shape == (N_FLAG_COLS,)
+        assert fc[FLAG_COL_MASKED] == 1
+        assert fc[FLAG_COL_SEG] == n_seg
+        assert fc[FLAG_COL_UNCORRECTED] == n_uncorr
+        assert fc[FLAG_COL_SEG_MASKED] == n_seg_masked
+        assert fc[FLAG_COL_UNCORRECTED_MASKED] == n_uncorr_masked

--- a/photutils/aperture/tests/test_batch_minmax.py
+++ b/photutils/aperture/tests/test_batch_minmax.py
@@ -1,0 +1,147 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch minimum/maximum kernel and the sort-free
+ApertureStats ``min`` and ``max`` path.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+from astropy.stats import SigmaClip
+from numpy.testing import assert_allclose, assert_array_equal
+
+from photutils.aperture import ApertureStats, CircularAperture
+from photutils.aperture._batch_stats import batch_minmax
+
+
+def _packed(rng, counts):
+    starts = np.concatenate(([0], np.cumsum(counts)[:-1])).astype(np.intp)
+    values = rng.normal(size=int(counts.sum()))
+    return values, starts, counts.astype(np.intp)
+
+
+def test_kernel_matches_numpy():
+    rng = np.random.default_rng(3)
+    counts = rng.integers(0, 40, 300)
+    counts[::7] = 0
+    counts[1::11] = 1
+    values, starts, counts = _packed(rng, counts)
+    vmin, vmax = batch_minmax(values, starts, counts)
+    for k, (start, count) in enumerate(zip(starts, counts, strict=True)):
+        if count == 0:
+            assert np.isnan(vmin[k])
+            assert np.isnan(vmax[k])
+        else:
+            chunk = values[start:start + count]
+            assert vmin[k] == chunk.min()
+            assert vmax[k] == chunk.max()
+
+
+def test_kernel_single_value_and_duplicates():
+    values = np.array([2.0, 5.0, 5.0, -1.0, -1.0, 7.0])
+    starts = np.array([0, 1, 3], dtype=np.intp)
+    counts = np.array([1, 2, 3], dtype=np.intp)
+    vmin, vmax = batch_minmax(values, starts, counts)
+    assert_array_equal(vmin, [2.0, 5.0, -1.0])
+    assert_array_equal(vmax, [2.0, 5.0, 7.0])
+
+
+def test_kernel_thread_safety():
+    rng = np.random.default_rng(4)
+    values, starts, counts = _packed(rng, rng.integers(1, 30, 200))
+    expected = batch_minmax(values, starts, counts)
+
+    def run(_):
+        return batch_minmax(values, starts, counts)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        for result in pool.map(run, range(8)):
+            for got, want in zip(result, expected, strict=True):
+                assert_array_equal(got, want)
+
+
+@pytest.fixture
+def stats_inputs():
+    rng = np.random.default_rng(5)
+    data = rng.normal(size=(120, 120))
+    positions = np.column_stack((rng.uniform(5, 115, 60),
+                                 rng.uniform(5, 115, 60)))
+    return data, CircularAperture(positions, r=4.0)
+
+
+def _reference_extremes(data, aperture):
+    vmin = []
+    vmax = []
+    for mask in aperture.to_mask(method='center'):
+        cutout = mask.get_values(data)
+        vmin.append(cutout.min())
+        vmax.append(cutout.max())
+    return np.array(vmin), np.array(vmax)
+
+
+@pytest.mark.parametrize('n_threads', [1, 3])
+def test_min_max_without_sort(stats_inputs, n_threads):
+    """
+    Test that min and max alone are computed without the per-source
+    sort and match both the reference and the sorted path.
+    """
+    data, aperture = stats_inputs
+    ref_min, ref_max = _reference_extremes(data, aperture)
+    stats = ApertureStats(data, aperture, n_threads=n_threads)
+    assert stats._fast_gather is not None
+    assert_allclose(stats.min, ref_min)
+    assert_allclose(stats.max, ref_max)
+    assert '_sorted_values' not in stats.__dict__
+    assert '_order_stats' not in stats.__dict__
+    # The sorted path gives the same values
+    vmin, vmax, _ = stats._order_stats
+    assert_array_equal(vmin, stats.min)
+    assert_array_equal(vmax, stats.max)
+
+
+def test_min_max_reuse_cached_sort(stats_inputs):
+    """
+    Test that min and max reuse the sorted buffer once it exists.
+    """
+    data, aperture = stats_inputs
+    stats = ApertureStats(data, aperture)
+    median = stats.median
+    assert '_sorted_values' in stats.__dict__
+    assert_array_equal(stats._minmax[0], stats._order_stats[0])
+    assert_array_equal(stats._minmax[1], stats._order_stats[1])
+    ref_min, ref_max = _reference_extremes(data, aperture)
+    assert_allclose(stats.min, ref_min)
+    assert_allclose(stats.max, ref_max)
+    assert np.all(stats.min <= median)
+    assert np.all(median <= stats.max)
+
+
+def test_min_max_with_sigma_clip(stats_inputs):
+    """
+    Test that the sigma-clipped min and max are the extremes of the
+    surviving values (the clipping kernel's sorted buffer).
+    """
+    data, aperture = stats_inputs
+    sigma_clip = SigmaClip(sigma=2.0, maxiters=5)
+    stats = ApertureStats(data, aperture, sigma_clip=sigma_clip)
+    assert stats._fast_gather.sorted_values is not None
+    assert_array_equal(stats._minmax[0], stats._order_stats[0])
+    assert_array_equal(stats._minmax[1], stats._order_stats[1])
+    vmin = []
+    vmax = []
+    for mask in aperture.to_mask(method='center'):
+        clipped = sigma_clip(mask.get_values(data), masked=False)
+        vmin.append(clipped.min())
+        vmax.append(clipped.max())
+    assert_allclose(stats.min, vmin)
+    assert_allclose(stats.max, vmax)
+
+
+def test_min_max_scalar_and_unit():
+    data = np.arange(400.0).reshape(20, 20)
+    aperture = CircularAperture((10.0, 10.0), r=2.5)
+    stats = ApertureStats(data, aperture)
+    values = aperture.to_mask(method='center').get_values(data)
+    assert stats.min == values.min()
+    assert stats.max == values.max()

--- a/photutils/aperture/tests/test_batch_minmax.py
+++ b/photutils/aperture/tests/test_batch_minmax.py
@@ -100,9 +100,10 @@ def test_min_max_without_sort(stats_inputs, n_threads):
     assert_array_equal(vmax, stats.max)
 
 
-def test_min_max_reuse_cached_sort(stats_inputs):
+def test_min_max_after_sort(stats_inputs):
     """
-    Test that min and max reuse the sorted buffer once it exists.
+    Test that min and max agree with the sorted path (and the
+    reference) when the sorted buffer already exists.
     """
     data, aperture = stats_inputs
     stats = ApertureStats(data, aperture)

--- a/photutils/aperture/tests/test_batch_photometry_driver.py
+++ b/photutils/aperture/tests/test_batch_photometry_driver.py
@@ -226,7 +226,7 @@ def test_weights_out():
     result = batch_aperture_sums(
         data, None, None, positions, SHAPE_CIRCLE, params, 3.0, 3.0,
         0.0, 0.0, 1, 1)
-    weights_out = result[10]
+    weights_out = result.weights_out
     assert list(weights_out) == [0, 1, 1]
 
 
@@ -247,8 +247,8 @@ def test_weights_out_clipped_bbox_zero_weight():
     result = batch_aperture_sums(
         data, None, None, positions, SHAPE_CIRCLE, params, 2.0, 2.0,
         0.0, 0.0, 0, 1)
-    fcounts = result[9]
-    weights_out = result[10]
+    fcounts = result.flag_counts
+    weights_out = result.weights_out
     assert fcounts[0, FLAG_COL_BBOX_CLIPPED] == 1
     assert weights_out[0] == 0
 
@@ -257,7 +257,7 @@ def test_weights_out_clipped_bbox_zero_weight():
     result = batch_aperture_sums(
         data, None, None, positions, SHAPE_CIRCLE, params, 2.0, 2.0,
         0.0, 0.0, 1, 1)
-    assert result[10][0] == 1
+    assert result.weights_out[0] == 1
 
 
 @pytest.mark.parametrize('radius', [2000.0, 8000.0, 20000.0])
@@ -278,10 +278,10 @@ def test_weights_out_large_aperture(radius):
         data, None, None, positions, SHAPE_CIRCLE, np.array([radius]),
         radius, radius, 0.0, 0.0, 1, 5)
 
-    assert result[10][0] == 1
-    assert result[9][0, FLAG_COL_BBOX_CLIPPED] == 1
+    assert result.weights_out[0] == 1
+    assert result.flag_counts[0, FLAG_COL_BBOX_CLIPPED] == 1
     # Every data pixel is well inside the aperture, so the sums are
     # unaffected by the outside-weight scan
-    assert result[9][0, FLAG_COL_N_PIXELS] == data.size
-    assert_allclose(result[0][0], data.sum())
-    assert_allclose(result[2][0], data.size)
+    assert result.flag_counts[0, FLAG_COL_N_PIXELS] == data.size
+    assert_allclose(result.sums[0], data.sum())
+    assert_allclose(result.areas[0], data.size)

--- a/photutils/aperture/tests/test_batch_photometry_driver.py
+++ b/photutils/aperture/tests/test_batch_photometry_driver.py
@@ -10,6 +10,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
+                                                  FLAG_COL_N_PIXELS,
                                                   SHAPE_CIRCLE,
                                                   SHAPE_CIRCULAR_ANNULUS,
                                                   SHAPE_ELLIPSE,
@@ -257,3 +258,30 @@ def test_weights_out_clipped_bbox_zero_weight():
         data, None, None, positions, SHAPE_CIRCLE, params, 2.0, 2.0,
         0.0, 0.0, 1, 1)
     assert result[10][0] == 1
+
+
+@pytest.mark.parametrize('radius', [2000.0, 8000.0, 20000.0])
+def test_weights_out_large_aperture(radius):
+    """
+    Test an aperture whose bounding box is far larger than the data.
+
+    Once a nonzero-fraction pixel outside the data has been found, the
+    remaining outside pixels cannot change the outside-weight result,
+    so the pixel loop narrows back to the part of the bounding box
+    inside the data. Without that, the cost of these apertures would
+    grow with the (enormous) bounding-box area rather than with the
+    data area.
+    """
+    data = np.ones((200, 200))
+    positions = np.array([[100.0, 100.0]])
+    result = batch_aperture_sums(
+        data, None, None, positions, SHAPE_CIRCLE, np.array([radius]),
+        radius, radius, 0.0, 0.0, 1, 5)
+
+    assert result[10][0] == 1
+    assert result[9][0, FLAG_COL_BBOX_CLIPPED] == 1
+    # Every data pixel is well inside the aperture, so the sums are
+    # unaffected by the outside-weight scan
+    assert result[9][0, FLAG_COL_N_PIXELS] == data.size
+    assert_allclose(result[0][0], data.sum())
+    assert_allclose(result[2][0], data.size)

--- a/photutils/aperture/tests/test_batch_photometry_driver.py
+++ b/photutils/aperture/tests/test_batch_photometry_driver.py
@@ -9,6 +9,10 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
+from photutils.aperture import (CircularAnnulus, CircularAperture,
+                                EllipticalAnnulus, EllipticalAperture,
+                                PolygonAperture, RectangularAnnulus,
+                                RectangularAperture)
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_N_PIXELS,
                                                   SHAPE_CIRCLE,
@@ -260,23 +264,133 @@ def test_weights_out_clipped_bbox_zero_weight():
     assert result.weights_out[0] == 1
 
 
+# Aperture factories (taking the positions) whose outside-weight
+# indicator is checked against the aperture's own mask at edge, corner,
+# interior, and off-image positions
+_OUTSIDE_WEIGHT_APERTURES = [
+    lambda pos: CircularAperture(pos, r=6.0),
+    lambda pos: CircularAnnulus(pos, r_in=3.0, r_out=6.0),
+    lambda pos: EllipticalAperture(pos, a=8.0, b=2.5, theta=0.7),
+    lambda pos: EllipticalAnnulus(pos, a_in=3.0, a_out=8.0, b_out=2.5,
+                                  theta=0.7),
+    lambda pos: RectangularAperture(pos, w=12.0, h=5.0, theta=0.5),
+    lambda pos: RectangularAnnulus(pos, w_in=5.0, w_out=12.0, h_out=5.0,
+                                   theta=0.5),
+    # A non-convex (L-shaped) polygon
+    lambda pos: PolygonAperture(pos, [(-6, -6), (6, -6), (6, -1),
+                                      (-1, -1), (-1, 6), (-6, 6)]),
+]
+
+
+def _outside_weight_positions():
+    """
+    Positions on and just beyond every edge and corner of the 40x40
+    test data, plus interior and far off-image positions.
+    """
+    rng = np.random.default_rng(7)
+    edge = np.array([-8.0, -3.0, -0.4, 0.3, 2.0, 5.0, 37.0, 39.2, 39.6,
+                     42.0, 47.0])
+    positions = [(x, 20.0) for x in edge] + [(20.0, y) for y in edge]
+    positions += [(x, y) for x in (-3.0, 1.0, 38.0, 42.0)
+                  for y in (-3.0, 1.0, 38.0, 42.0)]
+    positions += [(20.0, 20.0), (12.5, 27.5), (200.0, 200.0),
+                  (-100.0, 20.0)]
+    positions += [tuple(rng.uniform(-10, 50, 2)) for _ in range(20)]
+    return np.array(positions, dtype=np.float64)
+
+
+@pytest.mark.parametrize('make_aperture', _OUTSIDE_WEIGHT_APERTURES,
+                         ids=lambda fn: type(fn((0, 0))).__name__)
+@pytest.mark.parametrize(('method', 'use_exact', 'subpixels'),
+                         [('exact', 1, 1), ('center', 0, 1),
+                          ('subpixel', 0, 3)])
+def test_weights_out_matches_mask(make_aperture, method, use_exact,
+                                  subpixels):
+    """
+    Test the outside-weight indicator against the aperture mask.
+
+    The reference is the aperture's own unclipped ``to_mask`` array
+    with the part inside the data zeroed: the indicator must be set
+    exactly when a nonzero mask value remains.
+    """
+    data = np.ones((40, 40))
+    positions = _outside_weight_positions()
+    aperture = make_aperture(positions)
+    shape_code, params = aperture._batch_shape_params()
+    ext_x, ext_y = aperture._xy_extents
+    off_x, off_y = aperture._xy_bbox_offset
+    result = batch_aperture_sums(
+        data, None, None, positions, shape_code,
+        np.array(params, dtype=np.float64), float(ext_x), float(ext_y),
+        float(off_x), float(off_y), use_exact, subpixels)
+
+    expected = np.zeros(len(positions), dtype=np.uint8)
+    clipped = np.zeros(len(positions), dtype=bool)
+    masks = aperture.to_mask(method=method, subpixels=subpixels)
+    for i, mask in enumerate(masks):
+        slc_lg, slc_sm = mask.get_overlap_slices(data.shape)
+        if slc_lg is None:
+            continue
+        bbox = mask.bbox
+        clipped[i] = (bbox.ixmin < 0 or bbox.iymin < 0
+                      or bbox.ixmax > data.shape[1]
+                      or bbox.iymax > data.shape[0])
+        outside = mask.data.copy()
+        outside[slc_sm] = 0.0
+        expected[i] = np.any(outside > 0)
+
+    assert_array_equal(result.flag_counts[:, FLAG_COL_BBOX_CLIPPED],
+                       clipped)
+    assert_array_equal(result.weights_out, expected)
+    assert np.any(expected[clipped] == 1)
+
+
+def test_weights_out_aperture_entirely_outside():
+    """
+    Test an aperture that lies entirely in the clipped-away part of its
+    bounding box.
+
+    The L-shaped polygon centered at (-3, -3) has its bounding box
+    overlapping the data but no area inside it, so the exact-method
+    ring test (which assumes weight on both sides of the data edge)
+    does not apply and every outside pixel is scanned instead.
+    """
+    data = np.ones((40, 40))
+    aperture = PolygonAperture((-3.0, -3.0), [(-6, -6), (6, -6), (6, -1),
+                                              (-1, -1), (-1, 6), (-6, 6)])
+    shape_code, params = aperture._batch_shape_params()
+    ext_x, ext_y = aperture._xy_extents
+    off_x, off_y = aperture._xy_bbox_offset
+    for use_exact, subpixels in ((1, 1), (0, 1), (0, 3)):
+        result = batch_aperture_sums(
+            data, None, None, np.array([[-3.0, -3.0]]), shape_code,
+            np.array(params, dtype=np.float64), float(ext_x),
+            float(ext_y), float(off_x), float(off_y), use_exact,
+            subpixels)
+        assert result.overlap[0]
+        assert result.flag_counts[0, FLAG_COL_BBOX_CLIPPED] == 1
+        assert result.flag_counts[0, FLAG_COL_N_PIXELS] == 0
+        assert result.weights_out[0] == 1
+
+
+@pytest.mark.parametrize(('use_exact', 'subpixels'),
+                         [(1, 1), (0, 1), (0, 3)])
 @pytest.mark.parametrize('radius', [2000.0, 8000.0, 20000.0])
-def test_weights_out_large_aperture(radius):
+def test_weights_out_large_aperture(radius, use_exact, subpixels):
     """
     Test an aperture whose bounding box is far larger than the data.
 
-    Once a nonzero-fraction pixel outside the data has been found, the
-    remaining outside pixels cannot change the outside-weight result,
-    so the pixel loop narrows back to the part of the bounding box
-    inside the data. Without that, the cost of these apertures would
-    grow with the (enormous) bounding-box area rather than with the
-    data area.
+    The outside-weight test is separate from the accumulation loop and
+    stops at the first nonzero-fraction pixel outside the data (for the
+    exact method it tests only the ring of pixels just outside the data
+    edges), so the cost of these apertures does not grow with the
+    (enormous) bounding-box area.
     """
     data = np.ones((200, 200))
     positions = np.array([[100.0, 100.0]])
     result = batch_aperture_sums(
         data, None, None, positions, SHAPE_CIRCLE, np.array([radius]),
-        radius, radius, 0.0, 0.0, 1, 5)
+        radius, radius, 0.0, 0.0, use_exact, subpixels)
 
     assert result.weights_out[0] == 1
     assert result.flag_counts[0, FLAG_COL_BBOX_CLIPPED] == 1

--- a/photutils/aperture/tests/test_batch_photometry_driver.py
+++ b/photutils/aperture/tests/test_batch_photometry_driver.py
@@ -7,9 +7,10 @@ from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
-from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
+from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
+                                                  SHAPE_CIRCLE,
                                                   SHAPE_CIRCULAR_ANNULUS,
                                                   SHAPE_ELLIPSE,
                                                   SHAPE_ELLIPTICAL_ANNULUS,
@@ -129,3 +130,130 @@ class TestBatchApertureSums:
                 for res_arr, exp_arr in zip(result, expected[shape_code],
                                             strict=True):
                     assert_array_equal(res_arr, exp_arr)
+
+
+def test_params_per_source_circle():
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=(40, 40))
+    positions = np.array([[10.0, 10.0], [25.0, 25.0], [30.0, 12.0]])
+    radii = np.array([2.0, 3.5, 5.0])
+    psrc = radii[:, None].copy()
+    batch = batch_aperture_sums(
+        data, None, None, positions, SHAPE_CIRCLE, None, 0.0, 0.0,
+        0.0, 0.0, 1, 1, params_per_source=psrc)
+    for i, r in enumerate(radii):
+        single = batch_aperture_sums(
+            data, None, None, positions[i:i + 1], SHAPE_CIRCLE,
+            np.array([r]), r, r, 0.0, 0.0, 1, 1)
+        assert_allclose(batch[0][i], single[0][0], rtol=1e-12)
+
+
+def test_params_per_source_ellipse():
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=(40, 40))
+    positions = np.array([[10.0, 10.0], [25.0, 25.0], [30.0, 12.0]])
+    psrc = np.array([[3.0, 2.0, 0.5],
+                     [4.0, 1.0, -0.3],
+                     [2.5, 2.5, 1.2]])
+    batch = batch_aperture_sums(
+        data, None, None, positions, SHAPE_ELLIPSE, None, 0.0, 0.0,
+        0.0, 0.0, 1, 1, params_per_source=psrc)
+    for i, (semi_a, semi_b, theta) in enumerate(psrc):
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        ext_x = np.sqrt((semi_a * cos_theta)**2 + (semi_b * sin_theta)**2)
+        ext_y = np.sqrt((semi_a * sin_theta)**2 + (semi_b * cos_theta)**2)
+        single = batch_aperture_sums(
+            data, None, None, positions[i:i + 1], SHAPE_ELLIPSE,
+            np.array([semi_a, semi_b, theta]), ext_x, ext_y, 0.0, 0.0,
+            1, 1)
+        assert_allclose(batch[0][i], single[0][0], rtol=1e-12)
+
+
+def test_params_per_source_invalid():
+    data = np.ones((20, 20))
+    positions = np.array([[10.0, 10.0], [12.0, 12.0]])
+    psrc = np.array([[2.0], [3.0]])
+    params = np.array([2.0])
+
+    match = 'params must be given when params_per_source is None'
+    with pytest.raises(ValueError, match=match):
+        batch_aperture_sums(data, None, None, positions, SHAPE_CIRCLE,
+                            None, 2.0, 2.0, 0.0, 0.0, 1, 1)
+
+    match = 'give params or params_per_source, not both'
+    with pytest.raises(ValueError, match=match):
+        batch_aperture_sums(data, None, None, positions, SHAPE_CIRCLE,
+                            params, 2.0, 2.0, 0.0, 0.0, 1, 1,
+                            params_per_source=psrc)
+
+    match = 'params_per_source supports only circle and ellipse shapes'
+    with pytest.raises(ValueError, match=match):
+        batch_aperture_sums(data, None, None, positions,
+                            SHAPE_CIRCULAR_ANNULUS, None, 2.0, 2.0,
+                            0.0, 0.0, 1, 1, params_per_source=psrc)
+
+    match = 'params_per_source does not support emit_sum'
+    with pytest.raises(ValueError, match=match):
+        batch_aperture_sums(data, None, None, positions, SHAPE_CIRCLE,
+                            None, 2.0, 2.0, 0.0, 0.0, 1, 1, None, None,
+                            0, None, 1, params_per_source=psrc)
+
+    match = 'params_per_source must have one row per position'
+    with pytest.raises(ValueError, match=match):
+        batch_aperture_sums(data, None, None, positions, SHAPE_CIRCLE,
+                            None, 2.0, 2.0, 0.0, 0.0, 1, 1,
+                            params_per_source=psrc[:1])
+
+    match = 'params_per_source has the wrong column count'
+    with pytest.raises(ValueError, match=match):
+        batch_aperture_sums(data, None, None, positions, SHAPE_CIRCLE,
+                            None, 2.0, 2.0, 0.0, 0.0, 1, 1,
+                            params_per_source=np.zeros((2, 3)))
+    with pytest.raises(ValueError, match=match):
+        batch_aperture_sums(data, None, None, positions, SHAPE_ELLIPSE,
+                            None, 2.0, 2.0, 0.0, 0.0, 1, 1,
+                            params_per_source=np.zeros((2, 1)))
+
+
+def test_weights_out():
+    data = np.ones((20, 20))
+    positions = np.array([[10.0, 10.0],   # interior
+                          [1.0, 10.0],    # aperture off left edge
+                          [19.4, 10.0]])  # aperture off right edge
+    params = np.array([3.0])
+    result = batch_aperture_sums(
+        data, None, None, positions, SHAPE_CIRCLE, params, 3.0, 3.0,
+        0.0, 0.0, 1, 1)
+    weights_out = result[10]
+    assert list(weights_out) == [0, 1, 1]
+
+
+def test_weights_out_clipped_bbox_zero_weight():
+    """
+    Test that a bbox row can poke off-image while every off-image pixel
+    has zero aperture fraction.
+
+    ``weights_out`` must then be 0 even though ``FLAG_COL_BBOX_CLIPPED``
+    is 1. With method='center' (``use_exact=0``, ``subpixels=1``), a
+    circle of r=2.0 at y=1.4 has iymin = floor(1.4 - 2 + 0.5) = -1
+    (clipped), but the off-image pixel centers at y=-1 lie 2.4 > r from
+    the center, so their center-method fraction is zero.
+    """
+    data = np.ones((20, 20))
+    positions = np.array([[10.0, 1.4]])
+    params = np.array([2.0])
+    result = batch_aperture_sums(
+        data, None, None, positions, SHAPE_CIRCLE, params, 2.0, 2.0,
+        0.0, 0.0, 0, 1)
+    fcounts = result[9]
+    weights_out = result[10]
+    assert fcounts[0, FLAG_COL_BBOX_CLIPPED] == 1
+    assert weights_out[0] == 0
+
+    # The same aperture with the exact method has positive area
+    # off-image
+    result = batch_aperture_sums(
+        data, None, None, positions, SHAPE_CIRCLE, params, 2.0, 2.0,
+        0.0, 0.0, 1, 1)
+    assert result[10][0] == 1

--- a/photutils/aperture/tests/test_batch_sort.py
+++ b/photutils/aperture/tests/test_batch_sort.py
@@ -1,0 +1,75 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the callback-free sort of the batch statistics kernels.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from photutils.aperture._batch_stats import _heapsort_values, batch_sort_values
+
+
+def _adversarial_arrays(rng, n):
+    """
+    Arrays of length ``n`` that exercise the partitioning, sentinel,
+    and short-range paths of the introsort.
+    """
+    base = rng.normal(size=n)
+    arrays = [base, np.sort(base), np.sort(base)[::-1].copy(),
+              np.full(n, 3.5), rng.integers(0, 3, n).astype(float),
+              rng.integers(0, max(n // 4, 1), n).astype(float)]
+    # Organ pipe and sawtooth patterns
+    half = np.arange(n // 2, dtype=float)
+    arrays.append(np.concatenate((half, half[::-1], np.zeros(n % 2))))
+    arrays.append((np.arange(n) % 7).astype(float))
+    # Values with the same magnitude and both signs, and extremes
+    arrays.append(np.where(rng.random(n) < 0.5, base, -base))
+    arrays.append(np.where(rng.random(n) < 0.01, 1e300, base))
+    return arrays
+
+
+@pytest.mark.parametrize('n', [0, 1, 2, 3, 15, 16, 17, 31, 32, 33, 100,
+                               1000, 100_000])
+def test_sort_values_matches_numpy(n):
+    rng = np.random.default_rng(n)
+    for arr in _adversarial_arrays(rng, n):
+        arr = np.ascontiguousarray(arr, dtype=np.float64)
+        starts = np.array([0], dtype=np.intp)
+        counts = np.array([n], dtype=np.intp)
+        result = batch_sort_values(arr, starts, counts)
+        assert_array_equal(result, np.sort(arr))
+
+
+def test_sort_values_many_sources():
+    """
+    Test that each source's slice is sorted independently, including
+    empty sources, and that the input is not modified.
+    """
+    rng = np.random.default_rng(7)
+    counts = rng.integers(0, 60, 500).astype(np.intp)
+    counts[::13] = 0
+    counts[1::17] = 1
+    counts[2::19] = 17
+    starts = np.concatenate(([0], np.cumsum(counts)[:-1])).astype(np.intp)
+    values = rng.normal(size=int(counts.sum()))
+    original = values.copy()
+    result = batch_sort_values(values, starts, counts)
+    assert_array_equal(values, original)
+    for start, count in zip(starts, counts, strict=True):
+        assert_array_equal(result[start:start + count],
+                           np.sort(values[start:start + count]))
+
+
+@pytest.mark.parametrize('n', [0, 1, 2, 3, 16, 17, 100, 1000, 100_000])
+def test_heapsort_fallback(n):
+    """
+    Test the heapsort that the introsort falls back to when its
+    recursion budget is exhausted (not reachable with ordinary inputs).
+    """
+    rng = np.random.default_rng(n + 1)
+    for arr in _adversarial_arrays(rng, n):
+        values = np.ascontiguousarray(arr, dtype=np.float64).copy()
+        expected = np.sort(values)
+        _heapsort_values(values)
+        assert_array_equal(values, expected)

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -333,7 +333,9 @@ def batch_centroid_win(const double[:, ::1] data, *,
     on the current centroid estimate. The iteration, the integer
     bounding-box arithmetic, the per-pixel masking, and the final
     windowed second-order moments and raw error sums replicate the
-    previous per-source Python implementation exactly.
+    previous per-source Python implementation to within floating-point
+    rounding (the pixel sums are accumulated sequentially rather than
+    pairwise).
 
     Parameters
     ----------
@@ -597,8 +599,10 @@ def batch_kron_radius(const double[:, ::1] data, *,
     inside the circle of radius ``min_circ_radius`` for a source whose
     elliptical axes are both zero. The bounding-box arithmetic, the
     per-pixel masking, and the neighbor handling replicate the
-    previous per-source Python implementation exactly. The caller
-    forms the Kron radius from the two sums.
+    previous per-source Python implementation, with the sums agreeing
+    to within floating-point rounding (they are accumulated
+    sequentially rather than pairwise). The caller forms the Kron
+    radius from the two sums.
 
     Parameters
     ----------
@@ -1002,7 +1006,9 @@ def batch_flux_radius_solve(args_list, *, double fraction):
     found by a bracketed Brent root-find over ``[0.1, max_radius]``.
     The per-pixel circular overlap, the bracket, and the root-finder
     tolerances replicate the previous per-source
-    `scipy.optimize.root_scalar` implementation exactly.
+    `scipy.optimize.root_scalar` implementation (the same SciPy C
+    routine is used), so the roots agree to within floating-point
+    rounding of the sequentially accumulated flux sums.
 
     A bracket whose endpoints have the same sign has no (or multiple)
     solutions. As in the previous implementation, the maximum radius

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -11,6 +11,11 @@ per-source Python calls. The per-pixel segmentation masking (mask or
 mirror-correct) uses the same helper as the aperture batch drivers, so
 the semantics match the previous cutout-based code paths.
 
+The fractional-flux radius solver additionally runs its bracketed
+root-find entirely in C, using the ``brentq`` implementation exported
+by ``scipy.optimize.cython_optimize``, so that no Python call is made
+per root-finder iteration.
+
 The source loops run without the GIL and use no global mutable state,
 so this module is safe to use from multiple threads, including on
 free-threaded Python builds.
@@ -18,9 +23,12 @@ free-threaded Python builds.
 
 import numpy as np
 
-from photutils.aperture._batch_overlap cimport _resolve_seg_pixel
+from scipy.optimize.cython_optimize cimport brentq, zeros_full_output
 
-__all__ = ['batch_centroid_win']
+from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
+                                                _resolve_seg_pixel)
+
+__all__ = ['batch_centroid_win', 'batch_flux_radius_solve']
 
 
 cdef extern from "math.h" nogil:
@@ -348,3 +356,149 @@ def batch_centroid_win(const double[:, ::1] data, *,
                                  sigma[i], seg_method, compute_err,
                                  max_aper_size, &results[i, 0])
     return results_arr
+
+
+ctypedef struct _FluxRadiusArgs:
+    const double *data
+    Py_ssize_t nx
+    Py_ssize_t ny
+    double xmin_e
+    double ymin_e
+    double dx
+    double dy
+    double pixel_radius
+    int use_exact
+    int subpixels
+    double normflux
+
+
+cdef double _flux_radius_objective(double r,
+                                   void *args) noexcept nogil:
+    """
+    Fraction-of-flux residual ``1 - flux(r) / normflux`` for the
+    brentq root-find, accumulating ``data * overlap`` with the same
+    per-pixel arithmetic as ``circular_overlap_grid`` (grid edges
+    relative to the source centroid).
+    """
+    cdef _FluxRadiusArgs *p = <_FluxRadiusArgs *>args
+    cdef Py_ssize_t ix, iy
+    cdef double flux = 0.0
+    cdef double pymin, pxmin, frac
+
+    for iy in range(p.ny):
+        pymin = p.ymin_e + iy * p.dy
+        for ix in range(p.nx):
+            pxmin = p.xmin_e + ix * p.dx
+            frac = _circle_pixel_frac(pxmin, pymin, p.dx, p.dy,
+                                      p.pixel_radius, r, p.use_exact,
+                                      p.subpixels)
+            if frac > 0.0:
+                flux += p.data[iy * p.nx + ix] * frac
+    return 1.0 - flux / p.normflux
+
+
+def batch_flux_radius_solve(args_list, *, double fraction):
+    """
+    Solve the fractional-flux radius for many prepared sources in one
+    call.
+
+    For each source, the circular radius enclosing ``fraction`` of the
+    Kron flux is the root of ``1 - flux(r) / (kronflux * fraction)``,
+    found by a bracketed Brent root-find over ``[0.1, max_radius]``.
+    The per-pixel circular overlap, the bracket, and the root-finder
+    tolerances replicate the previous per-source
+    `scipy.optimize.root_scalar` implementation exactly.
+
+    A bracket whose endpoints have the same sign has no (or multiple)
+    solutions. As in the previous implementation, the maximum radius
+    is then reduced by 10% of its original value and the root-find is
+    retried, until either a root is found or the maximum radius drops
+    to the minimum radius (0.1), in which case NaN is returned.
+
+    Parameters
+    ----------
+    args_list : list
+        The prepared per-source arguments, as built by
+        ``SourceCatalog._flux_radius_optimizer_args``. Each entry is
+        either `None`, for a source that cannot have a solution (NaN
+        is returned), or the list ``[clean_data, grid_params,
+        kronflux, max_radius]``. ``clean_data`` is the C-contiguous
+        float64 source cutout with masked pixels zeroed,
+        ``grid_params`` is the tuple ``(xmin_e, xmax_e, ymin_e,
+        ymax_e, nx, ny, use_exact, subpixels)`` of
+        `~photutils.geometry.circular_overlap_grid` parameters whose
+        grid edges are relative to the source centroid, ``kronflux``
+        is the source Kron flux, and ``max_radius`` is the initial
+        upper bracket radius.
+
+    fraction : float
+        The fraction of the Kron flux at which to find the circular
+        radius.
+
+    Returns
+    -------
+    radius : 1D `~numpy.ndarray`
+        The circular radius enclosing the specified fraction of the
+        Kron flux for each source, with shape ``(n_sources,)``. NaN is
+        returned for `None` entries and where no solution was found.
+    """
+    cdef Py_ssize_t n_src = len(args_list)
+    radius_arr = np.full(n_src, np.nan)
+    cdef double[::1] radius = radius_arr
+    cdef const double[:, ::1] cdata
+    cdef _FluxRadiusArgs p
+    cdef zeros_full_output full_output
+    cdef double xmax_e, ymax_e
+    cdef double max_radius, delta, result
+    cdef bint found
+    cdef Py_ssize_t i
+
+    for i, entry in enumerate(args_list):
+        if entry is None:
+            continue
+        clean_data, grid_params, kronflux, max_radius_py = entry
+        cdata = clean_data
+        p.data = &cdata[0, 0]
+        p.xmin_e = grid_params[0]
+        xmax_e = grid_params[1]
+        p.ymin_e = grid_params[2]
+        ymax_e = grid_params[3]
+        p.nx = grid_params[4]
+        p.ny = grid_params[5]
+        # The pixel size and pixel radius are derived from the grid
+        # extent exactly as in ``circular_overlap_grid``
+        p.dx = (xmax_e - p.xmin_e) / p.nx
+        p.dy = (ymax_e - p.ymin_e) / p.ny
+        p.pixel_radius = 0.5 * sqrt(p.dx * p.dx + p.dy * p.dy)
+        p.use_exact = grid_params[6]
+        p.subpixels = grid_params[7]
+        p.normflux = kronflux * fraction
+        max_radius = max_radius_py
+
+        with nogil:
+            found = False
+            result = NAN
+            delta = 0.1 * max_radius
+            while max_radius > 0.1 and not found:
+                # xtol, rtol (4 * float64 eps), and maxiter are the
+                # root_scalar(method='brentq') defaults, so the same
+                # underlying C algorithm follows the identical
+                # iteration sequence
+                result = brentq(_flux_radius_objective, 0.1,
+                                max_radius, &p, 2e-12,
+                                8.881784197001252e-16, 100,
+                                &full_output)
+                if full_output.error_num == -1:
+                    # Sign error (same-sign bracket): shrink and
+                    # retry, matching the ValueError path of
+                    # root_scalar
+                    max_radius -= delta
+                else:
+                    # Success or non-convergence: root_scalar does
+                    # not raise on non-convergence, so accept the
+                    # root either way
+                    found = True
+            if not found:
+                result = NAN
+        radius[i] = result
+    return radius_arr

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -11,6 +11,11 @@ per-source Python calls. The per-pixel segmentation masking (mask or
 mirror-correct) uses the same helper as the aperture batch drivers, so
 the semantics match the previous cutout-based code paths.
 
+The moment kernels accumulate the raw and central spatial moments (and
+the raw centroid error sums) over each source's segment bounding box,
+using cutout-frame coordinates, so that the moment-based properties
+never need per-source cutout arrays.
+
 The fractional-flux radius solver additionally runs its bracketed
 root-find entirely in C, using the ``brentq`` implementation exported
 by ``scipy.optimize.cython_optimize``, so that no Python call is made
@@ -28,7 +33,9 @@ from scipy.optimize.cython_optimize cimport brentq, zeros_full_output
 from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
                                                 _resolve_seg_pixel)
 
-__all__ = ['batch_centroid_win', 'batch_flux_radius_solve']
+__all__ = ['batch_central_moments', 'batch_centroid_win',
+           'batch_flux_radius_solve', 'batch_moment_err',
+           'batch_raw_moments']
 
 
 cdef extern from "math.h" nogil:
@@ -502,3 +509,312 @@ def batch_flux_radius_solve(args_list, *, double fraction):
                 result = NAN
         radius[i] = result
     return radius_arr
+
+
+def batch_raw_moments(const double[:, ::1] convdata, *,
+                      const unsigned char[:, ::1] mask,
+                      const Py_ssize_t[:, ::1] segm,
+                      const Py_ssize_t[::1] labels,
+                      const Py_ssize_t[::1] bbox_iymin,
+                      const Py_ssize_t[::1] bbox_iymax,
+                      const Py_ssize_t[::1] bbox_ixmin,
+                      const Py_ssize_t[::1] bbox_ixmax):
+    """
+    Compute the raw spatial moments for many sources in one call.
+
+    The moments are computed up to 3rd order along each axis over the
+    segment bounding box of each source, using coordinates relative
+    to the bounding-box origin (i.e., the cutout frame). Pixels
+    outside the source segment, input-masked pixels, non-finite
+    values, and negative values contribute zero, which replicates the
+    zeroed moment cutouts of the previous per-source implementation.
+
+    Parameters
+    ----------
+    convdata : 2D ndarray of float64 (C-contiguous)
+        The convolved data array (or the data array itself if no
+        convolved data was input).
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where bit 1 (value 1) marks input-masked pixels
+        and bit 2 (value 2) marks non-finite data pixels folded into
+        the mask by the caller. Only bit 1 excludes a pixel here;
+        non-finite convolved values are excluded by their own test.
+        Must have the same shape as ``convdata``.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same
+        shape as ``convdata``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape
+        ``(n_sources,)``.
+
+    bbox_iymin, bbox_iymax, bbox_ixmin, bbox_ixmax : 1D ndarray of intp
+        The segment bounding box of each source, with shape
+        ``(n_sources,)``. The maxima are exclusive (slice ``stop``
+        values).
+
+    Returns
+    -------
+    result : 3D `~numpy.ndarray`
+        The raw moments with shape ``(n_sources, 4, 4)``. The element
+        ``[i, p, q]`` is the sum of ``v * cy**p * cx**q`` over the
+        included pixels of source ``i``, where ``v`` is the convolved
+        data value and ``(cx, cy)`` are the cutout-frame pixel
+        coordinates.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    result_arr = np.zeros((n_src, 4, 4))
+    cdef double[:, :, ::1] result = result_arr
+    cdef Py_ssize_t i, ix, iy, p, q, y0, y1, x0, x1, lbl
+    cdef double v, cx, cy
+    cdef double xpow[4]
+    cdef double ypow[4]
+
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            for iy in range(y0, y1):
+                cy = <double>(iy - y0)
+                ypow[0] = 1.0
+                ypow[1] = cy
+                ypow[2] = cy * cy
+                ypow[3] = cy * cy * cy
+                for ix in range(x0, x1):
+                    if segm[iy, ix] != lbl:
+                        continue
+                    if mask[iy, ix] & 1:
+                        continue
+                    v = convdata[iy, ix]
+                    if not isfinite(v) or v < 0.0:
+                        continue
+                    cx = <double>(ix - x0)
+                    xpow[0] = 1.0
+                    xpow[1] = cx
+                    xpow[2] = cx * cx
+                    xpow[3] = cx * cx * cx
+                    for p in range(4):
+                        for q in range(4):
+                            result[i, p, q] += (v * ypow[p]
+                                                * xpow[q])
+    return result_arr
+
+
+def batch_central_moments(const double[:, ::1] convdata, *,
+                          const unsigned char[:, ::1] mask,
+                          const Py_ssize_t[:, ::1] segm,
+                          const Py_ssize_t[::1] labels,
+                          const Py_ssize_t[::1] bbox_iymin,
+                          const Py_ssize_t[::1] bbox_iymax,
+                          const Py_ssize_t[::1] bbox_ixmin,
+                          const Py_ssize_t[::1] bbox_ixmax,
+                          const double[::1] xcen,
+                          const double[::1] ycen):
+    """
+    Compute the central spatial moments for many sources in one call.
+
+    These are the translation-invariant moments up to 3rd order along
+    each axis, i.e., the raw moments of `batch_raw_moments` computed
+    with coordinates measured from the given cutout-frame centroid.
+    The pixel-inclusion rules are identical to those of
+    `batch_raw_moments`.
+
+    Parameters
+    ----------
+    convdata : 2D ndarray of float64 (C-contiguous)
+        The convolved data array (or the data array itself if no
+        convolved data was input).
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where bit 1 (value 1) marks input-masked pixels
+        and bit 2 (value 2) marks non-finite data pixels folded into
+        the mask by the caller. Only bit 1 excludes a pixel here;
+        non-finite convolved values are excluded by their own test.
+        Must have the same shape as ``convdata``.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same
+        shape as ``convdata``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape
+        ``(n_sources,)``.
+
+    bbox_iymin, bbox_iymax, bbox_ixmin, bbox_ixmax : 1D ndarray of intp
+        The segment bounding box of each source, with shape
+        ``(n_sources,)``. The maxima are exclusive (slice ``stop``
+        values).
+
+    xcen, ycen : 1D ndarray of float64 (C-contiguous)
+        The cutout-frame centroid of each source, with shape
+        ``(n_sources,)``.
+
+    Returns
+    -------
+    result : 3D `~numpy.ndarray`
+        The central moments with shape ``(n_sources, 4, 4)``. The
+        element ``[i, p, q]`` is the sum of ``v * dy**p * dx**q``
+        over the included pixels of source ``i``, where ``v`` is the
+        convolved data value and ``(dx, dy)`` are the cutout-frame
+        pixel coordinates relative to the source centroid. If a
+        source centroid is not finite, every element except
+        ``[i, 0, 0]``, which is the plain sum of the included values,
+        is NaN.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    result_arr = np.zeros((n_src, 4, 4))
+    cdef double[:, :, ::1] result = result_arr
+    cdef Py_ssize_t i, ix, iy, p, q, y0, y1, x0, x1, lbl
+    cdef double v, cx, cy
+    cdef double xpow[4]
+    cdef double ypow[4]
+
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            for iy in range(y0, y1):
+                cy = <double>(iy - y0) - ycen[i]
+                ypow[0] = 1.0
+                ypow[1] = cy
+                ypow[2] = cy * cy
+                ypow[3] = cy * cy * cy
+                for ix in range(x0, x1):
+                    if segm[iy, ix] != lbl:
+                        continue
+                    if mask[iy, ix] & 1:
+                        continue
+                    v = convdata[iy, ix]
+                    if not isfinite(v) or v < 0.0:
+                        continue
+                    cx = <double>(ix - x0) - xcen[i]
+                    xpow[0] = 1.0
+                    xpow[1] = cx
+                    xpow[2] = cx * cx
+                    xpow[3] = cx * cx * cx
+                    for p in range(4):
+                        for q in range(4):
+                            result[i, p, q] += (v * ypow[p]
+                                                * xpow[q])
+
+            if not (isfinite(xcen[i]) and isfinite(ycen[i])):
+                # A non-finite centroid poisons every coordinate
+                # power, so all elements except [0, 0] (the plain
+                # flux sum) are NaN, as in the previous NumPy
+                # implementation. The sums above are NaN only where
+                # a source has at least one included pixel, so set
+                # them explicitly.
+                for p in range(4):
+                    for q in range(4):
+                        if p != 0 or q != 0:
+                            result[i, p, q] = NAN
+    return result_arr
+
+
+def batch_moment_err(const double[:, ::1] error, *,
+                     const double[:, ::1] convdata,
+                     const unsigned char[:, ::1] mask,
+                     const Py_ssize_t[:, ::1] segm,
+                     const Py_ssize_t[::1] labels,
+                     const Py_ssize_t[::1] bbox_iymin,
+                     const Py_ssize_t[::1] bbox_iymax,
+                     const Py_ssize_t[::1] bbox_ixmin,
+                     const Py_ssize_t[::1] bbox_ixmax,
+                     const double[::1] xcen,
+                     const double[::1] ycen):
+    """
+    Compute the raw centroid error sums for many sources in one call.
+
+    These are the unnormalized sums that the isophotal centroid error
+    covariance is built from. A pixel contributes its error variance
+    only if it is inside the source segment, is unmasked (neither
+    input-masked nor non-finite data), and contributes nonzero flux
+    weight to the moments (a finite, strictly positive convolved
+    value). This replicates the zeroing of the previous per-source
+    implementation, which set the error variance to zero wherever the
+    total mask was set or the moment data were zero.
+
+    Parameters
+    ----------
+    error : 2D ndarray of float64 (C-contiguous)
+        The pixel-wise 1-sigma errors. Must have the same shape as
+        ``convdata``.
+
+    convdata : 2D ndarray of float64 (C-contiguous)
+        The convolved data array (or the data array itself if no
+        convolved data was input).
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where bit 1 (value 1) marks input-masked pixels
+        and bit 2 (value 2) marks non-finite data pixels folded into
+        the mask by the caller. Any nonzero value excludes the pixel.
+        Must have the same shape as ``convdata``.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same
+        shape as ``convdata``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape
+        ``(n_sources,)``.
+
+    bbox_iymin, bbox_iymax, bbox_ixmin, bbox_ixmax : 1D ndarray of intp
+        The segment bounding box of each source, with shape
+        ``(n_sources,)``. The maxima are exclusive (slice ``stop``
+        values).
+
+    xcen, ycen : 1D ndarray of float64 (C-contiguous)
+        The cutout-frame centroid of each source, with shape
+        ``(n_sources,)``.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The raw error sums with shape ``(n_sources, 4)`` and columns
+        ``(sum_e2, sum_e2_dx2, sum_e2_dy2, sum_e2_dxdy)``, where
+        ``e2`` is the pixel error variance and ``(dx, dy)`` are the
+        cutout-frame pixel coordinates relative to the source
+        centroid.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    result_arr = np.zeros((n_src, 4))
+    cdef double[:, ::1] result = result_arr
+    cdef Py_ssize_t i, ix, iy, y0, y1, x0, x1, lbl
+    cdef double v, e, e2, dx, dy
+
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            for iy in range(y0, y1):
+                dy = <double>(iy - y0) - ycen[i]
+                for ix in range(x0, x1):
+                    if segm[iy, ix] != lbl:
+                        continue
+                    if mask[iy, ix] != 0:
+                        continue
+                    v = convdata[iy, ix]
+                    if not isfinite(v) or v <= 0.0:
+                        continue
+                    dx = <double>(ix - x0) - xcen[i]
+                    e = error[iy, ix]
+                    e2 = e * e
+                    result[i, 0] += e2
+                    result[i, 1] += e2 * dx * dx
+                    result[i, 2] += e2 * dy * dy
+                    result[i, 3] += e2 * dx * dy
+    return result_arr

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -34,13 +34,17 @@ from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
                                                 _resolve_seg_pixel)
 
 __all__ = ['batch_central_moments', 'batch_centroid_win',
-           'batch_flux_radius_solve', 'batch_moment_err',
-           'batch_raw_moments']
+           'batch_flux_radius_solve', 'batch_kron_radius',
+           'batch_moment_err', 'batch_raw_moments']
 
 
 cdef extern from "math.h" nogil:
     double exp(double x)
     double sqrt(double x)
+    double sin(double x)
+    double cos(double x)
+    double floor(double x)
+    double fmax(double x, double y)
     bint isfinite(double x)
     double NAN
 
@@ -448,6 +452,268 @@ def batch_centroid_win(const double[:, ::1] data, *,
                                  labels[i], xcen0[i], ycen0[i],
                                  sigma[i], seg_method, compute_err,
                                  max_aper_size, &results[i, 0])
+    return results_arr
+
+
+cdef void _kron_radius_source(const double *data,
+                              const unsigned char *mask,
+                              const Py_ssize_t *segm,
+                              Py_ssize_t nx_data, Py_ssize_t ny_data,
+                              Py_ssize_t label, double xc, double yc,
+                              double a, double b, double theta,
+                              double cxx, double cxy, double cyy,
+                              int seg_method, double scale,
+                              double min_circ_radius,
+                              Py_ssize_t max_aper_size,
+                              double *out) noexcept nogil:
+    """
+    Accumulate the Kron radius numerator and denominator for a single
+    source.
+
+    Replicates the previous per-source Python implementation: the
+    sums of ``data * r`` and ``data`` over the pixels whose centers
+    fall inside the ellipse of elliptical radius ``scale`` (or the
+    circle of radius ``min_circ_radius`` when both axes are zero),
+    excluding masked pixels and handling neighbor-source pixels per
+    ``seg_method``. Writes ``(numerator, denominator)`` into ``out``,
+    or NaN for an undefined measurement (no minimum circular radius
+    for a degenerate ellipse, an unreasonably large bounding box, or
+    no overlap with the data).
+    """
+    out[0] = NAN
+    out[1] = NAN
+
+    cdef bint use_circular = (a == 0 and b == 0)
+    cdef double half_w, half_h, cos_theta, sin_theta
+    if use_circular:
+        if min_circ_radius <= 0:
+            return
+        half_w = min_circ_radius
+        half_h = min_circ_radius
+    else:
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+        half_w = sqrt(a * a * cos_theta * cos_theta
+                      + b * b * sin_theta * sin_theta)
+        half_h = sqrt(a * a * sin_theta * sin_theta
+                      + b * b * cos_theta * cos_theta)
+
+    # The bounding box is kept as integral doubles until it is
+    # clipped, to avoid integer overflow for apertures far outside
+    # the image
+    cdef double ixmin_d = floor(xc - half_w + 0.5)
+    cdef double ixmax_d = floor(xc + half_w + 0.5) + 1.0
+    cdef double iymin_d = floor(yc - half_h + 0.5)
+    cdef double iymax_d = floor(yc + half_h + 0.5) + 1.0
+    if (ixmax_d - ixmin_d) * (iymax_d - iymin_d) > max_aper_size:
+        return
+
+    # Clip to the data
+    cdef double x0_d = ixmin_d if ixmin_d > 0.0 else 0.0
+    cdef double x1_d = ixmax_d if ixmax_d < nx_data else nx_data
+    cdef double y0_d = iymin_d if iymin_d > 0.0 else 0.0
+    cdef double y1_d = iymax_d if iymax_d < ny_data else ny_data
+    if x0_d >= x1_d or y0_d >= y1_d:
+        return
+    cdef Py_ssize_t x0 = <Py_ssize_t>x0_d
+    cdef Py_ssize_t x1 = <Py_ssize_t>x1_d
+    cdef Py_ssize_t y0 = <Py_ssize_t>y0_d
+    cdef Py_ssize_t y1 = <Py_ssize_t>y1_d
+
+    # The cutout-frame center offsets and the mirror center of the
+    # 'correct' method (truncation of the cutout center + 0.5
+    # replicates the Python int() call)
+    cdef double xoff = xc - <double>x0
+    cdef double yoff = yc - <double>y0
+    cdef Py_ssize_t ccx = <Py_ssize_t>(xoff + 0.5) + x0
+    cdef Py_ssize_t ccy = <Py_ssize_t>(yoff + 0.5) + y0
+    cdef double r_circ2 = min_circ_radius * min_circ_radius
+
+    cdef double numerator = 0.0
+    cdef double denominator = 0.0
+    cdef Py_ssize_t ix, iy, six, siy
+    # Write-only sinks required by the ``_resolve_seg_pixel``
+    # signature
+    cdef Py_ssize_t n_seg = 0, n_unc = 0
+    cdef double xx, yy, rr_sq, rr, v
+    for iy in range(y0, y1):
+        yy = <double>(iy - y0) - yoff
+        for ix in range(x0, x1):
+            xx = <double>(ix - x0) - xoff
+            rr_sq = cxx * xx * xx + cxy * xx * yy + cyy * yy * yy
+            rr = sqrt(fmax(rr_sq, 0.0))
+            if use_circular:
+                if xx * xx + yy * yy > r_circ2:
+                    continue
+            elif rr > scale:
+                continue
+            if mask[iy * nx_data + ix] != 0:
+                continue
+            six = ix
+            siy = iy
+            if (seg_method != 0
+                    and not _resolve_seg_pixel(
+                        segm, mask, nx_data, seg_method, label,
+                        ix, iy, x0, x1, y0, y1, ccx, ccy,
+                        &six, &siy, &n_seg, &n_unc)):
+                continue
+            v = data[siy * nx_data + six]
+            numerator += v * rr
+            denominator += v
+
+    out[0] = numerator
+    out[1] = denominator
+
+
+def batch_kron_radius(const double[:, ::1] data, *,
+                      const unsigned char[:, ::1] mask,
+                      const Py_ssize_t[:, ::1] segm,
+                      const Py_ssize_t[::1] labels,
+                      const double[::1] xcen,
+                      const double[::1] ycen,
+                      const double[::1] semimajor,
+                      const double[::1] semiminor,
+                      const double[::1] theta,
+                      const double[::1] cxx,
+                      const double[::1] cxy,
+                      const double[::1] cyy,
+                      const unsigned char[::1] skip,
+                      int seg_method, double scale,
+                      double min_circ_radius,
+                      Py_ssize_t max_aper_size):
+    """
+    Compute the Kron radius numerator and denominator for many sources
+    in one call.
+
+    For each source, the sums of ``data * r`` and ``data`` are
+    accumulated over the pixels whose centers fall inside the ellipse
+    of elliptical radius ``scale`` (in units of the isophotal
+    ellipse), where ``r`` is the elliptical radius of each pixel, or
+    inside the circle of radius ``min_circ_radius`` for a source whose
+    elliptical axes are both zero. The bounding-box arithmetic, the
+    per-pixel masking, and the neighbor handling replicate the
+    previous per-source Python implementation exactly. The caller
+    forms the Kron radius from the two sums.
+
+    Parameters
+    ----------
+    data : 2D ndarray of float64 (C-contiguous)
+        The data array.
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where nonzero values indicate masked (excluded)
+        pixels. Must have the same shape as ``data``. Bit 1 (value 1)
+        marks input-masked pixels and bit 2 (value 2) marks non-finite
+        data pixels folded into the mask by the caller. Any nonzero
+        value excludes the pixel and prevents it from being used as a
+        mirror pixel.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``data``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape ``(n_sources,)``.
+
+    xcen, ycen : 1D ndarray of float64 (C-contiguous)
+        The source centroids, with shape ``(n_sources,)``.
+
+    semimajor, semiminor : 1D ndarray of float64 (C-contiguous)
+        The isophotal semimajor and semiminor axes (1-sigma), with
+        shape ``(n_sources,)``. They are multiplied by ``scale`` to
+        form the measurement ellipse.
+
+    theta : 1D ndarray of float64 (C-contiguous)
+        The ellipse orientation in radians, with shape
+        ``(n_sources,)``.
+
+    cxx, cxy, cyy : 1D ndarray of float64 (C-contiguous)
+        The isophotal ellipse coefficients, with shape
+        ``(n_sources,)``.
+
+    skip : 1D ndarray of uint8 (C-contiguous)
+        Nonzero for sources that cannot have a measured Kron radius
+        (e.g., a completely masked source or a non-finite centroid or
+        shape), with shape ``(n_sources,)``.
+
+    seg_method : int
+        The segmentation masking method:
+
+        * 0: disables masking
+        * 1: excludes neighbor-source pixels
+             (``(seg > 0) & (seg != label)``)
+        * 3: replaces neighbor-source pixels with the values mirrored
+             across the (rounded) aperture center (the symmetric
+             ``'correct'`` method). A neighbor pixel whose mirror falls
+             outside the clipped bounding box, is itself a neighbor,
+             or is masked contributes zero instead.
+
+    scale : float
+        The elliptical radius of the measurement ellipse, in units of
+        the isophotal ellipse.
+
+    min_circ_radius : float
+        The radius of the measurement circle for sources whose
+        elliptical axes are both zero. Such sources are undefined if
+        it is not positive.
+
+    max_aper_size : Py_ssize_t
+        The maximum number of pixels in the (unclipped) bounding box.
+        Sources with a larger bounding box are undefined
+        (out-of-memory guard).
+
+    Returns
+    -------
+    result : 2D ndarray of float64
+        The per-source sums with shape ``(n_sources, 2)`` and columns
+        ``(numerator, denominator)``. Skipped and undefined sources
+        (including those rejected by ``max_aper_size`` and those whose
+        bounding box does not overlap the data) get the row
+        ``(nan, nan)``.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if a 2D array does not have the same shape as
+        ``data``.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = data.shape[0]
+    cdef Py_ssize_t nx_data = data.shape[1]
+
+    _check_length(xcen.shape[0], n_src, 'xcen')
+    _check_length(ycen.shape[0], n_src, 'ycen')
+    _check_length(semimajor.shape[0], n_src, 'semimajor')
+    _check_length(semiminor.shape[0], n_src, 'semiminor')
+    _check_length(theta.shape[0], n_src, 'theta')
+    _check_length(cxx.shape[0], n_src, 'cxx')
+    _check_length(cxy.shape[0], n_src, 'cxy')
+    _check_length(cyy.shape[0], n_src, 'cyy')
+    _check_length(skip.shape[0], n_src, 'skip')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'data')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'data')
+
+    results_arr = np.empty((n_src, 2))
+    cdef double[:, ::1] results = results_arr
+
+    cdef Py_ssize_t i
+    with nogil:
+        for i in range(n_src):
+            if skip[i]:
+                results[i, 0] = NAN
+                results[i, 1] = NAN
+                continue
+            _kron_radius_source(&data[0, 0], &mask[0, 0], &segm[0, 0],
+                                nx_data, ny_data, labels[i], xcen[i],
+                                ycen[i], semimajor[i] * scale,
+                                semiminor[i] * scale, theta[i], cxx[i],
+                                cxy[i], cyy[i], seg_method, scale,
+                                min_circ_radius, max_aper_size,
+                                &results[i, 0])
     return results_arr
 
 

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -1,0 +1,350 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: freethreading_compatible=True
+"""
+Batch Cython drivers for `~photutils.segmentation.SourceCatalog`
+per-source computations.
+
+Each driver accumulates per-pixel contributions directly into
+per-source outputs without generating per-source cutouts or making
+per-source Python calls. The per-pixel segmentation masking (mask or
+mirror-correct) uses the same helper as the aperture batch drivers, so
+the semantics match the previous cutout-based code paths.
+
+The source loops run without the GIL and use no global mutable state,
+so this module is safe to use from multiple threads, including on
+free-threaded Python builds.
+"""
+
+import numpy as np
+
+from photutils.aperture._batch_overlap cimport _resolve_seg_pixel
+
+__all__ = ['batch_centroid_win']
+
+
+cdef extern from "math.h" nogil:
+    double exp(double x)
+    double sqrt(double x)
+    bint isfinite(double x)
+    double NAN
+
+
+cdef void _centroid_win_source(const double *data, const double *error,
+                               const unsigned char *mask,
+                               const Py_ssize_t *segm,
+                               Py_ssize_t nx_data, Py_ssize_t ny_data,
+                               Py_ssize_t label, double xcen0,
+                               double ycen0, double sigma,
+                               int seg_method, bint compute_err,
+                               Py_ssize_t max_aper_size,
+                               double *out) noexcept nogil:
+    """
+    Compute the raw windowed-centroid quantities for a single source.
+
+    Replicates ``SourceCatalog._iterate_centroid_win``: an iterative
+    Gaussian-weighted centroid within a binary circular window of
+    radius ``4 * sigma``, with masked pixels contributing zero
+    and neighbor-source pixels excluded or mirror-corrected per
+    ``seg_method``. Writes the 10 output columns ``(xcen, ycen,
+    weighted_flux, cen_mom_xx, cen_mom_yy, cen_mom_xy, err_sum,
+    err_var_x, err_var_y, err_cov_xy)`` into ``out``.
+    """
+    cdef double inv_2sigma2 = -1.0 / (2.0 * sigma * sigma)
+    cdef double radius = 4.0 * sigma
+    cdef double radius_sq = radius * radius
+    # Truncation of (radius + 1.5) replicates the Python int() call
+    cdef Py_ssize_t bbox_halfsize = <Py_ssize_t>(radius + 1.5)
+    cdef Py_ssize_t full_n = 2 * bbox_halfsize + 1
+
+    out[0] = NAN
+    out[1] = NAN
+    out[2] = 0.0
+    out[3] = 0.0
+    out[4] = 0.0
+    out[5] = 0.0
+    out[6] = NAN
+    out[7] = NAN
+    out[8] = NAN
+    out[9] = NAN
+    if full_n * full_n > max_aper_size:
+        return
+
+    cdef double xcen = xcen0
+    cdef double ycen = ycen0
+    cdef double dcen = 1.0
+    cdef double weighted_flux = 0.0
+    cdef double dx_mom = 0.0
+    cdef double dy_mom = 0.0
+    cdef Py_ssize_t iter_ = 0
+    cdef Py_ssize_t ixmin, ixmax, iymin, iymax, x0, x1, y0, y1
+    cdef Py_ssize_t ccx, ccy, ix, iy, six, siy
+    cdef Py_ssize_t n_seg = 0, n_unc = 0
+    cdef double dx, dy, rr2, w, v, e, wv, wsq
+    cdef double sumw, sumwx, sumwy
+    # State of the last completed accumulation, for the final
+    # moment/error pass (the window may go empty on a later iteration,
+    # in which case the previous iteration's window is what the Python
+    # implementation reused)
+    cdef bint have_window = False
+    cdef double xc_last = 0.0, yc_last = 0.0
+    cdef double dxm_last = 0.0, dym_last = 0.0
+    cdef Py_ssize_t lx0 = 0, lx1 = 0, ly0 = 0, ly1 = 0
+    cdef Py_ssize_t lccx = 0, lccy = 0
+    cdef double sxx, syy, sxy, esum, evx, evy, ecxy
+
+    while iter_ < 16 and dcen > 0.0001:
+        # Truncation of (xcen + 0.5) replicates the Python int() call
+        # (including truncation toward zero for negative centers)
+        ixmin = <Py_ssize_t>(xcen + 0.5) - bbox_halfsize
+        ixmax = ixmin + full_n
+        iymin = <Py_ssize_t>(ycen + 0.5) - bbox_halfsize
+        iymax = iymin + full_n
+        x0 = ixmin if ixmin > 0 else 0
+        x1 = ixmax if ixmax < nx_data else nx_data
+        y0 = iymin if iymin > 0 else 0
+        y1 = iymax if iymax < ny_data else ny_data
+        if y0 >= y1 or x0 >= x1:
+            xcen = NAN
+            ycen = NAN
+            break
+        ccx = <Py_ssize_t>(xcen + 0.5)
+        ccy = <Py_ssize_t>(ycen + 0.5)
+
+        sumw = 0.0
+        sumwx = 0.0
+        sumwy = 0.0
+        for iy in range(y0, y1):
+            for ix in range(x0, x1):
+                dx = ix - xcen
+                dy = iy - ycen
+                rr2 = dx * dx + dy * dy
+                if rr2 > radius_sq:
+                    continue
+                if mask[iy * nx_data + ix] != 0:
+                    continue
+                six = ix
+                siy = iy
+                if (seg_method != 0
+                        and not _resolve_seg_pixel(
+                            segm, mask, nx_data, seg_method, label,
+                            ix, iy, x0, x1, y0, y1, ccx, ccy,
+                            &six, &siy, &n_seg, &n_unc)):
+                    continue
+                v = data[siy * nx_data + six]
+                w = exp(rr2 * inv_2sigma2)
+                wv = v * w
+                sumw += wv
+                sumwx += wv * dx
+                sumwy += wv * dy
+
+        weighted_flux = sumw
+        # 0/0 yields NaN (cdivision), matching the suppressed NumPy
+        # RuntimeWarning path; a NaN dcen ends the loop
+        dx_mom = sumwx / sumw
+        dy_mom = sumwy / sumw
+        dcen = sqrt(dx_mom * dx_mom + dy_mom * dy_mom)
+
+        have_window = True
+        xc_last = xcen
+        yc_last = ycen
+        dxm_last = dx_mom
+        dym_last = dy_mom
+        lx0 = x0
+        lx1 = x1
+        ly0 = y0
+        ly1 = y1
+        lccx = ccx
+        lccy = ccy
+
+        xcen += dx_mom * 2.0
+        ycen += dy_mom * 2.0
+        iter_ += 1
+
+    out[0] = xcen
+    out[1] = ycen
+    out[2] = weighted_flux
+    if not (isfinite(weighted_flux) and weighted_flux > 0
+            and have_window):
+        return
+
+    # Final pass over the last completed window using the pre-update
+    # center: windowed central 2nd-order moments and raw error sums.
+    sxx = 0.0
+    syy = 0.0
+    sxy = 0.0
+    esum = 0.0
+    evx = 0.0
+    evy = 0.0
+    ecxy = 0.0
+    for iy in range(ly0, ly1):
+        for ix in range(lx0, lx1):
+            dx = ix - xc_last
+            dy = iy - yc_last
+            rr2 = dx * dx + dy * dy
+            if rr2 > radius_sq:
+                continue
+            if mask[iy * nx_data + ix] != 0:
+                continue
+            six = ix
+            siy = iy
+            if (seg_method != 0
+                    and not _resolve_seg_pixel(
+                        segm, mask, nx_data, seg_method, label,
+                        ix, iy, lx0, lx1, ly0, ly1, lccx, lccy,
+                        &six, &siy, &n_seg, &n_unc)):
+                continue
+            v = data[siy * nx_data + six]
+            w = exp(rr2 * inv_2sigma2)
+            wv = v * w
+            sxx += wv * dx * dx
+            syy += wv * dy * dy
+            sxy += wv * dx * dy
+            if compute_err:
+                e = error[siy * nx_data + six]
+                wsq = w * w
+                esum += wsq * e * e
+                evx += wsq * e * e * dx * dx
+                evy += wsq * e * e * dy * dy
+                ecxy += wsq * e * e * dx * dy
+
+    out[3] = sxx / weighted_flux - dxm_last * dxm_last
+    out[4] = syy / weighted_flux - dym_last * dym_last
+    out[5] = sxy / weighted_flux - dxm_last * dym_last
+    if compute_err:
+        out[6] = esum
+        out[7] = evx
+        out[8] = evy
+        out[9] = ecxy
+
+
+def batch_centroid_win(const double[:, ::1] data, *,
+                       const double[:, ::1] error,
+                       const unsigned char[:, ::1] mask,
+                       const Py_ssize_t[:, ::1] segm,
+                       const Py_ssize_t[::1] labels,
+                       const double[::1] xcen0,
+                       const double[::1] ycen0,
+                       const double[::1] sigma,
+                       const unsigned char[::1] skip,
+                       int seg_method, int compute_err,
+                       Py_ssize_t max_aper_size):
+    """
+    Compute windowed-centroid quantities for many sources in one call.
+
+    For each source, an iterative Gaussian-weighted centroid is computed
+    within a binary circular window of radius ``4 * sigma`` centered
+    on the current centroid estimate. The iteration, the integer
+    bounding-box arithmetic, the per-pixel masking, and the final
+    windowed second-order moments and raw error sums replicate the
+    previous per-source Python implementation exactly.
+
+    Parameters
+    ----------
+    data : 2D ndarray of float64 (C-contiguous)
+        The data array.
+
+    error : 2D ndarray of float64 (C-contiguous) or `None`
+        The pixel-wise 1-sigma errors. Must have the same shape as
+        ``data``. Required (not `None`) if ``compute_err`` is nonzero.
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where nonzero values indicate masked (excluded)
+        pixels. Must have the same shape as ``data``. Bit 1 (value 1)
+        marks input-masked pixels and bit 2 (value 2) marks non-finite
+        data pixels folded into the mask by the caller. Any nonzero
+        value excludes the pixel and prevents it from being used as a
+        mirror pixel.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``data``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape ``(n_sources,)``.
+
+    xcen0, ycen0 : 1D ndarray of float64 (C-contiguous)
+        The initial (isophotal) centroids for each source, with shape
+        ``(n_sources,)``.
+
+    sigma : 1D ndarray of float64 (C-contiguous)
+        The Gaussian weighting sigma for each source, with shape
+        ``(n_sources,)``.
+
+    skip : 1D ndarray of uint8 (C-contiguous)
+        Nonzero for sources that cannot have a meaningful windowed
+        centroid (e.g., a non-finite half-light radius or a non-finite
+        initial centroid), with shape ``(n_sources,)``.
+
+    seg_method : int
+        The segmentation masking method:
+
+        * 0: disables masking
+        * 1: excludes neighbor-source pixels
+             (``(seg > 0) & (seg != label)``)
+        * 3: replaces neighbor-source pixels with the values mirrored
+             across the (rounded) window center (the symmetric
+             ``'correct'`` method). A neighbor pixel whose mirror falls
+             outside the clipped window, is itself a neighbor, or is
+             masked is excluded instead of replaced.
+
+    compute_err : int
+        If nonzero, also accumulate the raw (unnormalized) weighted
+        error sums.
+
+    max_aper_size : Py_ssize_t
+        The maximum number of pixels in the (unclipped) window. Sources
+        with a larger window are skipped (out-of-memory guard).
+
+    Returns
+    -------
+    result : 2D ndarray of float64
+        The raw per-source results with shape ``(n_sources, 10)`` and
+        columns ``(xcen, ycen, weighted_flux, cen_mom_xx, cen_mom_yy,
+        cen_mom_xy, err_sum, err_var_x, err_var_y, err_cov_xy)``. The
+        error columns are NaN unless ``compute_err`` is nonzero.
+        Skipped sources (including those rejected by ``max_aper_size``)
+        get the row ``(nan, nan, 0, 0, 0, 0, nan, nan, nan, nan)``.
+
+    Raises
+    ------
+    ValueError
+        If ``compute_err`` is nonzero and ``error`` is `None`.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = data.shape[0]
+    cdef Py_ssize_t nx_data = data.shape[1]
+    cdef bint has_error = error is not None
+
+    if compute_err and not has_error:
+        msg = 'error must be provided when compute_err is set'
+        raise ValueError(msg)
+
+    results_arr = np.empty((n_src, 10))
+    cdef double[:, ::1] results = results_arr
+    cdef const double *err_ptr = NULL
+    if has_error:
+        err_ptr = &error[0, 0]
+
+    cdef Py_ssize_t i
+    with nogil:
+        for i in range(n_src):
+            if skip[i]:
+                results[i, 0] = NAN
+                results[i, 1] = NAN
+                results[i, 2] = 0.0
+                results[i, 3] = 0.0
+                results[i, 4] = 0.0
+                results[i, 5] = 0.0
+                results[i, 6] = NAN
+                results[i, 7] = NAN
+                results[i, 8] = NAN
+                results[i, 9] = NAN
+                continue
+            _centroid_win_source(&data[0, 0], err_ptr, &mask[0, 0],
+                                 &segm[0, 0], nx_data, ny_data,
+                                 labels[i], xcen0[i], ycen0[i],
+                                 sigma[i], seg_method, compute_err,
+                                 max_aper_size, &results[i, 0])
+    return results_arr

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -45,6 +45,75 @@ cdef extern from "math.h" nogil:
     double NAN
 
 
+cdef int _check_length(Py_ssize_t n, Py_ssize_t n_src,
+                       str name) except -1:
+    """
+    Validate the length of a per-source input array.
+
+    This is kept out of the drivers so that their error handling stays
+    out of the per-pixel loops. The drivers compile with
+    ``boundscheck=False``, so a short per-source array would otherwise
+    read out of bounds.
+
+    Parameters
+    ----------
+    n : Py_ssize_t
+        The length of the per-source array.
+
+    n_src : Py_ssize_t
+        The number of sources (the length of ``labels``).
+
+    name : str
+        The name of the per-source array, used in the error message.
+
+    Returns
+    -------
+    result : int
+        Zero. A `ValueError` is raised if the length is invalid.
+    """
+    if n != n_src:
+        msg = f'{name} must have the same length as labels'
+        raise ValueError(msg)
+    return 0
+
+
+cdef int _check_shape(Py_ssize_t ny, Py_ssize_t nx, Py_ssize_t ny_ref,
+                      Py_ssize_t nx_ref, str name,
+                      str ref_name) except -1:
+    """
+    Validate the shape of a 2D image-sized input array.
+
+    This is kept out of the drivers so that their error handling stays
+    out of the per-pixel loops. The drivers compile with
+    ``boundscheck=False``, so a smaller array would otherwise read out
+    of bounds.
+
+    Parameters
+    ----------
+    ny, nx : Py_ssize_t
+        The shape of the array being checked.
+
+    ny_ref, nx_ref : Py_ssize_t
+        The shape of the reference array.
+
+    name : str
+        The name of the array being checked, used in the error
+        message.
+
+    ref_name : str
+        The name of the reference array, used in the error message.
+
+    Returns
+    -------
+    result : int
+        Zero. A `ValueError` is raised if the shape is invalid.
+    """
+    if ny != ny_ref or nx != nx_ref:
+        msg = f'{name} must have the same shape as {ref_name}'
+        raise ValueError(msg)
+    return 0
+
+
 cdef void _centroid_win_source(const double *data, const double *error,
                                const unsigned char *mask,
                                const Py_ssize_t *segm,
@@ -57,10 +126,10 @@ cdef void _centroid_win_source(const double *data, const double *error,
     """
     Compute the raw windowed-centroid quantities for a single source.
 
-    Replicates ``SourceCatalog._iterate_centroid_win``: an iterative
-    Gaussian-weighted centroid within a binary circular window of
-    radius ``4 * sigma``, with masked pixels contributing zero
-    and neighbor-source pixels excluded or mirror-corrected per
+    Replicates the previous per-source Python implementation: an
+    iterative Gaussian-weighted centroid within a binary circular
+    window of radius ``4 * sigma``, with masked pixels contributing
+    zero and neighbor-source pixels excluded or mirror-corrected per
     ``seg_method``. Writes the 10 output columns ``(xcen, ycen,
     weighted_flux, cen_mom_xx, cen_mom_yy, cen_mom_xy, err_sum,
     err_var_x, err_var_y, err_cov_xy)`` into ``out``.
@@ -94,6 +163,9 @@ cdef void _centroid_win_source(const double *data, const double *error,
     cdef Py_ssize_t iter_ = 0
     cdef Py_ssize_t ixmin, ixmax, iymin, iymax, x0, x1, y0, y1
     cdef Py_ssize_t ccx, ccy, ix, iy, six, siy
+    # Write-only sinks required by the ``_resolve_seg_pixel``
+    # signature; they accumulate across all iterations and the final
+    # pass, so they are not a per-window count and are never read
     cdef Py_ssize_t n_seg = 0, n_unc = 0
     cdef double dx, dy, rr2, w, v, e, wv, wsq
     cdef double sumw, sumwx, sumwy
@@ -325,7 +397,9 @@ def batch_centroid_win(const double[:, ::1] data, *,
     Raises
     ------
     ValueError
-        If ``compute_err`` is nonzero and ``error`` is `None`.
+        If ``compute_err`` is nonzero and ``error`` is `None`, if a
+        per-source array does not have the same length as ``labels``,
+        or if a 2D array does not have the same shape as ``data``.
     """
     cdef Py_ssize_t n_src = labels.shape[0]
     cdef Py_ssize_t ny_data = data.shape[0]
@@ -335,6 +409,18 @@ def batch_centroid_win(const double[:, ::1] data, *,
     if compute_err and not has_error:
         msg = 'error must be provided when compute_err is set'
         raise ValueError(msg)
+
+    _check_length(xcen0.shape[0], n_src, 'xcen0')
+    _check_length(ycen0.shape[0], n_src, 'ycen0')
+    _check_length(sigma.shape[0], n_src, 'sigma')
+    _check_length(skip.shape[0], n_src, 'skip')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'data')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'data')
+    if has_error:
+        _check_shape(error.shape[0], error.shape[1], ny_data, nx_data,
+                     'error', 'data')
 
     results_arr = np.empty((n_src, 10))
     cdef double[:, ::1] results = results_arr
@@ -564,8 +650,27 @@ def batch_raw_moments(const double[:, ::1] convdata, *,
         included pixels of source ``i``, where ``v`` is the convolved
         data value and ``(cx, cy)`` are the cutout-frame pixel
         coordinates.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if a 2D array does not have the same shape as
+        ``convdata``.
     """
     cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = convdata.shape[0]
+    cdef Py_ssize_t nx_data = convdata.shape[1]
+
+    _check_length(bbox_iymin.shape[0], n_src, 'bbox_iymin')
+    _check_length(bbox_iymax.shape[0], n_src, 'bbox_iymax')
+    _check_length(bbox_ixmin.shape[0], n_src, 'bbox_ixmin')
+    _check_length(bbox_ixmax.shape[0], n_src, 'bbox_ixmax')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'convdata')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'convdata')
+
     result_arr = np.zeros((n_src, 4, 4))
     cdef double[:, :, ::1] result = result_arr
     cdef Py_ssize_t i, ix, iy, p, q, y0, y1, x0, x1, lbl
@@ -667,8 +772,29 @@ def batch_central_moments(const double[:, ::1] convdata, *,
         source centroid is not finite, every element except
         ``[i, 0, 0]``, which is the plain sum of the included values,
         is NaN.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if a 2D array does not have the same shape as
+        ``convdata``.
     """
     cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = convdata.shape[0]
+    cdef Py_ssize_t nx_data = convdata.shape[1]
+
+    _check_length(bbox_iymin.shape[0], n_src, 'bbox_iymin')
+    _check_length(bbox_iymax.shape[0], n_src, 'bbox_iymax')
+    _check_length(bbox_ixmin.shape[0], n_src, 'bbox_ixmin')
+    _check_length(bbox_ixmax.shape[0], n_src, 'bbox_ixmax')
+    _check_length(xcen.shape[0], n_src, 'xcen')
+    _check_length(ycen.shape[0], n_src, 'ycen')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'convdata')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'convdata')
+
     result_arr = np.zeros((n_src, 4, 4))
     cdef double[:, :, ::1] result = result_arr
     cdef Py_ssize_t i, ix, iy, p, q, y0, y1, x0, x1, lbl
@@ -786,8 +912,31 @@ def batch_moment_err(const double[:, ::1] error, *,
         ``e2`` is the pixel error variance and ``(dx, dy)`` are the
         cutout-frame pixel coordinates relative to the source
         centroid.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if a 2D array does not have the same shape as
+        ``error``.
     """
     cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = error.shape[0]
+    cdef Py_ssize_t nx_data = error.shape[1]
+
+    _check_length(bbox_iymin.shape[0], n_src, 'bbox_iymin')
+    _check_length(bbox_iymax.shape[0], n_src, 'bbox_iymax')
+    _check_length(bbox_ixmin.shape[0], n_src, 'bbox_ixmin')
+    _check_length(bbox_ixmax.shape[0], n_src, 'bbox_ixmax')
+    _check_length(xcen.shape[0], n_src, 'xcen')
+    _check_length(ycen.shape[0], n_src, 'ycen')
+    _check_shape(convdata.shape[0], convdata.shape[1], ny_data,
+                 nx_data, 'convdata', 'error')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'error')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'error')
+
     result_arr = np.zeros((n_src, 4))
     cdef double[:, ::1] result = result_arr
     cdef Py_ssize_t i, ix, iy, y0, y1, x0, x1, lbl

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -14,7 +14,9 @@ the semantics match the previous cutout-based code paths.
 The moment kernels accumulate the raw and central spatial moments (and
 the raw centroid error sums) over each source's segment bounding box,
 using cutout-frame coordinates, so that the moment-based properties
-never need per-source cutout arrays.
+never need per-source cutout arrays. The segment gather packs the
+unmasked segment pixel values of all sources into a single array for
+the pixel-statistics properties (e.g., ``segment_flux``).
 
 The fractional-flux radius solver additionally runs its bracketed
 root-find entirely in C, using the ``brentq`` implementation exported
@@ -36,7 +38,7 @@ from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
 __all__ = ['batch_central_moments', 'batch_centroid_win',
            'batch_flux_radius_prepare', 'batch_flux_radius_solve',
            'batch_kron_radius', 'batch_moment_err', 'batch_quad_boxes',
-           'batch_raw_moments']
+           'batch_raw_moments', 'batch_segment_gather']
 
 
 cdef extern from "math.h" nogil:
@@ -1265,6 +1267,130 @@ def batch_quad_boxes(const double[:, ::1] data, *,
                             box_var[i, k] = e * e
                     k += 1
     return status_arr, peak_arr, boxes_arr, box_var_arr
+
+
+def batch_segment_gather(const double[:, ::1] values, *,
+                         const unsigned char[:, ::1] mask,
+                         const Py_ssize_t[:, ::1] segm,
+                         const Py_ssize_t[::1] labels,
+                         const Py_ssize_t[::1] bbox_iymin,
+                         const Py_ssize_t[::1] bbox_iymax,
+                         const Py_ssize_t[::1] bbox_ixmin,
+                         const Py_ssize_t[::1] bbox_ixmax):
+    """
+    Pack the unmasked segment pixel values of many sources into one
+    array.
+
+    For each source, the values of the pixels within its segment
+    bounding box that belong to the source segment and are unmasked
+    are copied, in row-major order, into a packed array. A source
+    with no such pixels contributes a single NaN, replicating the
+    previous per-source masked-array ``compressed()`` values (with a
+    single NaN for completely masked sources).
+
+    Parameters
+    ----------
+    values : 2D ndarray of float64 (C-contiguous)
+        The array to gather from (e.g., the data, error, or background
+        array).
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where nonzero values indicate masked (excluded)
+        pixels. Must have the same shape as ``values``. Bit 1 (value
+        1) marks input-masked pixels and bit 2 (value 2) marks
+        non-finite data pixels folded into the mask by the caller.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``values``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape ``(n_sources,)``.
+
+    bbox_iymin, bbox_iymax, bbox_ixmin, bbox_ixmax : 1D ndarray of intp
+        The segment bounding box of each source, with shape
+        ``(n_sources,)``. The maxima are exclusive (slice ``stop``
+        values).
+
+    Returns
+    -------
+    packed : 1D ndarray of float64
+        The packed pixel values of all sources.
+
+    offsets : 1D ndarray of intp
+        The start offset of each source in ``packed``, with shape
+        ``(n_sources + 1,)``; the values of source ``i`` are
+        ``packed[offsets[i]:offsets[i + 1]]``.
+
+    counts : 1D ndarray of intp
+        The number of unmasked segment pixels of each source, with
+        shape ``(n_sources,)``. A source with a zero count occupies a
+        single NaN in ``packed``.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if a 2D array does not have the same shape as
+        ``values``.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = values.shape[0]
+    cdef Py_ssize_t nx_data = values.shape[1]
+
+    _check_length(bbox_iymin.shape[0], n_src, 'bbox_iymin')
+    _check_length(bbox_iymax.shape[0], n_src, 'bbox_iymax')
+    _check_length(bbox_ixmin.shape[0], n_src, 'bbox_ixmin')
+    _check_length(bbox_ixmax.shape[0], n_src, 'bbox_ixmax')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'values')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'values')
+
+    offsets_arr = np.zeros(n_src + 1, dtype=np.intp)
+    counts_arr = np.zeros(n_src, dtype=np.intp)
+    cdef Py_ssize_t[::1] offsets = offsets_arr
+    cdef Py_ssize_t[::1] counts = counts_arr
+    cdef Py_ssize_t i, ix, iy, y0, y1, x0, x1, lbl, n, pos
+
+    # First pass: count the contributing pixels of each source
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            n = 0
+            for iy in range(y0, y1):
+                for ix in range(x0, x1):
+                    if segm[iy, ix] == lbl and mask[iy, ix] == 0:
+                        n += 1
+            counts[i] = n
+            offsets[i + 1] = offsets[i] + (n if n > 0 else 1)
+
+    packed_arr = np.empty(offsets[n_src])
+    cdef double[::1] packed = packed_arr
+
+    # Second pass: copy the values
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            pos = offsets[i]
+            if counts[i] == 0:
+                packed[pos] = NAN
+                continue
+            for iy in range(y0, y1):
+                for ix in range(x0, x1):
+                    if segm[iy, ix] == lbl and mask[iy, ix] == 0:
+                        packed[pos] = values[iy, ix]
+                        pos += 1
+    return packed_arr, offsets_arr, counts_arr
 
 
 def batch_raw_moments(const double[:, ::1] convdata, *,

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -959,30 +959,140 @@ ctypedef struct _FluxRadiusArgs:
     int use_exact
     int subpixels
     double normflux
+    # Radial binning of the cutout pixels (see ``_bin_flux_radius_pixels``)
+    double bin_width
+    Py_ssize_t n_bins
+    const Py_ssize_t *order
+    const Py_ssize_t *bin_starts
+    const double *bin_cumsum
+
+
+cdef void _bin_flux_radius_pixels(_FluxRadiusArgs *p, Py_ssize_t *order,
+                                  Py_ssize_t *bin_of,
+                                  Py_ssize_t *bin_starts,
+                                  double *bin_cumsum,
+                                  Py_ssize_t *work) noexcept nogil:
+    """
+    Bin the cutout pixels of a source by the distance of their centers
+    from the source centroid (a counting sort), and accumulate the
+    prefix sums of the data over the bins.
+
+    This lets ``_flux_radius_objective`` add the fully-enclosed pixels
+    of a circle in one step and evaluate the overlap fraction only for
+    the pixels in the bins that straddle the circle boundary, instead
+    of classifying every cutout pixel on every root-finder iteration.
+
+    Parameters
+    ----------
+    p : _FluxRadiusArgs *
+        The per-source arguments. On input the grid and data members
+        are set; on output the ``order``, ``bin_starts``, and
+        ``bin_cumsum`` members point at the filled arrays.
+
+    order : Py_ssize_t *
+        Output of length ``nx * ny``: the flat pixel indices grouped by
+        increasing distance bin.
+
+    bin_of : Py_ssize_t *
+        Scratch of length ``nx * ny`` (the bin of each pixel).
+
+    bin_starts : Py_ssize_t *
+        Output of length ``n_bins + 1``: the start of each bin in
+        ``order``.
+
+    bin_cumsum : double *
+        Output of length ``n_bins + 1``: ``bin_cumsum[b]`` is the sum of
+        the data over the pixels in the bins before ``b``.
+
+    work : Py_ssize_t *
+        Scratch of length ``n_bins`` (the per-bin fill positions).
+    """
+    cdef Py_ssize_t n_pix = p.nx * p.ny
+    cdef Py_ssize_t ix, iy, k, b, n_bins = p.n_bins
+    cdef double pxcen, pycen, d
+    cdef double inv_width = 1.0 / p.bin_width
+
+    for b in range(n_bins + 1):
+        bin_starts[b] = 0
+    # The bin of each pixel and the pixel count of each bin
+    k = 0
+    for iy in range(p.ny):
+        pycen = p.ymin_e + iy * p.dy + 0.5 * p.dy
+        for ix in range(p.nx):
+            pxcen = p.xmin_e + ix * p.dx + 0.5 * p.dx
+            d = sqrt(pxcen * pxcen + pycen * pycen)
+            b = <Py_ssize_t>(d * inv_width)
+            if b >= n_bins:
+                b = n_bins - 1
+            bin_of[k] = b
+            bin_starts[b + 1] += 1
+            k += 1
+    # Convert the counts to start offsets, then place the pixels
+    # (row-major within each bin)
+    for b in range(n_bins):
+        bin_starts[b + 1] += bin_starts[b]
+        work[b] = bin_starts[b]
+    for k in range(n_pix):
+        b = bin_of[k]
+        order[work[b]] = k
+        work[b] += 1
+    # Prefix sums of the data over the bins
+    bin_cumsum[0] = 0.0
+    for b in range(n_bins):
+        bin_cumsum[b + 1] = bin_cumsum[b]
+        for k in range(bin_starts[b], bin_starts[b + 1]):
+            bin_cumsum[b + 1] += p.data[order[k]]
+    p.order = order
+    p.bin_starts = bin_starts
+    p.bin_cumsum = bin_cumsum
 
 
 cdef double _flux_radius_objective(double r,
                                    void *args) noexcept nogil:
     """
     Fraction-of-flux residual ``1 - flux(r) / normflux`` for the
-    brentq root-find, accumulating ``data * overlap`` with the same
-    per-pixel arithmetic as ``circular_overlap_grid`` (grid edges
-    relative to the source centroid).
+    brentq root-find.
+
+    The flux is ``sum(data * overlap)`` with the same per-pixel
+    overlap arithmetic as ``circular_overlap_grid`` (grid edges
+    relative to the source centroid). The pixels are visited through
+    the radial bins of ``_bin_flux_radius_pixels``: bins whose pixels
+    all lie within ``r - pixel_radius`` of the centroid are fully
+    enclosed (overlap fraction exactly 1, as in the interior fast path
+    of ``circle_frac_from_d2``) and are added from the prefix sums;
+    bins beyond ``r + pixel_radius`` have zero overlap; the pixels of
+    the remaining bins are evaluated individually.
     """
     cdef _FluxRadiusArgs *p = <_FluxRadiusArgs *>args
-    cdef Py_ssize_t ix, iy
-    cdef double flux = 0.0
-    cdef double pymin, pxmin, frac
+    cdef Py_ssize_t b, b_lo, b_hi, k, idx
+    cdef double flux, pymin, pxmin, frac
+    cdef double r_inner = r - p.pixel_radius
+    cdef double r_outer = r + p.pixel_radius
 
-    for iy in range(p.ny):
-        pymin = p.ymin_e + iy * p.dy
-        for ix in range(p.nx):
-            pxmin = p.xmin_e + ix * p.dx
+    # Bins entirely inside: every pixel has d < (b + 1) * width, so
+    # d < r_inner when (b + 1) * width <= r_inner
+    b_lo = 0
+    if r_inner > 0.0:
+        b_lo = <Py_ssize_t>(r_inner / p.bin_width)
+        if b_lo > p.n_bins:
+            b_lo = p.n_bins
+    # Bins entirely outside: every pixel has d >= b * width, so
+    # d >= r_outer when b * width >= r_outer
+    b_hi = <Py_ssize_t>(r_outer / p.bin_width) + 1
+    if b_hi > p.n_bins:
+        b_hi = p.n_bins
+
+    flux = p.bin_cumsum[b_lo]
+    for b in range(b_lo, b_hi):
+        for k in range(p.bin_starts[b], p.bin_starts[b + 1]):
+            idx = p.order[k]
+            pymin = p.ymin_e + (idx // p.nx) * p.dy
+            pxmin = p.xmin_e + (idx % p.nx) * p.dx
             frac = _circle_pixel_frac(pxmin, pymin, p.dx, p.dy,
                                       p.pixel_radius, r, p.use_exact,
                                       p.subpixels)
             if frac > 0.0:
-                flux += p.data[iy * p.nx + ix] * frac
+                flux += p.data[idx] * frac
     return 1.0 - flux / p.normflux
 
 
@@ -998,7 +1108,11 @@ def batch_flux_radius_solve(args_list, *, double fraction):
     tolerances replicate the previous per-source
     `scipy.optimize.root_scalar` implementation (the same SciPy C
     routine is used), so the roots agree to within floating-point
-    rounding of the sequentially accumulated flux sums.
+    rounding of the flux sums. The cutout pixels are binned once per
+    source by their distance from the centroid, so that each
+    root-finder evaluation adds the fully enclosed pixels from prefix
+    sums and evaluates the overlap only for the pixels near the circle
+    boundary (see ``_flux_radius_objective``).
 
     A bracket whose endpoints have the same sign has no (or multiple)
     solutions. As in the previous implementation, the maximum radius
@@ -1039,10 +1153,29 @@ def batch_flux_radius_solve(args_list, *, double fraction):
     cdef const double[:, ::1] cdata
     cdef _FluxRadiusArgs p
     cdef zeros_full_output full_output
-    cdef double xmax_e, ymax_e
+    cdef double xmax_e, ymax_e, max_extent
     cdef double max_radius, delta, result
     cdef bint found
-    cdef Py_ssize_t i
+    cdef Py_ssize_t i, n_pix, n_bins, max_pix = 0, max_bins = 0
+
+    # Scratch buffers for the radial binning, sized for the largest
+    # cutout (local to this call, so the function is thread safe)
+    for entry in args_list:
+        if entry is None:
+            continue
+        n_pix = entry[1][4] * entry[1][5]
+        if n_pix > max_pix:
+            max_pix = n_pix
+    order_arr = np.empty(max(max_pix, 1), dtype=np.intp)
+    bin_of_arr = np.empty(max(max_pix, 1), dtype=np.intp)
+    cdef Py_ssize_t[::1] order = order_arr
+    cdef Py_ssize_t[::1] bin_of = bin_of_arr
+    bin_starts_arr = np.empty(1, dtype=np.intp)
+    bin_cumsum_arr = np.empty(1, dtype=np.float64)
+    work_arr = np.empty(1, dtype=np.intp)
+    cdef Py_ssize_t[::1] bin_starts = bin_starts_arr
+    cdef double[::1] bin_cumsum = bin_cumsum_arr
+    cdef Py_ssize_t[::1] work = work_arr
 
     for i, entry in enumerate(args_list):
         if entry is None:
@@ -1066,7 +1199,27 @@ def batch_flux_radius_solve(args_list, *, double fraction):
         p.normflux = kronflux * fraction
         max_radius = max_radius_py
 
+        # Radial bins of a quarter pixel diagonal out to the farthest
+        # cutout corner; the boundary band of a circle then spans the
+        # pixel diagonal plus two bins
+        p.bin_width = 0.5 * p.pixel_radius
+        max_extent = sqrt(max(p.xmin_e * p.xmin_e, xmax_e * xmax_e)
+                          + max(p.ymin_e * p.ymin_e, ymax_e * ymax_e))
+        n_bins = <Py_ssize_t>(max_extent / p.bin_width) + 1
+        p.n_bins = n_bins
+        if n_bins > max_bins:
+            max_bins = n_bins
+            bin_starts_arr = np.empty(max_bins + 1, dtype=np.intp)
+            bin_cumsum_arr = np.empty(max_bins + 1, dtype=np.float64)
+            work_arr = np.empty(max_bins, dtype=np.intp)
+            bin_starts = bin_starts_arr
+            bin_cumsum = bin_cumsum_arr
+            work = work_arr
+
         with nogil:
+            _bin_flux_radius_pixels(&p, &order[0], &bin_of[0],
+                                    &bin_starts[0], &bin_cumsum[0],
+                                    &work[0])
             found = False
             result = NAN
             delta = 0.1 * max_radius

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -35,7 +35,8 @@ from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
 
 __all__ = ['batch_central_moments', 'batch_centroid_win',
            'batch_flux_radius_prepare', 'batch_flux_radius_solve',
-           'batch_kron_radius', 'batch_moment_err', 'batch_raw_moments']
+           'batch_kron_radius', 'batch_moment_err', 'batch_quad_boxes',
+           'batch_raw_moments']
 
 
 cdef extern from "math.h" nogil:
@@ -1093,6 +1094,177 @@ def batch_flux_radius_solve(args_list, *, double fraction):
                 result = NAN
         radius[i] = result
     return radius_arr
+
+
+def batch_quad_boxes(const double[:, ::1] data, *,
+                     const double[:, ::1] error,
+                     const unsigned char[:, ::1] mask,
+                     const Py_ssize_t[:, ::1] segm,
+                     const Py_ssize_t[::1] labels,
+                     const Py_ssize_t[::1] bbox_iymin,
+                     const Py_ssize_t[::1] bbox_iymax,
+                     const Py_ssize_t[::1] bbox_ixmin,
+                     const Py_ssize_t[::1] bbox_ixmax,
+                     int compute_err):
+    """
+    Gather the 3x3 peak-pixel boxes of the quadratic centroid fit for
+    many sources in one call.
+
+    For each source, the data within its segment bounding box is
+    treated as a cutout whose pixels outside the source segment,
+    input-masked, or non-finite are zero, and the first (row-major)
+    maximum of that cutout is the peak pixel. The 3x3 box centered on
+    the peak is returned together with the pixel variances of the box
+    (zero for masked pixels), replicating the previous per-source
+    Python implementation exactly.
+
+    Parameters
+    ----------
+    data : 2D ndarray of float64 (C-contiguous)
+        The data array.
+
+    error : 2D ndarray of float64 (C-contiguous) or `None`
+        The pixel-wise 1-sigma errors. Must have the same shape as
+        ``data``. Required (not `None`) if ``compute_err`` is nonzero.
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where nonzero values indicate masked (zeroed)
+        pixels. Must have the same shape as ``data``. Bit 1 (value 1)
+        marks input-masked pixels and bit 2 (value 2) marks non-finite
+        data pixels folded into the mask by the caller.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``data``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape ``(n_sources,)``.
+
+    bbox_iymin, bbox_iymax, bbox_ixmin, bbox_ixmax : 1D ndarray of intp
+        The segment bounding box of each source, with shape
+        ``(n_sources,)``. The maxima are exclusive (slice ``stop``
+        values).
+
+    compute_err : int
+        If nonzero, also gather the pixel variances of the boxes.
+
+    Returns
+    -------
+    status : 1D ndarray of intp
+        The per-source status: 0 if the 3x3 box was gathered, 1 if the
+        cutout is smaller than 3x3, 2 if every cutout pixel is masked,
+        and 3 if the peak pixel lies on the cutout edge (so no box
+        fits). Only status 0 rows have valid boxes.
+
+    peak : 2D ndarray of intp
+        The cutout-frame ``(x, y)`` index of the peak pixel, with shape
+        ``(n_sources, 2)``. Valid for status 0 and 3; ``(-1, -1)``
+        otherwise.
+
+    boxes : 2D ndarray of float64
+        The zero-filled cutout values of the 3x3 box around the peak in
+        row-major order, with shape ``(n_sources, 9)``. Zero for
+        statuses other than 0.
+
+    box_var : 2D ndarray of float64
+        The pixel variances of the box, zero for masked pixels, with
+        shape ``(n_sources, 9)``. All zero unless ``compute_err`` is
+        nonzero.
+
+    Raises
+    ------
+    ValueError
+        If ``compute_err`` is nonzero and ``error`` is `None`, if a
+        per-source array does not have the same length as ``labels``,
+        or if a 2D array does not have the same shape as ``data``.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = data.shape[0]
+    cdef Py_ssize_t nx_data = data.shape[1]
+    cdef bint has_error = error is not None
+
+    if compute_err and not has_error:
+        msg = 'error must be provided when compute_err is set'
+        raise ValueError(msg)
+
+    _check_length(bbox_iymin.shape[0], n_src, 'bbox_iymin')
+    _check_length(bbox_iymax.shape[0], n_src, 'bbox_iymax')
+    _check_length(bbox_ixmin.shape[0], n_src, 'bbox_ixmin')
+    _check_length(bbox_ixmax.shape[0], n_src, 'bbox_ixmax')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'data')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'data')
+    if has_error:
+        _check_shape(error.shape[0], error.shape[1], ny_data, nx_data,
+                     'error', 'data')
+
+    status_arr = np.zeros(n_src, dtype=np.intp)
+    peak_arr = np.full((n_src, 2), -1, dtype=np.intp)
+    boxes_arr = np.zeros((n_src, 9))
+    box_var_arr = np.zeros((n_src, 9))
+    cdef Py_ssize_t[::1] status = status_arr
+    cdef Py_ssize_t[:, ::1] peak = peak_arr
+    cdef double[:, ::1] boxes = boxes_arr
+    cdef double[:, ::1] box_var = box_var_arr
+    cdef const double *err_ptr = NULL
+    if has_error:
+        err_ptr = &error[0, 0]
+
+    cdef Py_ssize_t i, ix, iy, y0, y1, x0, x1, lbl, k
+    cdef Py_ssize_t xpeak, ypeak, bx, by
+    cdef double v, vmax, e
+    cdef bint found, masked
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            if y1 - y0 < 3 or x1 - x0 < 3:
+                status[i] = 1
+                continue
+
+            # First (row-major) maximum of the zero-filled cutout
+            found = False
+            vmax = 0.0
+            xpeak = 0
+            ypeak = 0
+            for iy in range(y0, y1):
+                for ix in range(x0, x1):
+                    if segm[iy, ix] != lbl or mask[iy, ix] != 0:
+                        v = 0.0
+                    else:
+                        v = data[iy, ix]
+                        found = True
+                    if (iy == y0 and ix == x0) or v > vmax:
+                        vmax = v
+                        xpeak = ix
+                        ypeak = iy
+            if not found:
+                status[i] = 2
+                continue
+
+            peak[i, 0] = xpeak - x0
+            peak[i, 1] = ypeak - y0
+            if (xpeak == x0 or xpeak == x1 - 1 or ypeak == y0
+                    or ypeak == y1 - 1):
+                status[i] = 3
+                continue
+
+            k = 0
+            for by in range(ypeak - 1, ypeak + 2):
+                for bx in range(xpeak - 1, xpeak + 2):
+                    masked = (segm[by, bx] != lbl or mask[by, bx] != 0)
+                    if not masked:
+                        boxes[i, k] = data[by, bx]
+                        if compute_err:
+                            e = err_ptr[by * nx_data + bx]
+                            box_var[i, k] = e * e
+                    k += 1
+    return status_arr, peak_arr, boxes_arr, box_var_arr
 
 
 def batch_raw_moments(const double[:, ::1] convdata, *,

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -34,8 +34,8 @@ from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
                                                 _resolve_seg_pixel)
 
 __all__ = ['batch_central_moments', 'batch_centroid_win',
-           'batch_flux_radius_solve', 'batch_kron_radius',
-           'batch_moment_err', 'batch_raw_moments']
+           'batch_flux_radius_prepare', 'batch_flux_radius_solve',
+           'batch_kron_radius', 'batch_moment_err', 'batch_raw_moments']
 
 
 cdef extern from "math.h" nogil:
@@ -44,6 +44,7 @@ cdef extern from "math.h" nogil:
     double sin(double x)
     double cos(double x)
     double floor(double x)
+    double ceil(double x)
     double fmax(double x, double y)
     bint isfinite(double x)
     double NAN
@@ -715,6 +716,237 @@ def batch_kron_radius(const double[:, ::1] data, *,
                                 min_circ_radius, max_aper_size,
                                 &results[i, 0])
     return results_arr
+
+
+cdef void _flux_radius_cutout(const double *data,
+                              const unsigned char *mask,
+                              const Py_ssize_t *segm,
+                              Py_ssize_t nx_data, Py_ssize_t label,
+                              Py_ssize_t x0, Py_ssize_t x1,
+                              Py_ssize_t y0, Py_ssize_t y1,
+                              Py_ssize_t ccx, Py_ssize_t ccy,
+                              double local_bkg, int seg_method,
+                              double *out) noexcept nogil:
+    """
+    Fill the cleaned, background-subtracted cutout of a single source
+    for the flux-radius root-find.
+
+    Replicates the previous per-source Python preparation: masked and
+    non-finite pixels are zero, neighbor-source pixels are zeroed or
+    mirror-corrected per ``seg_method`` (an uncorrectable neighbor
+    pixel is zero), and every other pixel is ``data - local_bkg``.
+    Writes the ``(y1 - y0, x1 - x0)`` cutout in row-major order into
+    ``out``.
+    """
+    cdef Py_ssize_t ix, iy, six, siy
+    cdef Py_ssize_t nx = x1 - x0
+    # Write-only sinks required by the ``_resolve_seg_pixel``
+    # signature
+    cdef Py_ssize_t n_seg = 0, n_unc = 0
+    cdef double value
+    for iy in range(y0, y1):
+        for ix in range(x0, x1):
+            value = 0.0
+            if mask[iy * nx_data + ix] == 0:
+                six = ix
+                siy = iy
+                if (seg_method == 0
+                        or _resolve_seg_pixel(
+                            segm, mask, nx_data, seg_method, label,
+                            ix, iy, x0, x1, y0, y1, ccx, ccy,
+                            &six, &siy, &n_seg, &n_unc)):
+                    value = data[siy * nx_data + six] - local_bkg
+            out[(iy - y0) * nx + (ix - x0)] = value
+
+
+def batch_flux_radius_prepare(const double[:, ::1] data, *,
+                              const unsigned char[:, ::1] mask,
+                              const Py_ssize_t[:, ::1] segm,
+                              const Py_ssize_t[::1] labels,
+                              const double[::1] xcen,
+                              const double[::1] ycen,
+                              const double[::1] local_bkg,
+                              const double[::1] kronflux,
+                              const double[::1] max_radius,
+                              const unsigned char[::1] skip,
+                              int seg_method, int use_exact,
+                              int subpixels, Py_ssize_t max_aper_size):
+    """
+    Prepare the per-source inputs of the flux-radius root-find for
+    many sources in one call.
+
+    For each source, the cutout of the data within the bounding box
+    of the circle of radius ``max_radius`` (clipped to the data) is
+    cleaned and background-subtracted (see ``_flux_radius_cutout``)
+    and the `~photutils.geometry.circular_overlap_grid` grid
+    parameters of that cutout, relative to the source centroid, are
+    computed. The bounding-box arithmetic, the per-pixel masking, and
+    the neighbor handling replicate the previous per-source Python
+    implementation exactly.
+
+    Parameters
+    ----------
+    data : 2D ndarray of float64 (C-contiguous)
+        The data array.
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where nonzero values indicate masked (zeroed)
+        pixels. Must have the same shape as ``data``. Bit 1 (value 1)
+        marks input-masked pixels and bit 2 (value 2) marks non-finite
+        data pixels folded into the mask by the caller. Any nonzero
+        value zeroes the pixel and prevents it from being used as a
+        mirror pixel.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``data``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape ``(n_sources,)``.
+
+    xcen, ycen : 1D ndarray of float64 (C-contiguous)
+        The source centroids, with shape ``(n_sources,)``.
+
+    local_bkg : 1D ndarray of float64 (C-contiguous)
+        The per-source local background to subtract from each pixel
+        value, with shape ``(n_sources,)``.
+
+    kronflux : 1D ndarray of float64 (C-contiguous)
+        The Kron flux of each source, with shape ``(n_sources,)``.
+
+    max_radius : 1D ndarray of float64 (C-contiguous)
+        The maximum circular radius of each source (the initial upper
+        bracket of the root-find), with shape ``(n_sources,)``.
+
+    skip : 1D ndarray of uint8 (C-contiguous)
+        Nonzero for sources that cannot have a solution (e.g., a
+        non-finite centroid, Kron flux, or maximum radius, or a zero
+        Kron flux), with shape ``(n_sources,)``.
+
+    seg_method : int
+        The segmentation masking method:
+
+        * 0: disables masking
+        * 1: zeroes neighbor-source pixels
+             (``(seg > 0) & (seg != label)``)
+        * 3: replaces neighbor-source pixels with the values mirrored
+             across the (rounded) cutout center (the symmetric
+             ``'correct'`` method). A neighbor pixel whose mirror falls
+             outside the clipped cutout, is itself a neighbor, or is
+             masked is zeroed instead.
+
+    use_exact : int
+        Whether the root-find computes exact overlap fractions (1) or
+        uses subpixel sampling (0).
+
+    subpixels : int
+        The number of subpixels in each dimension when ``use_exact``
+        is 0.
+
+    max_aper_size : Py_ssize_t
+        The maximum number of pixels in the (unclipped) bounding box.
+        Sources with a larger bounding box are skipped (out-of-memory
+        guard).
+
+    Returns
+    -------
+    args : list
+        The prepared per-source arguments consumed by
+        ``batch_flux_radius_solve``, with one entry per source. Each
+        entry is either `None`, for a skipped source (including those
+        rejected by ``max_aper_size`` and those whose bounding box
+        does not overlap the data), or the list ``[clean_data,
+        grid_params, kronflux, max_radius]``, where ``clean_data`` is
+        the cleaned C-contiguous float64 cutout and ``grid_params`` is
+        the tuple ``(xmin_e, xmax_e, ymin_e, ymax_e, nx, ny,
+        use_exact, subpixels)`` of grid parameters whose edges are
+        relative to the source centroid.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if a 2D array does not have the same shape as
+        ``data``.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = data.shape[0]
+    cdef Py_ssize_t nx_data = data.shape[1]
+
+    _check_length(xcen.shape[0], n_src, 'xcen')
+    _check_length(ycen.shape[0], n_src, 'ycen')
+    _check_length(local_bkg.shape[0], n_src, 'local_bkg')
+    _check_length(kronflux.shape[0], n_src, 'kronflux')
+    _check_length(max_radius.shape[0], n_src, 'max_radius')
+    _check_length(skip.shape[0], n_src, 'skip')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'data')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'data')
+
+    cdef Py_ssize_t i, x0, x1, y0, y1, nx, ny, ccx, ccy
+    cdef double xc, yc, rmax, ixmin_d, ixmax_d, iymin_d, iymax_d
+    cdef double x0_d, x1_d, y0_d, y1_d, cutout_xcen, cutout_ycen
+    cdef double[:, ::1] cutout
+    args = []
+    for i in range(n_src):
+        if skip[i]:
+            args.append(None)
+            continue
+        xc = xcen[i]
+        yc = ycen[i]
+        rmax = max_radius[i]
+
+        # The bounding box of the maximum-radius circle, kept as
+        # integral doubles until it is clipped to avoid integer
+        # overflow for sources far outside the image
+        ixmin_d = floor(xc - rmax + 0.5)
+        ixmax_d = ceil(xc + rmax + 0.5)
+        iymin_d = floor(yc - rmax + 0.5)
+        iymax_d = ceil(yc + rmax + 0.5)
+        if (iymax_d - iymin_d) * (ixmax_d - ixmin_d) > max_aper_size:
+            args.append(None)
+            continue
+
+        # Clip to the data
+        x0_d = ixmin_d if ixmin_d > 0.0 else 0.0
+        x1_d = ixmax_d if ixmax_d < nx_data else nx_data
+        y0_d = iymin_d if iymin_d > 0.0 else 0.0
+        y1_d = iymax_d if iymax_d < ny_data else ny_data
+        if y0_d >= y1_d or x0_d >= x1_d:
+            args.append(None)
+            continue
+        x0 = <Py_ssize_t>x0_d
+        x1 = <Py_ssize_t>x1_d
+        y0 = <Py_ssize_t>y0_d
+        y1 = <Py_ssize_t>y1_d
+        nx = x1 - x0
+        ny = y1 - y0
+
+        # The cutout-frame centroid and the mirror center of the
+        # 'correct' method (truncation of the cutout centroid + 0.5
+        # replicates the Python int() call)
+        cutout_xcen = xc - <double>x0
+        cutout_ycen = yc - <double>y0
+        ccx = <Py_ssize_t>(cutout_xcen + 0.5) + x0
+        ccy = <Py_ssize_t>(cutout_ycen + 0.5) + y0
+
+        clean_data = np.empty((ny, nx))
+        cutout = clean_data
+        with nogil:
+            _flux_radius_cutout(&data[0, 0], &mask[0, 0], &segm[0, 0],
+                                nx_data, labels[i], x0, x1, y0, y1,
+                                ccx, ccy, local_bkg[i], seg_method,
+                                &cutout[0, 0])
+
+        grid_params = (-0.5 - cutout_xcen,
+                       (<double>nx - 0.5) - cutout_xcen,
+                       -0.5 - cutout_ycen,
+                       (<double>ny - 0.5) - cutout_ycen,
+                       nx, ny, use_exact, subpixels)
+        args.append([clean_data, grid_params, kronflux[i], rmax])
+    return args
 
 
 ctypedef struct _FluxRadiusArgs:

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -37,8 +37,9 @@ from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
 
 __all__ = ['batch_central_moments', 'batch_centroid_win',
            'batch_flux_radius_prepare', 'batch_flux_radius_solve',
-           'batch_kron_radius', 'batch_moment_err', 'batch_quad_boxes',
-           'batch_raw_moments', 'batch_segment_gather']
+           'batch_kron_radius', 'batch_moment_err', 'batch_perimeter',
+           'batch_quad_boxes', 'batch_raw_moments',
+           'batch_segment_gather']
 
 
 cdef extern from "math.h" nogil:
@@ -1096,6 +1097,146 @@ def batch_flux_radius_solve(args_list, *, double fraction):
                 result = NAN
         radius[i] = result
     return radius_arr
+
+
+cdef inline bint _is_source_pixel(const unsigned char *mask,
+                                  const Py_ssize_t *segm,
+                                  Py_ssize_t nx_data, Py_ssize_t label,
+                                  Py_ssize_t ix, Py_ssize_t iy,
+                                  Py_ssize_t x0, Py_ssize_t x1,
+                                  Py_ssize_t y0, Py_ssize_t y1) noexcept nogil:
+    """
+    Whether a pixel is an unmasked pixel of the source segment, with
+    pixels outside the clipped bounding box treated as background.
+    """
+    if ix < x0 or ix >= x1 or iy < y0 or iy >= y1:
+        return False
+    return (segm[iy * nx_data + ix] == label
+            and mask[iy * nx_data + ix] == 0)
+
+
+cdef inline bint _is_border_pixel(const unsigned char *mask,
+                                  const Py_ssize_t *segm,
+                                  Py_ssize_t nx_data, Py_ssize_t label,
+                                  Py_ssize_t ix, Py_ssize_t iy,
+                                  Py_ssize_t x0, Py_ssize_t x1,
+                                  Py_ssize_t y0, Py_ssize_t y1) noexcept nogil:
+    """
+    Whether a pixel is a source pixel with at least one 4-connected
+    neighbor that is not a source pixel (i.e., a source pixel removed
+    by a binary erosion with a cross footprint).
+    """
+    if not _is_source_pixel(mask, segm, nx_data, label, ix, iy, x0, x1,
+                            y0, y1):
+        return False
+    return not (_is_source_pixel(mask, segm, nx_data, label, ix - 1, iy,
+                                 x0, x1, y0, y1)
+                and _is_source_pixel(mask, segm, nx_data, label, ix + 1,
+                                     iy, x0, x1, y0, y1)
+                and _is_source_pixel(mask, segm, nx_data, label, ix,
+                                     iy - 1, x0, x1, y0, y1)
+                and _is_source_pixel(mask, segm, nx_data, label, ix,
+                                     iy + 1, x0, x1, y0, y1))
+
+
+def batch_perimeter(const unsigned char[:, ::1] mask, *,
+                    const Py_ssize_t[:, ::1] segm,
+                    const Py_ssize_t[::1] labels,
+                    const Py_ssize_t[::1] bbox_iymin,
+                    const Py_ssize_t[::1] bbox_iymax,
+                    const Py_ssize_t[::1] bbox_ixmin,
+                    const Py_ssize_t[::1] bbox_ixmax):
+    """
+    Compute the border-pixel pattern histograms of the perimeter
+    estimator for many sources in one call.
+
+    For each source, the unmasked segment pixels form a binary image
+    (zero outside the segment bounding box). Its border pixels are
+    the source pixels removed by a binary erosion with a 4-connected
+    cross footprint, and the border image is convolved with the
+    ``[[10, 2, 10], [2, 1, 2], [10, 2, 10]]`` kernel at every
+    bounding-box pixel. The histogram of the convolved values below 34
+    is returned; the caller applies the perimeter weights of the
+    estimator of Benkrid et al. (2000) to it. This replicates the
+    previous per-source implementation exactly.
+
+    Parameters
+    ----------
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where nonzero values indicate masked (excluded)
+        pixels. Bit 1 (value 1) marks input-masked pixels and bit 2
+        (value 2) marks non-finite data pixels folded into the mask by
+        the caller.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``mask``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape ``(n_sources,)``.
+
+    bbox_iymin, bbox_iymax, bbox_ixmin, bbox_ixmax : 1D ndarray of intp
+        The segment bounding box of each source, with shape
+        ``(n_sources,)``. The maxima are exclusive (slice ``stop``
+        values).
+
+    Returns
+    -------
+    hist : 2D ndarray of intp
+        The histogram of the convolved border values of each source,
+        with shape ``(n_sources, 34)``.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if ``segm`` does not have the same shape as
+        ``mask``.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = mask.shape[0]
+    cdef Py_ssize_t nx_data = mask.shape[1]
+
+    _check_length(bbox_iymin.shape[0], n_src, 'bbox_iymin')
+    _check_length(bbox_iymax.shape[0], n_src, 'bbox_iymax')
+    _check_length(bbox_ixmin.shape[0], n_src, 'bbox_ixmin')
+    _check_length(bbox_ixmax.shape[0], n_src, 'bbox_ixmax')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'mask')
+
+    hist_arr = np.zeros((n_src, 34), dtype=np.intp)
+    cdef Py_ssize_t[:, ::1] hist = hist_arr
+    cdef const unsigned char *mask_ptr = &mask[0, 0]
+    cdef const Py_ssize_t *segm_ptr = &segm[0, 0]
+    cdef Py_ssize_t i, ix, iy, y0, y1, x0, x1, lbl, value
+    cdef Py_ssize_t dx, dy, weight
+
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            for iy in range(y0, y1):
+                for ix in range(x0, x1):
+                    value = 0
+                    for dy in range(-1, 2):
+                        for dx in range(-1, 2):
+                            if dx == 0 and dy == 0:
+                                weight = 1
+                            elif dx == 0 or dy == 0:
+                                weight = 2
+                            else:
+                                weight = 10
+                            if _is_border_pixel(mask_ptr, segm_ptr,
+                                                nx_data, lbl, ix + dx,
+                                                iy + dy, x0, x1, y0, y1):
+                                value += weight
+                    if value < 34:
+                        hist[i, value] += 1
+    return hist_arr
 
 
 def batch_quad_boxes(const double[:, ::1] data, *,

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -33,7 +33,7 @@ import numpy as np
 from scipy.optimize.cython_optimize cimport brentq, zeros_full_output
 
 from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
-                                                _resolve_seg_pixel)
+                                                _seg_pixel_contributes)
 
 __all__ = ['batch_central_moments', 'batch_centroid_win',
            'batch_flux_radius_prepare', 'batch_flux_radius_solve',
@@ -172,10 +172,6 @@ cdef void _centroid_win_source(const double *data, const double *error,
     cdef Py_ssize_t iter_ = 0
     cdef Py_ssize_t ixmin, ixmax, iymin, iymax, x0, x1, y0, y1
     cdef Py_ssize_t ccx, ccy, ix, iy, six, siy
-    # Write-only sinks required by the ``_resolve_seg_pixel``
-    # signature; they accumulate across all iterations and the final
-    # pass, so they are not a per-window count and are never read
-    cdef Py_ssize_t n_seg = 0, n_unc = 0
     cdef double dx, dy, rr2, w, v, e, wv, wsq
     cdef double sumw, sumwx, sumwy
     # State of the last completed accumulation, for the final
@@ -222,10 +218,10 @@ cdef void _centroid_win_source(const double *data, const double *error,
                 six = ix
                 siy = iy
                 if (seg_method != 0
-                        and not _resolve_seg_pixel(
+                        and not _seg_pixel_contributes(
                             segm, mask, nx_data, seg_method, label,
                             ix, iy, x0, x1, y0, y1, ccx, ccy,
-                            &six, &siy, &n_seg, &n_unc)):
+                            &six, &siy)):
                     continue
                 v = data[siy * nx_data + six]
                 w = exp(rr2 * inv_2sigma2)
@@ -285,10 +281,10 @@ cdef void _centroid_win_source(const double *data, const double *error,
             six = ix
             siy = iy
             if (seg_method != 0
-                    and not _resolve_seg_pixel(
+                    and not _seg_pixel_contributes(
                         segm, mask, nx_data, seg_method, label,
                         ix, iy, lx0, lx1, ly0, ly1, lccx, lccy,
-                        &six, &siy, &n_seg, &n_unc)):
+                        &six, &siy)):
                 continue
             v = data[siy * nx_data + six]
             w = exp(rr2 * inv_2sigma2)
@@ -539,9 +535,6 @@ cdef void _kron_radius_source(const double *data,
     cdef double numerator = 0.0
     cdef double denominator = 0.0
     cdef Py_ssize_t ix, iy, six, siy
-    # Write-only sinks required by the ``_resolve_seg_pixel``
-    # signature
-    cdef Py_ssize_t n_seg = 0, n_unc = 0
     cdef double xx, yy, rr_sq, rr, v
     for iy in range(y0, y1):
         yy = <double>(iy - y0) - yoff
@@ -559,10 +552,10 @@ cdef void _kron_radius_source(const double *data,
             six = ix
             siy = iy
             if (seg_method != 0
-                    and not _resolve_seg_pixel(
+                    and not _seg_pixel_contributes(
                         segm, mask, nx_data, seg_method, label,
                         ix, iy, x0, x1, y0, y1, ccx, ccy,
-                        &six, &siy, &n_seg, &n_unc)):
+                        &six, &siy)):
                 continue
             v = data[siy * nx_data + six]
             numerator += v * rr
@@ -748,9 +741,6 @@ cdef void _flux_radius_cutout(const double *data,
     """
     cdef Py_ssize_t ix, iy, six, siy
     cdef Py_ssize_t nx = x1 - x0
-    # Write-only sinks required by the ``_resolve_seg_pixel``
-    # signature
-    cdef Py_ssize_t n_seg = 0, n_unc = 0
     cdef double value
     for iy in range(y0, y1):
         for ix in range(x0, x1):
@@ -759,10 +749,10 @@ cdef void _flux_radius_cutout(const double *data,
                 six = ix
                 siy = iy
                 if (seg_method == 0
-                        or _resolve_seg_pixel(
+                        or _seg_pixel_contributes(
                             segm, mask, nx_data, seg_method, label,
                             ix, iy, x0, x1, y0, y1, ccx, ccy,
-                            &six, &siy, &n_seg, &n_unc)):
+                            &six, &siy)):
                     value = data[siy * nx_data + six] - local_bkg
             out[(iy - y0) * nx + (ix - x0)] = value
 

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -37,8 +37,8 @@ from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
 
 __all__ = ['batch_central_moments', 'batch_centroid_win',
            'batch_flux_radius_prepare', 'batch_flux_radius_solve',
-           'batch_kron_radius', 'batch_moment_err', 'batch_perimeter',
-           'batch_quad_boxes', 'batch_raw_moments',
+           'batch_kron_radius', 'batch_minmax_index', 'batch_moment_err',
+           'batch_perimeter', 'batch_quad_boxes', 'batch_raw_moments',
            'batch_segment_gather']
 
 
@@ -1528,6 +1528,118 @@ def batch_segment_gather(const double[:, ::1] values, *,
                         packed[pos] = values[iy, ix]
                         pos += 1
     return packed_arr, offsets_arr, counts_arr
+
+
+def batch_minmax_index(const double[:, ::1] values, *,
+                       const unsigned char[:, ::1] mask,
+                       const Py_ssize_t[:, ::1] segm,
+                       const Py_ssize_t[::1] labels,
+                       const Py_ssize_t[::1] bbox_iymin,
+                       const Py_ssize_t[::1] bbox_iymax,
+                       const Py_ssize_t[::1] bbox_ixmin,
+                       const Py_ssize_t[::1] bbox_ixmax):
+    """
+    Find the positions of the minimum and maximum unmasked segment
+    pixel values of many sources in one call.
+
+    For each source, the unmasked pixels of its segment within its
+    bounding box are scanned in row-major order and the cutout-frame
+    ``(y, x)`` positions of the first minimum and the first maximum
+    value are returned, replicating ``numpy.argmin`` and
+    ``numpy.argmax`` on the previous per-source masked cutouts.
+
+    Parameters
+    ----------
+    values : 2D ndarray of float64 (C-contiguous)
+        The array to scan (e.g., the data array). Its unmasked segment
+        values are assumed finite.
+
+    mask : 2D ndarray of uint8 (C-contiguous)
+        A mask array where nonzero values indicate masked (excluded)
+        pixels. Must have the same shape as ``values``. Bit 1 (value
+        1) marks input-masked pixels and bit 2 (value 2) marks
+        non-finite data pixels folded into the mask by the caller.
+
+    segm : 2D ndarray of intp (C-contiguous)
+        The segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``values``.
+
+    labels : 1D ndarray of intp (C-contiguous)
+        The source label for each source, with shape ``(n_sources,)``.
+
+    bbox_iymin, bbox_iymax, bbox_ixmin, bbox_ixmax : 1D ndarray of intp
+        The segment bounding box of each source, with shape
+        ``(n_sources,)``. The maxima are exclusive (slice ``stop``
+        values).
+
+    Returns
+    -------
+    index : 2D ndarray of intp
+        The cutout-frame positions with shape ``(n_sources, 4)`` and
+        columns ``(y_min, x_min, y_max, x_max)`` of the first minimum
+        and the first maximum value of each source. All four columns
+        are -1 for a source with no unmasked segment pixels.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``labels``, or if a 2D array does not have the same shape as
+        ``values``.
+    """
+    cdef Py_ssize_t n_src = labels.shape[0]
+    cdef Py_ssize_t ny_data = values.shape[0]
+    cdef Py_ssize_t nx_data = values.shape[1]
+
+    _check_length(bbox_iymin.shape[0], n_src, 'bbox_iymin')
+    _check_length(bbox_iymax.shape[0], n_src, 'bbox_iymax')
+    _check_length(bbox_ixmin.shape[0], n_src, 'bbox_ixmin')
+    _check_length(bbox_ixmax.shape[0], n_src, 'bbox_ixmax')
+    _check_shape(mask.shape[0], mask.shape[1], ny_data, nx_data,
+                 'mask', 'values')
+    _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
+                 'segm', 'values')
+
+    index_arr = np.full((n_src, 4), -1, dtype=np.intp)
+    cdef Py_ssize_t[:, ::1] index = index_arr
+    cdef Py_ssize_t i, ix, iy, y0, y1, x0, x1, lbl
+    cdef Py_ssize_t ymin_idx, xmin_idx, ymax_idx, xmax_idx
+    cdef double v, vmin, vmax
+    cdef bint found
+
+    with nogil:
+        for i in range(n_src):
+            lbl = labels[i]
+            y0 = bbox_iymin[i]
+            y1 = bbox_iymax[i]
+            x0 = bbox_ixmin[i]
+            x1 = bbox_ixmax[i]
+            found = False
+            vmin = 0.0
+            vmax = 0.0
+            ymin_idx = xmin_idx = ymax_idx = xmax_idx = -1
+            for iy in range(y0, y1):
+                for ix in range(x0, x1):
+                    if segm[iy, ix] != lbl or mask[iy, ix] != 0:
+                        continue
+                    v = values[iy, ix]
+                    # Strict comparisons keep the first occurrence of
+                    # a repeated extreme, as numpy.argmin/argmax do
+                    if not found or v < vmin:
+                        vmin = v
+                        ymin_idx = iy - y0
+                        xmin_idx = ix - x0
+                    if not found or v > vmax:
+                        vmax = v
+                        ymax_idx = iy - y0
+                        xmax_idx = ix - x0
+                    found = True
+            index[i, 0] = ymin_idx
+            index[i, 1] = xmin_idx
+            index[i, 2] = ymax_idx
+            index[i, 3] = xmax_idx
+    return index_arr
 
 
 def batch_raw_moments(const double[:, ::1] convdata, *,

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -1107,12 +1107,15 @@ def batch_flux_radius_solve(args_list, *, double fraction):
     The per-pixel circular overlap, the bracket, and the root-finder
     tolerances replicate the previous per-source
     `scipy.optimize.root_scalar` implementation (the same SciPy C
-    routine is used), so the roots agree to within floating-point
-    rounding of the flux sums. The cutout pixels are binned once per
-    source by their distance from the centroid, so that each
-    root-finder evaluation adds the fully enclosed pixels from prefix
-    sums and evaluates the overlap only for the pixels near the circle
-    boundary (see ``_flux_radius_objective``).
+    routine is used). The cutout pixels are binned once per source by
+    their distance from the centroid, so that each root-finder
+    evaluation adds the fully enclosed pixels from prefix sums and
+    evaluates the overlap only for the pixels near the circle boundary
+    (see ``_flux_radius_objective``). Every pixel receives the same
+    overlap fraction as before, but the flux is summed in a different
+    order, which perturbs the Brent iteration path: the roots agree
+    with the previous implementation to within the root-finder's
+    absolute tolerance (``xtol`` = 2e-12 pixels), not to rounding.
 
     A bracket whose endpoints have the same sign has no (or multiple)
     solutions. As in the previous implementation, the maximum radius

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -20,8 +20,19 @@ from scipy.optimize import root_scalar
 
 from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture, RectangularAnnulus)
+from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
+                                                  FLAG_COL_MASKED,
+                                                  FLAG_COL_N_PIXELS,
+                                                  FLAG_COL_NONFINITE_DATA,
+                                                  FLAG_COL_SEG,
+                                                  FLAG_COL_SEG_MASKED,
+                                                  FLAG_COL_UNCORRECTED,
+                                                  FLAG_COL_UNCORRECTED_MASKED,
+                                                  FLAG_COL_VALID, SHAPE_CIRCLE,
+                                                  SHAPE_ELLIPSE,
+                                                  batch_aperture_sums)
 from photutils.background import SExtractorBackground
-from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
+from photutils.geometry import circular_overlap_grid
 from photutils.morphology import gini as gini_func
 from photutils.segmentation._batch_catalog import batch_centroid_win
 from photutils.segmentation.core import SegmentationImage
@@ -292,10 +303,10 @@ class SourceCatalog:
 
     progress_bar : bool, optional
         Whether to display a progress bar when calculating
-        some properties (e.g., ``kron_radius``, ``kron_flux``,
-        ``flux_radius``, ``circular_photometry``,
-        ``centroid_quad``). The progress bar requires that the `tqdm
-        <https://tqdm.github.io/>`_ optional dependency be installed.
+        some properties (e.g., ``kron_radius``, ``flux_radius``,
+        ``circular_photometry``, ``centroid_quad``). The progress bar
+        requires that the `tqdm <https://tqdm.github.io/>`_ optional
+        dependency be installed.
 
     Notes
     -----
@@ -4812,138 +4823,116 @@ class SourceCatalog:
             kron_params = self._validate_kron_params(kron_params)
             kron_aperture = self._make_kron_apertures(kron_params)
 
-        labels = self.labels
-        if self.progress_bar:
-            labels = add_progress_bar(labels, desc='kron_photometry')
+        n_src = len(kron_aperture)
+        flux = np.full(n_src, np.nan)
+        flux_err = np.full(n_src, np.nan)
+        kron_flags = np.zeros(n_src, dtype=int)
 
-        _floor = math.floor
         max_size = max(self._data.size, 1_000_000)
-        ny_img, nx_img = self._data.shape
+        _floor = math.floor
 
-        flux = []
-        flux_err = []
-        kron_flags = []
-        for label, aperture, bkg in zip(labels, kron_aperture,
-                                        self._local_background, strict=True):
+        # Pre-filter undefined and oversized apertures, and group the
+        # rest by aperture shape for the batch driver
+        circ_idx = []
+        circ_params = []
+        ell_idx = []
+        ell_params = []
+        positions = np.zeros((n_src, 2))
+        for i, aperture in enumerate(kron_aperture):
             if aperture is None:
-                flux.append(np.nan)
-                flux_err.append(np.nan)
-                kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
+                kron_flags[i] = SEGMENTATION_FLAGS.KRON_UNDEFINED
                 continue
-
             xcen, ycen = aperture.positions
-
-            # Compute the aperture mask directly, bypassing the
-            # aperture's to_mask() method and ApertureMask/BoundingBox
-            # property overhead.
+            positions[i] = (xcen, ycen)
             if isinstance(aperture, CircularAperture):
                 r = aperture.r
-                ixmin = _floor(xcen - r + 0.5)
-                ixmax = _floor(xcen + r + 1.5)
-                iymin = _floor(ycen - r + 0.5)
-                iymax = _floor(ycen + r + 1.5)
-                nx = ixmax - ixmin
-                ny = iymax - iymin
+                nx = _floor(xcen + r + 1.5) - _floor(xcen - r + 0.5)
+                ny = _floor(ycen + r + 1.5) - _floor(ycen - r + 0.5)
                 if nx * ny > max_size:
-                    flux.append(np.nan)
-                    flux_err.append(np.nan)
-                    kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
+                    kron_flags[i] = SEGMENTATION_FLAGS.KRON_UNDEFINED
                     continue
-                edges = (ixmin - 0.5 - xcen, ixmax - 0.5 - xcen,
-                         iymin - 0.5 - ycen, iymax - 0.5 - ycen)
-                mask_data = circular_overlap_grid(
-                    edges[0], edges[1], edges[2], edges[3],
-                    nx, ny, r, 1, 1)
+                circ_idx.append(i)
+                circ_params.append((r,))
             else:
                 a = aperture.a
                 b = aperture.b
                 theta_val = aperture.theta
-                theta_rad = (theta_val.to_value(u.radian)
-                             if hasattr(theta_val, 'to')
-                             else float(theta_val))
-                cos_t = math.cos(theta_rad)
-                sin_t = math.sin(theta_rad)
+                theta = (theta_val.to_value(u.radian)
+                         if hasattr(theta_val, 'to')
+                         else float(theta_val))
+                cos_t = math.cos(theta)
+                sin_t = math.sin(theta)
                 x_ext = math.sqrt((a * cos_t) ** 2 + (b * sin_t) ** 2)
                 y_ext = math.sqrt((a * sin_t) ** 2 + (b * cos_t) ** 2)
-                ixmin = _floor(xcen - x_ext + 0.5)
-                ixmax = _floor(xcen + x_ext + 1.5)
-                iymin = _floor(ycen - y_ext + 0.5)
-                iymax = _floor(ycen + y_ext + 1.5)
-                nx = ixmax - ixmin
-                ny = iymax - iymin
+                nx = (_floor(xcen + x_ext + 1.5)
+                      - _floor(xcen - x_ext + 0.5))
+                ny = (_floor(ycen + y_ext + 1.5)
+                      - _floor(ycen - y_ext + 0.5))
                 if nx * ny > max_size:
-                    flux.append(np.nan)
-                    flux_err.append(np.nan)
-                    kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
+                    kron_flags[i] = SEGMENTATION_FLAGS.KRON_UNDEFINED
                     continue
-                edges = (ixmin - 0.5 - xcen, ixmax - 0.5 - xcen,
-                         iymin - 0.5 - ycen, iymax - 0.5 - ycen)
-                mask_data = elliptical_overlap_grid(
-                    edges[0], edges[1], edges[2], edges[3],
-                    nx, ny, a, b, theta_rad, 1, 1)
+                ell_idx.append(i)
+                ell_params.append((a, b, theta))
 
-            bbox = BoundingBox(ixmin, ixmax, iymin, iymax)
-            (data, error, mask, _, slc_sm,
-             flag_masks) = self._make_aperture_data(label, xcen, ycen, bbox,
-                                                    bkg)
-            if data is None:
-                flux.append(np.nan)
-                flux_err.append(np.nan)
-                kron_flags.append(SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
+        arrays = self._get_batch_arrays()
+        seg_code = _SEG_METHOD_CODES[self.aperture_mask_method]
+        seg_arr = arrays['segm'] if seg_code != 0 else None
+        labels_arr = np.ascontiguousarray(np.atleast_1d(self.labels),
+                                          dtype=np.intp)
+        local_bkg = np.ascontiguousarray(self._local_background,
+                                         dtype=np.float64)
+        has_error = self._error is not None
+
+        for idx, params_list, shape_code in (
+                (circ_idx, circ_params, SHAPE_CIRCLE),
+                (ell_idx, ell_params, SHAPE_ELLIPSE)):
+            if not idx:
                 continue
+            idx = np.array(idx)
+            psrc = np.ascontiguousarray(params_list, dtype=np.float64)
+            pos = np.ascontiguousarray(positions[idx])
+            seg_labels = labels_arr[idx] if seg_code != 0 else None
+            (sums, sum_vars, _, overlap, _, _, _, _, _, fcounts,
+             weights_out) = batch_aperture_sums(
+                arrays['data'], arrays['error'], arrays['mask'], pos,
+                shape_code, None, 0.0, 0.0, 0.0, 0.0, 1, 1, seg_arr,
+                seg_labels, seg_code, local_bkg[idx], 0,
+                params_per_source=psrc)
 
-            aperture_weights = mask_data[slc_sm]
-            in_aperture = aperture_weights > 0
-            pixel_mask = in_aperture & ~mask
+            n_pix = fcounts[:, FLAG_COL_N_PIXELS]
+            clipped = fcounts[:, FLAG_COL_BBOX_CLIPPED].astype(bool)
+            weights_out = weights_out.astype(bool)
+            # Membership matches the previous cutout-based
+            # ``in_aperture & ~mask`` rule: under 'correct',
+            # uncorrectable neighbor pixels stay members (with value
+            # zero), so they keep the flux at 0.0 rather than NaN
+            members = fcounts[:, FLAG_COL_VALID].copy()
+            if seg_code == 3:
+                members += fcounts[:, FLAG_COL_UNCORRECTED]
+            good = overlap & (members > 0)
+            flux[idx] = np.where(good, sums, np.nan)
+            if has_error:
+                flux_err[idx] = np.where(good, np.sqrt(sum_vars),
+                                         np.nan)
 
-            kron_flag = 0
-            # The aperture bounding box extends beyond the data array.
-            # The box corners can have zero aperture weight, so compare
-            # the number of nonzero-weight pixels within the data to the
-            # total number in the aperture. The overlap is partial only
-            # if at least one nonzero-weight pixel falls both inside and
-            # outside of the data.
-            if (ixmin < 0 or iymin < 0 or ixmax > nx_img
-                    or iymax > ny_img):
-                n_inside = np.count_nonzero(in_aperture)
-                if n_inside == 0:
-                    kron_flag |= SEGMENTATION_FLAGS.KRON_NO_OVERLAP
-                elif n_inside != np.count_nonzero(mask_data):
-                    kron_flag |= SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP
-
-            if np.any(flag_masks['data_mask'] & in_aperture):
-                kron_flag |= SEGMENTATION_FLAGS.KRON_MASKED_PIXELS
-
-            segm_mask = flag_masks['segm_mask']
-            if segm_mask is not None and np.any(segm_mask & in_aperture):
-                kron_flag |= SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS
-
-            uncorrected_mask = flag_masks['uncorrected_mask']
-            if (uncorrected_mask is not None
-                    and np.any(uncorrected_mask & in_aperture)):
-                kron_flag |= SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS
-
-            kron_flags.append(kron_flag)
-
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
-                values = (aperture_weights * data)[pixel_mask]
-                flux_ = np.nan if values.shape == (0,) else np.sum(values)
-                flux.append(flux_)
-
-                if error is None:
-                    flux_err_ = np.nan
-                else:
-                    values = (aperture_weights**2 * error**2)[pixel_mask]
-                    if values.shape == (0,):
-                        flux_err_ = np.nan
-                    else:
-                        flux_err_ = np.sqrt(np.sum(values))
-                flux_err.append(flux_err_)
-
-        flux = np.array(flux)
-        flux_err = np.array(flux_err)
-        kron_flags = np.array(kron_flags, dtype=int)
+            grp_flags = np.zeros(len(idx), dtype=int)
+            no_ovl = ~overlap | (clipped & (n_pix == 0))
+            grp_flags[no_ovl] |= SEGMENTATION_FLAGS.KRON_NO_OVERLAP
+            grp_flags[(n_pix > 0) & weights_out] |= (
+                SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP)
+            masked_any = (fcounts[:, FLAG_COL_MASKED]
+                          + fcounts[:, FLAG_COL_NONFINITE_DATA]) > 0
+            grp_flags[masked_any] |= (
+                SEGMENTATION_FLAGS.KRON_MASKED_PIXELS)
+            seg_any = (fcounts[:, FLAG_COL_SEG]
+                       + fcounts[:, FLAG_COL_SEG_MASKED]) > 0
+            grp_flags[seg_any] |= (
+                SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS)
+            unc_any = (fcounts[:, FLAG_COL_UNCORRECTED]
+                       + fcounts[:, FLAG_COL_UNCORRECTED_MASKED]) > 0
+            grp_flags[unc_any] |= (
+                SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS)
+            kron_flags[idx] |= grp_flags
 
         return flux, flux_err, kron_flags
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -37,6 +37,7 @@ from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_flux_radius_solve,
                                                    batch_kron_radius,
                                                    batch_moment_err,
+                                                   batch_quad_boxes,
                                                    batch_raw_moments)
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
@@ -49,7 +50,6 @@ from photutils.utils._deprecation import (_get_future_column_names,
 from photutils.utils._flags import update_flag_docstring
 from photutils.utils._misc import _get_meta
 from photutils.utils._parameters import validate_table_columns
-from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils._wcs_helpers import compute_pixel_to_sky_jacobians
 from photutils.utils.cutouts import CutoutImage
@@ -304,11 +304,10 @@ class SourceCatalog:
         the Kron flux).
 
     progress_bar : bool, optional
-        Whether to display a progress bar when calculating
-        some properties (e.g., ``kron_radius``, ``flux_radius``,
-        ``circular_photometry``, ``centroid_quad``). The progress bar
-        requires that the `tqdm <https://tqdm.github.io/>`_ optional
-        dependency be installed.
+        Whether to display a progress bar when calculating properties.
+        All property calculations are now computed for all sources at
+        once in compiled code, so no progress bar is displayed. This
+        keyword is retained for backwards compatibility.
 
     Notes
     -----
@@ -2423,63 +2422,6 @@ class SourceCatalog:
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.centroid_win - origin
 
-    @staticmethod
-    def _centroid_quad_var(coeffs, xm_rel, ym_rel, pinv, box_var):
-        """
-        Propagate pixel variances through the quadratic peak solution.
-
-        The quadratic-fit coefficients are linear in the pixel values
-        (``c = pinv @ pixels``) and the peak position is a rational
-        function of the coefficients, so the position variances follow
-        from the delta method.
-
-        Parameters
-        ----------
-        coeffs : `~numpy.ndarray`
-            The six quadratic-fit coefficients for the terms
-            ``[1, x, y, xy, x^2, y^2]``.
-
-        xm_rel, ym_rel : float
-            The peak position in the relative (3x3 box) coordinates.
-
-        pinv : `~numpy.ndarray`
-            The (6, 9) pseudo-inverse of the design matrix.
-
-        box_var : `~numpy.ndarray`
-            The 9 pixel variances of the 3x3 fit box, with masked
-            pixels set to zero.
-
-        Returns
-        -------
-        var_x, var_y : float
-            The variances of the peak ``x`` and ``y`` positions.
-
-        cov_xy : float
-            The covariance of the peak ``x`` and ``y`` positions.
-        """
-        c10, c01, c11, c20, c02 = coeffs[1:]
-        det = 4.0 * c20 * c02 - c11 * c11
-        grad_x = np.array(
-            [0.0,
-             -2.0 * c02 / det,
-             c11 / det,
-             (c01 + 2.0 * c11 * xm_rel) / det,
-             -4.0 * c02 * xm_rel / det,
-             (-2.0 * c10 - 4.0 * c20 * xm_rel) / det])
-        grad_y = np.array(
-            [0.0,
-             c11 / det,
-             -2.0 * c20 / det,
-             (c10 + 2.0 * c11 * ym_rel) / det,
-             (-2.0 * c01 - 4.0 * c02 * ym_rel) / det,
-             -4.0 * c20 * ym_rel / det])
-        u_x = grad_x @ pinv
-        u_y = grad_y @ pinv
-        var_x = np.sum(u_x**2 * box_var)
-        var_y = np.sum(u_y**2 * box_var)
-        cov_xy = np.sum(u_x * u_y * box_var)
-        return var_x, var_y, cov_xy
-
     @cached_property
     @use_detcat
     def _centroid_quad_results(self):
@@ -2495,7 +2437,7 @@ class SourceCatalog:
         """
         # Precompute the pseudo-inverse for the 3x3 relative coordinate
         # design matrix [1, x, y, xy, x^2, y^2]. This is constant for
-        # all sources and avoids per-source lstsq calls.
+        # all sources.
         xi = np.arange(3)
         x, y = np.meshgrid(xi, xi)
         x = x.ravel()
@@ -2511,90 +2453,86 @@ class SourceCatalog:
 
         compute_err = self._error is not None
 
-        _nan = np.nan
-        nan_result = (_nan, _nan, _nan, _nan, _nan)
-        results = []
+        # Gather the 3x3 box around the peak pixel of each masked
+        # (zero-filled) cutout
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        status, peak, boxes, box_var = batch_quad_boxes(
+            arrays['data'], error=arrays['error'], mask=arrays['mask'],
+            segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax, compute_err=int(compute_err))
+        nx = ixmax - ixmin
+        ny = iymax - iymin
+        n_src = len(status)
 
-        cutouts = self._data_cutouts
-        if self.progress_bar:
-            desc = 'centroid_quad'
-            cutouts = add_progress_bar(cutouts, desc=desc)
+        results = np.full((n_src, 5), np.nan)
 
-        for cutout, error_cutout, mask in zip(cutouts,
-                                              self._error_cutouts,
-                                              self._cutout_total_masks,
-                                              strict=True):
-            ny, nx = cutout.shape
+        # If the peak is at the edge of the cutout, return the peak
+        # position. No fit is performed, so no errors can be
+        # propagated.
+        edge = status == 3
+        results[edge, 0] = peak[edge, 0]
+        results[edge, 1] = peak[edge, 1]
 
-            # Cutout must be at least 3x3 for the quadratic fit
-            if ny < 3 or nx < 3:
-                results.append(nan_result)
-                continue
-
-            # A source with no unmasked pixels has no peak; without this
-            # guard the masked (zeroed) cutout below would return the
-            # position of its first pixel as the "peak"
-            if np.all(mask):
-                results.append(nan_result)
-                continue
-
-            # Apply mask: _cutout_total_masks already includes
-            # non-finite data values, so cutout[mask] = 0.0 handles both
-            # masked pixels and non-finite values.
-            cutout = np.array(cutout, dtype=float)
-            cutout[mask] = 0.0
-
-            # Find peak pixel
-            yidx, xidx = np.unravel_index(np.argmax(cutout), cutout.shape)
-
-            # If peak at edge of cutout, return peak position. No fit
-            # is performed, so no errors can be propagated.
-            if xidx == 0 or xidx == nx - 1 or yidx == 0 or yidx == ny - 1:
-                results.append((float(xidx), float(yidx), _nan, _nan,
-                                _nan))
-                continue
-
-            # Extract 3x3 box centered on peak (guaranteed to fit
-            # since peak is not at edge)
-            xidx0 = xidx - 1
-            yidx0 = yidx - 1
-            cutout_flat = cutout[yidx0:yidx0 + 3, xidx0:xidx0 + 3].ravel()
-
-            # Compute polynomial coefficients via precomputed
-            # pseudo-inverse
-            c = pinv @ cutout_flat
-            c10, c01, c11, c20, c02 = c[1], c[2], c[3], c[4], c[5]
-
-            det = 4.0 * c20 * c02 - c11 * c11
-            if det <= 0 or c20 > 0:
-                results.append(nan_result)
-                continue
-
+        # Fit the quadratic to the 3x3 box of the remaining sources
+        fit = status == 0
+        xidx0 = peak[:, 0] - 1
+        yidx0 = peak[:, 1] - 1
+        # einsum (rather than a BLAS matmul) keeps the per-source
+        # arithmetic independent of the number of sources, so a sliced
+        # catalog reproduces the parent catalog values exactly
+        coeffs = np.einsum('ij,nj->ni', pinv, boxes)
+        c10 = coeffs[:, 1]
+        c01 = coeffs[:, 2]
+        c11 = coeffs[:, 3]
+        c20 = coeffs[:, 4]
+        c02 = coeffs[:, 5]
+        det = 4.0 * c20 * c02 - c11 * c11
+        fit &= ~((det <= 0) | (c20 > 0))
+        # Ignore RuntimeWarning from the sources without a fit
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             # Maximum in relative coords, then convert to cutout coords
             xm_rel = (c01 * c11 - 2.0 * c02 * c10) / det
             ym_rel = (c10 * c11 - 2.0 * c20 * c01) / det
             xm = xm_rel + xidx0
             ym = ym_rel + yidx0
+            fit &= ((xm > 0.0) & (xm < (nx - 1.0))
+                    & (ym > 0.0) & (ym < (ny - 1.0)))
+            results[fit, 0] = xm[fit]
+            results[fit, 1] = ym[fit]
 
-            if not (0.0 < xm < (nx - 1.0) and 0.0 < ym < (ny - 1.0)):
-                results.append(nan_result)
-                continue
-
-            var_x = var_y = cov_xy = _nan
             if compute_err:
-                # Pixel variances of the fit box; masked pixels have
-                # a fixed (zeroed) data value, so they contribute no
-                # variance
-                box_var = (error_cutout[yidx0:yidx0 + 3, xidx0:xidx0 + 3]
-                           .astype(float).ravel()**2)
-                box_var[mask[yidx0:yidx0 + 3,
-                             xidx0:xidx0 + 3].ravel()] = 0.0
-                var_x, var_y, cov_xy = self._centroid_quad_var(
-                    c, xm_rel, ym_rel, pinv, box_var)
-
-            results.append((xm, ym, var_x, var_y, cov_xy))
-
-        results = np.array(results)
+                # Propagate the pixel variances through the quadratic
+                # peak solution. The fit coefficients are linear in the
+                # pixel values (``c = pinv @ pixels``) and the peak
+                # position is a rational function of the coefficients,
+                # so the position variances follow from the delta
+                # method. Masked pixels have a fixed (zeroed) data
+                # value, so they contribute no variance.
+                zeros = np.zeros(n_src)
+                grad_x = np.column_stack(
+                    [zeros,
+                     -2.0 * c02 / det,
+                     c11 / det,
+                     (c01 + 2.0 * c11 * xm_rel) / det,
+                     -4.0 * c02 * xm_rel / det,
+                     (-2.0 * c10 - 4.0 * c20 * xm_rel) / det])
+                grad_y = np.column_stack(
+                    [zeros,
+                     c11 / det,
+                     -2.0 * c20 / det,
+                     (c10 + 2.0 * c11 * ym_rel) / det,
+                     (-2.0 * c01 - 4.0 * c02 * ym_rel) / det,
+                     -4.0 * c20 * ym_rel / det])
+                u_x = np.einsum('ni,ij->nj', grad_x, pinv)
+                u_y = np.einsum('ni,ij->nj', grad_y, pinv)
+                results[fit, 2] = np.sum(u_x**2 * box_var, axis=1)[fit]
+                results[fit, 3] = np.sum(u_y**2 * box_var, axis=1)[fit]
+                results[fit, 4] = np.sum(u_x * u_y * box_var, axis=1)[fit]
 
         # Use the segment barycenter if the fit returned NaN. Fallback
         # sources use the isophotal centroid, so also use the isophotal

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -38,7 +38,8 @@ from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_kron_radius,
                                                    batch_moment_err,
                                                    batch_quad_boxes,
-                                                   batch_raw_moments)
+                                                   batch_raw_moments,
+                                                   batch_segment_gather)
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
                                           decode_segmentation_flags)
@@ -816,8 +817,9 @@ class SourceCatalog:
         result : dict
             A dict with keys ``'data'``, ``'error'``, ``'mask'``, and
             ``'segm'``. The ``'error'`` value is `None` if no error
-            array was input. A ``'convdata'`` key is added lazily by
-            ``_get_batch_convdata``.
+            array was input. The ``'convdata'`` and ``'background'``
+            keys are added lazily by ``_get_batch_convdata`` and
+            ``_get_batch_background``.
         """
         if self._batch_arrays_cache is None:
             data = np.ascontiguousarray(self._data, dtype=np.float64)
@@ -845,6 +847,17 @@ class SourceCatalog:
             arrays['convdata'] = np.ascontiguousarray(
                 self._convolved_data, dtype=np.float64)
         return arrays['convdata']
+
+    def _get_batch_background(self):
+        """
+        Return the cached C-contiguous float64 background array used by
+        the batch segment gather.
+        """
+        arrays = self._get_batch_arrays()
+        if 'background' not in arrays:
+            arrays['background'] = np.ascontiguousarray(
+                self._background, dtype=np.float64)
+        return arrays['background']
 
     def _get_batch_bboxes(self):
         """
@@ -1521,7 +1534,13 @@ class SourceCatalog:
         """
         True if all pixels over the source segment are masked.
         """
-        return np.array([np.all(mask) for mask in self._cutout_total_masks])
+        # The gathered data values hold a single NaN for a completely
+        # masked source, and a non-finite data value is always masked,
+        # so no other source has a NaN value
+        values = self._data_values
+        sizes = np.array([arr.size for arr in values])
+        first = np.array([arr[0] for arr in values])
+        return (sizes == 1) & np.isnan(first)
 
     @cached_property
     @_update_flags_docstring
@@ -1697,21 +1716,33 @@ class SourceCatalog:
         return {int(label): flags
                 for label, flags in zip(self.labels, decoded, strict=True)}
 
-    def _get_values(self, array):
+    def _segment_values(self, array):
         """
-        Get a 1D array of unmasked values from the input array within
-        the source segment.
+        Get a list of 1D arrays of the unmasked values of ``array``
+        within each source segment.
 
         An array with a single NaN is returned for completely-masked
         sources.
+
+        Parameters
+        ----------
+        array : 2D `~numpy.ndarray`
+            The C-contiguous float64 full-image array to gather from.
+
+        Returns
+        -------
+        result : list of 1D `~numpy.ndarray`
+            The per-source values, in row-major pixel order.
         """
-        values = []
-        for arr in array:
-            compressed = arr.compressed()
-            if len(compressed) == 0:
-                compressed = np.array([np.nan])
-            values.append(compressed)
-        return values
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        packed, offsets, _ = batch_segment_gather(
+            array, mask=arrays['mask'], segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax)
+        return np.split(packed, offsets[1:-1])
 
     @staticmethod
     def _reduceat(values, ufunc, *, transform=None):
@@ -1755,36 +1786,39 @@ class SourceCatalog:
     @cached_property
     def _data_values(self):
         """
-        A 1D array of unmasked data values.
+        A list of 1D arrays of the unmasked data values within each
+        source segment.
 
         An array with a single NaN is returned for completely-masked
         sources.
         """
-        return self._get_values(self._array('data_cutout_masked'))
+        return self._segment_values(self._get_batch_arrays()['data'])
 
     @cached_property
     def _error_values(self):
         """
-        A 1D array of unmasked error values.
+        A list of 1D arrays of the unmasked error values within each
+        source segment.
 
         An array with a single NaN is returned for completely-masked
         sources.
         """
         if self._error is None:
             return self._null_objects
-        return self._get_values(self._array('error_cutout_masked'))
+        return self._segment_values(self._get_batch_arrays()['error'])
 
     @cached_property
     def _background_values(self):
         """
-        A 1D array of unmasked background values.
+        A list of 1D arrays of the unmasked background values within
+        each source segment.
 
         An array with a single NaN is returned for completely-masked
         sources.
         """
         if self._background is None:
             return self._null_objects
-        return self._get_values(self._array('background_cutout_masked'))
+        return self._segment_values(self._get_batch_background())
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -164,12 +164,10 @@ def _batch_gini(values):
 
     The values of each source are sorted with NumPy in a Python loop
     rather than with the compiled ``batch_gini`` kernel shared with
-    `~photutils.aperture.ApertureStats`. NumPy's vectorized sort beats
-    the kernel's scalar introsort for sources of more than ~50 pixels
-    (e.g., 23 versus 31 ms for 10k 144-pixel sources and 50 versus 86
-    ms for 1k 2500-pixel sources); the kernel is faster only for very
-    small sources (2.5 versus 27 ms for 100k four-pixel sources), where
-    the per-source Python overhead of this loop dominates.
+    `~photutils.aperture.ApertureStats`. NumPy's vectorized sort
+    beats the kernel's scalar introsort for sources of more than ~50
+    pixels. The kernel is faster only for very small sources, where the
+    per-source Python overhead of this loop dominates.
 
     Parameters
     ----------
@@ -188,8 +186,8 @@ def _batch_gini(values):
     starts = offsets[:-1]
     # Sort the absolute values within each source in place (a single
     # sort per source is much cheaper than one lexsort over all of the
-    # values); the placeholder values of empty sources are harmless
-    # because their results are set to NaN below
+    # values). The placeholder values of empty sources are harmless
+    # because their results are set to NaN below.
     values = np.abs(np.nan_to_num(packed))
     for start, stop in zip(starts, offsets[1:], strict=True):
         values[start:stop].sort()
@@ -628,11 +626,13 @@ class SourceCatalog:
 
         self._custom_properties = []
         self._flux_radius_cache = {}
+
         # The full-image arrays used by the batch Cython drivers, filled
         # lazily by _get_batch_arrays. The dict is shared by reference
         # with sliced catalogs (see __getitem__), so whichever catalog
         # builds the arrays first populates it for all of them.
         self._batch_arrays_cache = {}
+
         self.meta = _get_meta()
         self._update_meta()
 
@@ -1035,8 +1035,7 @@ class SourceCatalog:
         Return the source labels as the C-contiguous intp array used by
         the batch Cython drivers.
         """
-        return np.ascontiguousarray(np.atleast_1d(self.labels),
-                                    dtype=np.intp)
+        return np.ascontiguousarray(np.atleast_1d(self.labels), dtype=np.intp)
 
     @cached_property
     def _batch_bboxes(self):
@@ -1322,18 +1321,6 @@ class SourceCatalog:
             data_mask |= mask_cutout
         return data_mask
 
-    def _make_cutout_data_masks(self, data_cutouts, mask_cutouts):
-        """
-        Make a list of cutout data masks, combining both the input
-        ``mask`` and non-finite ``data`` values for each source.
-        """
-        data_masks = []
-        for (data_cutout, mask_cutout) in zip(data_cutouts, mask_cutouts,
-                                              strict=True):
-            data_masks.append(self._make_cutout_data_mask(data_cutout,
-                                                          mask_cutout))
-        return data_masks
-
     @cached_property
     def _cutout_segment_masks(self):
         """
@@ -1349,31 +1336,21 @@ class SourceCatalog:
                        strict=True)]
 
     @cached_property
-    def _cutout_data_masks(self):
-        """
-        Cutout boolean mask of non-finite ``data`` values combined with
-        the input ``mask`` array.
-
-        The mask is `True` for non-finite ``data`` values and where the
-        input ``mask`` is `True`.
-        """
-        return self._make_cutout_data_masks(self._data_cutouts,
-                                            self._mask_cutouts)
-
-    @cached_property
     def _cutout_total_masks(self):
         """
-        Boolean mask representing the combination of
-        ``_cutout_segment_masks`` and ``_cutout_data_masks``.
+        Cutout boolean masks combining the segment mask, non-finite
+        ``data`` values, and the input ``mask`` array.
 
-        This mask is applied to ``data``, ``error``, and ``background``
-        inputs when calculating properties.
+        Each mask is `True` for pixels outside the source segment, for
+        non-finite ``data`` values, and where the input ``mask`` is
+        `True`. These masks are applied to the masked cutout
+        properties.
         """
-        masks = []
-        for mask1, mask2 in zip(self._cutout_segment_masks,
-                                self._cutout_data_masks, strict=True):
-            masks.append(mask1 | mask2)
-        return masks
+        return [segm_mask
+                | self._make_cutout_data_mask(data_cutout, mask_cutout)
+                for segm_mask, data_cutout, mask_cutout
+                in zip(self._cutout_segment_masks, self._data_cutouts,
+                       self._mask_cutouts, strict=True)]
 
     def _prepare_cutouts(self, arrays, *, units=True, masked=False,
                          dtype=None):
@@ -2179,6 +2156,10 @@ class SourceCatalog:
             jac = compute_pixel_to_sky_jacobians(xycen[good, 0],
                                                  xycen[good, 1],
                                                  self.wcs)
+            # The Einstein summation computes the matrix product of the
+            # Jacobian, the pixel covariance, and the Jacobian transpose
+            # for each source. The result is the sky covariance matrix
+            # in the local tangent plane.
             sky_cov = np.einsum('nij,njk,nlk->nil', jac, pix_cov[good], jac)
             sky_err[good, 0] = np.sqrt(sky_cov[:, 0, 0])
             sky_err[good, 1] = np.sqrt(sky_cov[:, 1, 1])
@@ -2285,9 +2266,9 @@ class SourceCatalog:
             err_cov_xy = err_cov_xy * norm
 
             # Handle fully correlated profiles of point-like sources
-            # that cause a singularity. The determinant check
-            # includes the pixel-size correction in the variances
-            # but not in the covariance.
+            # that cause a singularity. The determinant check includes
+            # the pixel-size correction in the variances but not in the
+            # covariance.
             singular = (self._singular_covariance_mask
                         & ((err_var_x * err_var_y - err_cov_xy**2)
                            < err_sum_norm**2))
@@ -2312,12 +2293,19 @@ class SourceCatalog:
         Apply the fallback conditions for the windowed centroid.
 
         Reset the centroid to the isophotal centroid when any of the
-        following conditions hold: the centroid diverged far from the
-        isophotal centroid and lies outside the 1-sigma ellipse, the
-        total weighted flux is non-positive, the windowed 2nd-order
-        moments are negative, or the windowed covariance determinant
-        is negative. Fallback sources also use the isophotal centroid
-        errors. Sources with NaN half-light radius keep NaN.
+        following conditions hold:
+
+        * The centroid diverged far from the isophotal centroid and lies
+          outside the 1-sigma ellipse
+
+        * The total weighted flux is non-positive
+
+        * The windowed 2nd-order moments are negative
+
+        * The windowed covariance determinant is negative.
+
+        Fallback sources also use the isophotal centroid errors. Sources
+        with NaN half-light radius keep NaN.
 
         Parameters
         ----------
@@ -2423,8 +2411,8 @@ class SourceCatalog:
         # meaningful windowed centroid.
         nan_hl = ~np.isfinite(radius_hl)
 
-        # Apply a minimum half-light radius of 0.5 pixels (matching
-        # SourceExtractor) for valid but very small values
+        # Apply a minimum half-light radius of 0.5 pixels for valid but
+        # very small values.
         min_radius = 0.5
         small_mask = np.isfinite(radius_hl) & (radius_hl < min_radius)
         radius_hl[small_mask] = min_radius
@@ -2436,10 +2424,8 @@ class SourceCatalog:
         y_centroid = np.atleast_1d(self.y_centroid).astype(float)
 
         sigma = 2.0 * radius_hl * gaussian_fwhm_to_sigma
-        # np.isnan (not ~np.isfinite) for parity with the previous
-        # per-source math.isnan checks
-        skip = (nan_hl | np.isnan(x_centroid)
-                | np.isnan(y_centroid)).astype(np.uint8)
+        skip = (nan_hl | ~np.isfinite(x_centroid)
+                | ~np.isfinite(y_centroid)).astype(np.uint8)
         arrays = self._get_batch_arrays()
         results = batch_centroid_win(
             arrays['data'], error=arrays['error'],
@@ -2646,7 +2632,7 @@ class SourceCatalog:
         compute_err = self._error is not None
 
         # Gather the 3x3 box around the peak pixel of each masked
-        # (zero-filled) cutout
+        # (zero-filled) cutout.
         arrays = self._get_batch_arrays()
         iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         status, peak, boxes, box_var = batch_quad_boxes(
@@ -2662,19 +2648,18 @@ class SourceCatalog:
         results = np.full((n_src, 5), np.nan)
 
         # If the peak is at the edge of the cutout, return the peak
-        # position. No fit is performed, so no errors can be
-        # propagated.
+        # position. No fit is performed, so no errors can be propagated.
         edge = status == 3
         results[edge, 0] = peak[edge, 0]
         results[edge, 1] = peak[edge, 1]
 
-        # Fit the quadratic to the 3x3 box of the remaining sources
+        # Fit the quadratic to the 3x3 box of the remaining sources.
         fit = status == 0
         xidx0 = peak[:, 0] - 1
         yidx0 = peak[:, 1] - 1
         # einsum (rather than a BLAS matmul) keeps the per-source
         # arithmetic independent of the number of sources, so a sliced
-        # catalog reproduces the parent catalog values exactly
+        # catalog reproduces the parent catalog values exactly.
         coeffs = np.einsum('ij,nj->ni', pinv, boxes)
         c10 = coeffs[:, 1]
         c01 = coeffs[:, 2]
@@ -2850,7 +2835,7 @@ class SourceCatalog:
         quadratic centroid, ``[[var_x, cov_xy], [cov_xy, var_y]]``.
 
         Fallback sources hold the isophotal covariance (see
-        ``_centroid_err_cov``); matrices are all-NaN where errors are
+        ``_centroid_err_cov``). Matrices are all-NaN where errors are
         unavailable.
         """
         results = self._centroid_quad_results
@@ -3620,9 +3605,9 @@ class SourceCatalog:
         weights[[13, 23]] = (1 + np.sqrt(2.0)) / 2.0
 
         # Histogram of the convolved border-pixel patterns of each
-        # source (see batch_perimeter); the weights are applied with
+        # source (see batch_perimeter). The weights are applied with
         # einsum so the per-source arithmetic is independent of the
-        # number of sources
+        # number of sources.
         arrays = self._get_batch_arrays()
         iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         hist = batch_perimeter(
@@ -3689,8 +3674,7 @@ class SourceCatalog:
             # is non-negative for a real symmetric matrix. Clip tiny
             # negative rounding to zero.
             half_trace = 0.5 * (covar[:, 0, 0] + covar[:, 1, 1])
-            disc = np.maximum(half_trace**2 - self._raw_covariance_det,
-                              0.0)
+            disc = np.maximum(half_trace**2 - self._raw_covariance_det, 0.0)
             min_eigval = half_trace - np.sqrt(disc)
             degenerate = (np.isfinite(min_eigval)
                           & (min_eigval < 1.0 / 12.0))
@@ -3795,13 +3779,13 @@ class SourceCatalog:
         idx = np.unique(np.where(np.isfinite(self._covariance))[0])
         eigvals[idx] = np.linalg.eigvalsh(self._covariance[idx])
 
-        # Check for negative variance
-        # (just in case covariance matrix is not positive semidefinite)
+        # Check for negative variance (in case covariance matrix is not
+        # positive semidefinite).
         idx2 = np.unique(np.where(eigvals < 0)[0])
         eigvals[idx2] = (np.nan, np.nan)
 
-        # Sort each eigenvalue pair in descending order
-        # (eigvalsh returns values in ascending order)
+        # Sort each eigenvalue pair in descending order (eigvalsh
+        # returns values in ascending order).
         eigvals = np.fliplr(eigvals)
 
         return eigvals * u.pix**2

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -525,7 +525,11 @@ class SourceCatalog:
 
         self._custom_properties = []
         self._flux_radius_cache = {}
-        self._batch_arrays_cache = None
+        # The full-image arrays used by the batch Cython drivers, filled
+        # lazily by _get_batch_arrays. The dict is shared by reference
+        # with sliced catalogs (see __getitem__), so whichever catalog
+        # builds the arrays first populates it for all of them.
+        self._batch_arrays_cache = {}
         self.meta = _get_meta()
         self._update_meta()
 
@@ -868,8 +872,10 @@ class SourceCatalog:
 
         The dict holds float64 ``data`` and ``error`` arrays, a uint8
         ``mask`` plane (bit 1 = input mask, bit 2 = non-finite data),
-        and an intp ``segm`` array. The arrays are read-only inputs
-        shared by reference with sliced catalogs (see ``__getitem__``).
+        and an intp ``segm`` array. The dict itself is created in
+        ``__init__`` and shared by reference with sliced catalogs (see
+        ``__getitem__``), so the arrays are built once no matter which
+        of the parent or sliced catalogs first needs them.
 
         Returns
         -------
@@ -880,7 +886,8 @@ class SourceCatalog:
             keys are added lazily by ``_get_batch_convdata`` and
             ``_get_batch_background``.
         """
-        if self._batch_arrays_cache is None:
+        arrays = self._batch_arrays_cache
+        if 'data' not in arrays:
             data = np.ascontiguousarray(self._data, dtype=np.float64)
             error = None
             if self._error is not None:
@@ -891,10 +898,9 @@ class SourceCatalog:
             mask_plane[~np.isfinite(data)] |= 2
             segm = np.ascontiguousarray(
                 self._segmentation_image.data, dtype=np.intp)
-            self._batch_arrays_cache = {'data': data, 'error': error,
-                                        'mask': mask_plane,
-                                        'segm': segm}
-        return self._batch_arrays_cache
+            arrays.update(data=data, error=error, mask=mask_plane,
+                          segm=segm)
+        return arrays
 
     def _get_batch_convdata(self):
         """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -62,9 +62,101 @@ __all__ = ['SourceCatalog']
 _SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'correct': 3}
 
 
-def _batch_gini(packed, offsets, counts):
+class _SegmentValues:
     """
-    Compute the Gini coefficient of the packed pixel values of many
+    The unmasked pixel values within the segments of many sources,
+    packed into one array.
+
+    This is the container form of the ``batch_segment_gather`` outputs.
+    Indexing it with an integer, slice, index array, or boolean mask
+    returns a new container holding the selected sources (always at
+    least one), which lets `SourceCatalog.__getitem__` slice the cached
+    values along the source axis. Iterating over it yields the 1D
+    array of each source.
+
+    Parameters
+    ----------
+    packed : 1D `~numpy.ndarray`
+        The packed values of all sources in row-major pixel order, with
+        a single NaN placeholder for a source with no unmasked pixels.
+
+    offsets : 1D `~numpy.ndarray`
+        The start offset of each source in ``packed``, with length
+        ``n_sources + 1``.
+
+    counts : 1D `~numpy.ndarray`
+        The number of unmasked pixels of each source (zero for a
+        completely masked source, which occupies one placeholder slot).
+    """
+
+    __slots__ = ('counts', 'offsets', 'packed')
+
+    def __init__(self, packed, offsets, counts):
+        self.packed = packed
+        self.offsets = offsets
+        self.counts = counts
+
+    def __len__(self):
+        return len(self.counts)
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __getitem__(self, index):
+        idx = np.atleast_1d(np.arange(len(self))[index])
+        sizes = self.sizes[idx]
+        offsets = np.zeros(len(idx) + 1, dtype=np.intp)
+        np.cumsum(sizes, out=offsets[1:])
+        # The position of each selected value in the parent packed array
+        pos = (np.repeat(self.offsets[idx] - offsets[:-1], sizes)
+               + np.arange(offsets[-1]))
+        return _SegmentValues(self.packed[pos], offsets, self.counts[idx])
+
+    @property
+    def sizes(self):
+        """
+        The number of packed slots of each source (one for a completely
+        masked source).
+        """
+        return np.diff(self.offsets)
+
+    @property
+    def values(self):
+        """
+        A list of the 1D value arrays of each source (a single NaN for
+        a completely masked source).
+        """
+        return np.split(self.packed, self.offsets[1:-1])
+
+    def reduce(self, ufunc, *, transform=None):
+        """
+        Reduce the values of each source with a ufunc.
+
+        Parameters
+        ----------
+        ufunc : `~numpy.ufunc`
+            The NumPy ufunc to apply (e.g., `~numpy.add`,
+            `~numpy.minimum`, `~numpy.maximum`).
+
+        transform : callable or `None`, optional
+            An optional transformation to apply to the packed values
+            before reducing (e.g., `~numpy.square`).
+
+        Returns
+        -------
+        result : 1D `~numpy.ndarray`
+            The per-source reduction (NaN for a completely masked
+            source).
+        """
+        packed = self.packed
+        if transform is not None:
+            packed = transform(packed)
+        return ufunc.reduceat(packed, self.offsets[:-1])
+
+
+def _batch_gini(values):
+    """
+    Compute the Gini coefficient of the segment pixel values of many
     sources.
 
     This is the vectorized form of `photutils.morphology.gini` applied
@@ -74,24 +166,18 @@ def _batch_gini(packed, offsets, counts):
 
     Parameters
     ----------
-    packed : 1D `~numpy.ndarray`
-        The packed pixel values of all sources (see
-        ``batch_segment_gather``), with a single placeholder value for
-        a source with no pixels.
-
-    offsets : 1D `~numpy.ndarray`
-        The start offset of each source in ``packed`` (length
-        ``n_sources + 1``).
-
-    counts : 1D `~numpy.ndarray`
-        The number of pixels of each source.
+    values : `_SegmentValues`
+        The packed segment pixel values of the sources.
 
     Returns
     -------
     result : 1D `~numpy.ndarray`
         The Gini coefficient of each source.
     """
-    sizes = np.diff(offsets)
+    packed = values.packed
+    offsets = values.offsets
+    counts = values.counts
+    sizes = values.sizes
     starts = offsets[:-1]
     # Sort the absolute values within each source in place (a single
     # sort per source is much cheaper than one lexsort over all of the
@@ -761,7 +847,10 @@ class SourceCatalog:
                 # iterables. Such properties are never collapsed by
                 # __getattribute__ and internal code relies on them
                 # always being iterable.
-                if newcls.isscalar and key.startswith('_'):
+                if isinstance(value, _SegmentValues):
+                    # Always a container of at least one source
+                    val = value[index]
+                elif newcls.isscalar and key.startswith('_'):
                     if isinstance(value, np.ndarray):
                         val = value[:, np.newaxis][index]
                     else:
@@ -1614,13 +1703,7 @@ class SourceCatalog:
         """
         True if all pixels over the source segment are masked.
         """
-        # The gathered data values hold a single NaN for a completely
-        # masked source, and a non-finite data value is always masked,
-        # so no other source has a NaN value
-        values = self._data_values
-        sizes = np.array([arr.size for arr in values])
-        first = np.array([arr[0] for arr in values])
-        return (sizes == 1) & np.isnan(first)
+        return self._data_values.counts == 0
 
     @cached_property
     @_update_flags_docstring
@@ -1829,11 +1912,10 @@ class SourceCatalog:
 
     def _segment_values(self, array):
         """
-        Get a list of 1D arrays of the unmasked values of ``array``
-        within each source segment.
+        Get the unmasked values of ``array`` within each source segment
+        as a packed `_SegmentValues` container.
 
-        An array with a single NaN is returned for completely-masked
-        sources.
+        A single NaN is held for completely-masked sources.
 
         Parameters
         ----------
@@ -1842,86 +1924,45 @@ class SourceCatalog:
 
         Returns
         -------
-        result : list of 1D `~numpy.ndarray`
+        result : `_SegmentValues`
             The per-source values, in row-major pixel order.
         """
-        packed, offsets, _ = self._segment_gather(array)
-        return np.split(packed, offsets[1:-1])
-
-    @staticmethod
-    def _reduceat(values, ufunc, *, transform=None):
-        """
-        Apply ``ufunc.reduceat`` to a list of arrays.
-
-        This is significantly faster than a list comprehension with
-        individual NumPy calls for each array.
-
-        Parameters
-        ----------
-        values : list of 1D `~numpy.ndarray`
-            A list of 1D arrays.
-
-        ufunc : `~numpy.ufunc`
-            The NumPy ufunc to apply (e.g., `~numpy.add`,
-            `~numpy.minimum`, `~numpy.maximum`).
-
-        transform : callable or None, optional
-            An optional transformation to apply to the concatenated
-            array before reducing (e.g., `~numpy.square`).
-
-        Returns
-        -------
-        result : `~numpy.ndarray`
-            The reduceat result.
-
-        sizes : `~numpy.ndarray`
-            The sizes of the input arrays.
-        """
-        if not values:
-            return np.array([]), np.array([], dtype=int)
-
-        sizes = np.array([len(arr) for arr in values])
-        splits = np.concatenate(([0], np.cumsum(sizes[:-1])))
-        concat = np.concatenate(values)
-        if transform is not None:
-            concat = transform(concat)
-        return ufunc.reduceat(concat, splits), sizes
+        return _SegmentValues(*self._segment_gather(array))
 
     @cached_property
     def _data_values(self):
         """
-        A list of 1D arrays of the unmasked data values within each
-        source segment.
+        The unmasked data values within each source segment, as a
+        packed `_SegmentValues` container.
 
-        An array with a single NaN is returned for completely-masked
-        sources.
+        A single NaN is held for completely-masked sources.
         """
         return self._segment_values(self._get_batch_arrays()['data'])
 
     @cached_property
     def _error_values(self):
         """
-        A list of 1D arrays of the unmasked error values within each
-        source segment.
+        The unmasked error values within each source segment, as a
+        packed `_SegmentValues` container, or `None` if no error array
+        was input.
 
-        An array with a single NaN is returned for completely-masked
-        sources.
+        A single NaN is held for completely-masked sources.
         """
         if self._error is None:
-            return self._null_objects
+            return None
         return self._segment_values(self._get_batch_arrays()['error'])
 
     @cached_property
     def _background_values(self):
         """
-        A list of 1D arrays of the unmasked background values within
-        each source segment.
+        The unmasked background values within each source segment, as
+        a packed `_SegmentValues` container, or `None` if no background
+        array was input.
 
-        An array with a single NaN is returned for completely-masked
-        sources.
+        A single NaN is held for completely-masked sources.
         """
         if self._background is None:
-            return self._null_objects
+            return None
         return self._segment_values(self._get_batch_background())
 
     @cached_property
@@ -3218,7 +3259,7 @@ class SourceCatalog:
         The minimum pixel value of the ``data`` within the source
         segment.
         """
-        values, _ = self._reduceat(self._data_values, np.minimum)
+        values = self._data_values.reduce(np.minimum)
         values -= self._local_background
         if self._data_unit is not None:
             values <<= self._data_unit
@@ -3230,7 +3271,7 @@ class SourceCatalog:
         The maximum pixel value of the ``data`` within the source
         segment.
         """
-        values, _ = self._reduceat(self._data_values, np.maximum)
+        values = self._data_values.reduce(np.maximum)
         values -= self._local_background
         if self._data_unit is not None:
             values <<= self._data_unit
@@ -3363,13 +3404,14 @@ class SourceCatalog:
         Non-finite pixel values (NaN and inf) are excluded
         (automatically masked).
         """
-        source_sum, sizes = self._reduceat(self._data_values, np.add)
+        values = self._data_values
+        source_sum = values.reduce(np.add)
         # Subtract the local background over the number of unmasked
         # pixels actually included in the sum. The "area" property is
         # not used here because it is taken from the detection catalog
         # (if input), whose pixel count can differ when the data masks
         # differ.
-        source_sum -= sizes * self._local_background
+        source_sum -= values.counts * self._local_background
         if self._data_unit is not None:
             source_sum <<= self._data_unit
         return source_sum
@@ -3399,8 +3441,7 @@ class SourceCatalog:
         if self._error is None:
             err = self._null_values
         else:
-            err_sq, _ = self._reduceat(self._error_values, np.add,
-                                       transform=np.square)
+            err_sq = self._error_values.reduce(np.add, transform=np.square)
             err = np.sqrt(err_sq)
 
         if self._data_unit is not None:
@@ -3419,8 +3460,7 @@ class SourceCatalog:
         if self._background is None:
             bkg_sum = self._null_values
         else:
-            bkg_sum, _ = self._reduceat(
-                self._background_values, np.add)
+            bkg_sum = self._background_values.reduce(np.add)
 
         if self._data_unit is not None:
             bkg_sum <<= self._data_unit
@@ -3438,9 +3478,10 @@ class SourceCatalog:
         if self._background is None:
             bkg_mean = self._null_values
         else:
-            bkg_sum, sizes = self._reduceat(
-                self._background_values, np.add)
-            bkg_mean = bkg_sum / sizes
+            values = self._background_values
+            # The placeholder slot of a completely masked source keeps
+            # its (NaN) mean free of a division by zero
+            bkg_mean = values.reduce(np.add) / values.sizes
 
         if self._data_unit is not None:
             bkg_mean <<= self._data_unit
@@ -3498,7 +3539,7 @@ class SourceCatalog:
         if a mask is input to `SourceCatalog` or if the ``data`` within
         the segment contains invalid values (NaN and inf).
         """
-        areas = np.array([arr.size for arr in self._data_values]).astype(float)
+        areas = self._data_values.counts.astype(float)
         areas[self._all_masked] = np.nan
         return areas << (u.pix**2)
 
@@ -3960,9 +4001,7 @@ class SourceCatalog:
         from the calculation. If only a single finite pixel remains
         after filtering, the Gini coefficient is 0.0.
         """
-        packed, offsets, counts = self._segment_gather(
-            self._get_batch_arrays()['data'])
-        return _batch_gini(packed, offsets, counts)
+        return _batch_gini(self._data_values)
 
     @cached_property
     def _local_background_apertures(self):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -29,7 +29,6 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_VALID, SHAPE_CIRCLE,
                                                   SHAPE_ELLIPSE,
                                                   batch_aperture_sums)
-from photutils.aperture._batch_stats import batch_gini
 from photutils.aperture._segmentation import SEG_METHOD_CODES
 from photutils.background import SExtractorBackground
 from photutils.segmentation._batch_catalog import (batch_central_moments,
@@ -150,6 +149,63 @@ class _SegmentValues:
         if transform is not None:
             packed = transform(packed)
         return ufunc.reduceat(packed, self.offsets[:-1])
+
+
+def _batch_gini(values):
+    """
+    Compute the Gini coefficient of the segment pixel values of many
+    sources.
+
+    This is the vectorized form of `photutils.morphology.gini` applied
+    to each source's unmasked (finite) absolute pixel values: NaN for a
+    source with no pixels, 0.0 for a single pixel or a zero mean, and
+    otherwise the Lotz et al. (2004) sum over the sorted values.
+
+    The values of each source are sorted with NumPy in a Python loop
+    rather than with the compiled ``batch_gini`` kernel shared with
+    `~photutils.aperture.ApertureStats`, whose per-source ``qsort``
+    (with a comparison callback) is 2-2.5 times slower than NumPy's
+    sort for sources of ~50 or more pixels; the kernel is faster only
+    for very small sources (e.g., 3 versus 26 ms for 100k four-pixel
+    sources, but 43 versus 22 ms for 10k 144-pixel sources).
+
+    Parameters
+    ----------
+    values : `_SegmentValues`
+        The packed segment pixel values of the sources.
+
+    Returns
+    -------
+    result : 1D `~numpy.ndarray`
+        The Gini coefficient of each source.
+    """
+    packed = values.packed
+    offsets = values.offsets
+    counts = values.counts
+    sizes = values.sizes
+    starts = offsets[:-1]
+    # Sort the absolute values within each source in place (a single
+    # sort per source is much cheaper than one lexsort over all of the
+    # values); the placeholder values of empty sources are harmless
+    # because their results are set to NaN below
+    values = np.abs(np.nan_to_num(packed))
+    for start, stop in zip(starts, offsets[1:], strict=True):
+        values[start:stop].sort()
+    # 1-based rank of each value within its source
+    rank = np.arange(len(values)) - np.repeat(starts, sizes) + 1
+    n_pixels = np.repeat(counts, sizes)
+    kernel = (2.0 * rank - n_pixels - 1) * values
+
+    # Ignore RuntimeWarning from the empty and single-pixel sources
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        mean = np.add.reduceat(values, starts) / counts
+        normalization = mean * counts * (counts - 1)
+        result = np.add.reduceat(kernel, starts) / normalization
+    result[normalization == 0.0] = 0.0
+    result[counts == 1] = 0.0
+    result[counts == 0] = np.nan
+    return result
 
 
 # Remove in 4.0
@@ -3960,11 +4016,7 @@ class SourceCatalog:
         from the calculation. If only a single finite pixel remains
         after filtering, the Gini coefficient is 0.0.
         """
-        # The compiled kernel shared with ApertureStats takes the same
-        # packed layout (a completely masked source has a zero count and
-        # is set to NaN)
-        values = self._data_values
-        return batch_gini(values.packed, values.offsets[:-1], values.counts)
+        return _batch_gini(self._data_values)
 
     @cached_property
     def _local_background_apertures(self):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -36,6 +36,7 @@ from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_flux_radius_prepare,
                                                    batch_flux_radius_solve,
                                                    batch_kron_radius,
+                                                   batch_minmax_index,
                                                    batch_moment_err,
                                                    batch_perimeter,
                                                    batch_quad_boxes,
@@ -3294,6 +3295,53 @@ class SourceCatalog:
         return values
 
     @cached_property
+    def _cutout_minmax_index(self):
+        """
+        The cutout-frame ``(y_min, x_min, y_max, x_max)`` positions of
+        the first minimum and first maximum unmasked ``data`` value of
+        each source, as an ``(n_labels, 4)`` intp array with -1 for a
+        completely masked source (see ``batch_minmax_index``).
+        """
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        return batch_minmax_index(
+            arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
+            labels=self._batch_labels(), bbox_iymin=iymin,
+            bbox_iymax=iymax, bbox_ixmin=ixmin, bbox_ixmax=ixmax)
+
+    def _extreme_value_index(self, columns, *, origin):
+        """
+        Return the ``(y, x)`` positions of an extreme ``data`` value of
+        each source from ``_cutout_minmax_index``.
+
+        Parameters
+        ----------
+        columns : slice
+            The two columns of ``_cutout_minmax_index`` to return.
+
+        origin : bool
+            Whether to add the bounding-box origin, giving positions in
+            the full data array instead of the cutout frame.
+
+        Returns
+        -------
+        result : 2D `~numpy.ndarray`
+            The ``(n_labels, 2)`` positions, as integers, or as floats
+            with NaN rows for completely masked sources if there are
+            any.
+        """
+        # Private cached arrays keep their leading source axis for
+        # scalar catalogs, so they are read directly (not via _array)
+        index = self._cutout_minmax_index[:, columns]
+        if origin:
+            index = index + self._batch_bboxes[:, [0, 2]]
+        all_masked = self._all_masked
+        if np.any(all_masked):
+            index = index.astype(float)
+            index[all_masked] = np.nan
+        return index
+
+    @cached_property
     def cutout_min_value_index(self):
         """
         The ``(y, x)`` coordinate, relative to the cutout data, of the
@@ -3302,14 +3350,7 @@ class SourceCatalog:
         If there are multiple occurrences of the minimum value, only the
         first occurrence is returned.
         """
-        data = self._array('data_cutout_masked')
-        idx = []
-        for arr in data:
-            if np.all(arr.mask):
-                idx.append((np.nan, np.nan))
-            else:
-                idx.append(np.unravel_index(np.argmin(arr), arr.shape))
-        return np.array(idx)
+        return self._extreme_value_index(slice(0, 2), origin=False)
 
     @cached_property
     def cutout_max_value_index(self):
@@ -3320,14 +3361,7 @@ class SourceCatalog:
         If there are multiple occurrences of the maximum value, only the
         first occurrence is returned.
         """
-        data = self._array('data_cutout_masked')
-        idx = []
-        for arr in data:
-            if np.all(arr.mask):
-                idx.append((np.nan, np.nan))
-            else:
-                idx.append(np.unravel_index(np.argmax(arr), arr.shape))
-        return np.array(idx)
+        return self._extreme_value_index(slice(2, 4), origin=False)
 
     @cached_property
     def min_value_index(self):
@@ -3338,11 +3372,7 @@ class SourceCatalog:
         If there are multiple occurrences of the minimum value, only the
         first occurrence is returned.
         """
-        index = self._array('cutout_min_value_index')
-        out = []
-        for idx, slc in zip(index, self._slices_iter, strict=True):
-            out.append((idx[0] + slc[0].start, idx[1] + slc[1].start))
-        return np.array(out)
+        return self._extreme_value_index(slice(0, 2), origin=True)
 
     @cached_property
     def max_value_index(self):
@@ -3353,11 +3383,7 @@ class SourceCatalog:
         If there are multiple occurrences of the maximum value, only the
         first occurrence is returned.
         """
-        index = self._array('cutout_max_value_index')
-        out = []
-        for idx, slc in zip(index, self._slices_iter, strict=True):
-            out.append((idx[0] + slc[0].start, idx[1] + slc[1].start))
-        return np.array(out)
+        return self._extreme_value_index(slice(2, 4), origin=True)
 
     @cached_property
     def min_value_xindex(self):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -924,21 +924,36 @@ class SourceCatalog:
                 self._background, dtype=np.float64)
         return arrays['background']
 
+    def _batch_labels(self):
+        """
+        Return the source labels as the C-contiguous intp array used by
+        the batch Cython drivers.
+        """
+        return np.ascontiguousarray(np.atleast_1d(self.labels),
+                                    dtype=np.intp)
+
+    @cached_property
+    def _batch_bboxes(self):
+        """
+        The per-source segment bounding boxes as an ``(n_labels, 4)``
+        intp array with columns ``(iymin, iymax, ixmin, ixmax)``, where
+        the maxima are exclusive.
+
+        A 2D array (rather than a tuple of arrays) so that the cached
+        value is sliced along the source axis by ``__getitem__``.
+        """
+        bboxes = np.empty((len(self._slices_iter), 4), dtype=np.intp)
+        for i, (slc_y, slc_x) in enumerate(self._slices_iter):
+            bboxes[i] = (slc_y.start, slc_y.stop, slc_x.start, slc_x.stop)
+        return bboxes
+
     def _get_batch_bboxes(self):
         """
         Return the per-source segment bounding boxes as
-        ``(iymin, iymax, ixmin, ixmax)`` intp arrays.
+        ``(iymin, iymax, ixmin, ixmax)`` C-contiguous intp arrays.
         """
-        slices = self._slices_iter
-        iymin = np.array([slc[0].start for slc in slices],
-                         dtype=np.intp)
-        iymax = np.array([slc[0].stop for slc in slices],
-                         dtype=np.intp)
-        ixmin = np.array([slc[1].start for slc in slices],
-                         dtype=np.intp)
-        ixmax = np.array([slc[1].stop for slc in slices],
-                         dtype=np.intp)
-        return iymin, iymax, ixmin, ixmax
+        return tuple(np.ascontiguousarray(col)
+                     for col in self._batch_bboxes.T)
 
     @cached_property
     def isscalar(self):
@@ -1808,8 +1823,7 @@ class SourceCatalog:
         iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         return batch_segment_gather(
             array, mask=arrays['mask'], segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
             bbox_ixmax=ixmax)
 
@@ -1921,8 +1935,7 @@ class SourceCatalog:
         return batch_raw_moments(
             self._get_batch_convdata(), mask=arrays['mask'],
             segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
             bbox_ixmax=ixmax)
 
@@ -1939,8 +1952,7 @@ class SourceCatalog:
         return batch_central_moments(
             self._get_batch_convdata(), mask=arrays['mask'],
             segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
             bbox_ixmax=ixmax,
             xcen=np.ascontiguousarray(cutout_centroid[:, 0]),
@@ -2029,8 +2041,7 @@ class SourceCatalog:
         acc = batch_moment_err(
             arrays['error'], convdata=self._get_batch_convdata(),
             mask=arrays['mask'], segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
             bbox_ixmax=ixmax,
             xcen=np.ascontiguousarray(cutout_centroid[:, 0]),
@@ -2375,8 +2386,7 @@ class SourceCatalog:
         results = batch_centroid_win(
             arrays['data'], error=arrays['error'],
             mask=arrays['mask'], segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             xcen0=x_centroid, ycen0=y_centroid, sigma=sigma,
             skip=skip,
             seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],
@@ -2584,8 +2594,7 @@ class SourceCatalog:
         status, peak, boxes, box_var = batch_quad_boxes(
             arrays['data'], error=arrays['error'], mask=arrays['mask'],
             segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
             bbox_ixmax=ixmax, compute_err=int(compute_err))
         nx = ixmax - ixmin
@@ -3535,8 +3544,7 @@ class SourceCatalog:
         iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         hist = batch_perimeter(
             arrays['mask'], segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
             bbox_ixmax=ixmax)
         perimeter = np.einsum('nk,k->n', hist.astype(float), weights)
@@ -4322,8 +4330,7 @@ class SourceCatalog:
         arrays = self._get_batch_arrays()
         sums = batch_kron_radius(
             arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             xcen=xcen, ycen=ycen, semimajor=semimajor,
             semiminor=semiminor, theta=theta, cxx=cxx, cxy=cxy, cyy=cyy,
             skip=skip,
@@ -4826,8 +4833,7 @@ class SourceCatalog:
         arrays = self._get_batch_arrays()
         seg_code = _SEG_METHOD_CODES[self.aperture_mask_method]
         seg_arr = arrays['segm'] if seg_code != 0 else None
-        labels_arr = np.ascontiguousarray(np.atleast_1d(self.labels),
-                                          dtype=np.intp)
+        labels_arr = self._batch_labels()
         local_bkg = np.ascontiguousarray(self._local_background,
                                          dtype=np.float64)
         has_error = self._error is not None
@@ -5065,8 +5071,7 @@ class SourceCatalog:
         arrays = self._get_batch_arrays()
         return batch_flux_radius_prepare(
             arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
+            labels=self._batch_labels(),
             xcen=x_centroid, ycen=y_centroid, local_bkg=local_bkg,
             kronflux=kron_flux, max_radius=max_radius, skip=skip,
             seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1693,6 +1693,41 @@ class SourceCatalog:
                                      masked=True)
 
     @cached_property
+    def _segment_pixel_flags(self):
+        """
+        The bitwise OR of the pixel condition bits over each source
+        segment, as a uint8 array.
+
+        Bit 1 (value 1) is set if any segment pixel is input-masked,
+        bit 2 (value 2) if any segment ``data`` value is non-finite,
+        and bit 3 (value 4) if any segment ``error`` value is
+        non-finite. The bits are evaluated on every segment pixel,
+        including input-masked pixels.
+        """
+        arrays = self._get_batch_arrays()
+        pixel_flags = arrays['mask'].copy()
+        if arrays['error'] is not None:
+            pixel_flags[~np.isfinite(arrays['error'])] |= 4
+
+        # Gather the pixel flags of every segment pixel (the all-zero
+        # mask excludes nothing) and reduce them per source
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        packed, offsets, counts = batch_segment_gather(
+            pixel_flags.astype(np.float64),
+            mask=np.zeros(pixel_flags.shape, dtype=np.uint8),
+            segm=arrays['segm'], labels=self._batch_labels(),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax)
+
+        # A source without segment pixels holds a single NaN
+        # placeholder, whose integer cast is undefined
+        with np.errstate(invalid='ignore'):
+            packed = packed.astype(np.uint8)
+        segment_flags = np.bitwise_or.reduceat(packed, offsets[:-1])
+        segment_flags[counts == 0] = 0
+        return segment_flags
+
+    @cached_property
     def _all_masked(self):
         """
         True if all pixels over the source segment are masked.
@@ -1748,31 +1783,12 @@ class SourceCatalog:
                          for slc in self._slices_iter])
         flags[edge] |= SEGMENTATION_FLAGS.EDGE_TOUCH
 
-        # Input-masked pixels within the source segment
-        if self._mask is not None:
-            masked = np.array(
-                [np.any(mask_cut & ~segm_mask)
-                 for mask_cut, segm_mask in zip(
-                     self._mask_cutouts,
-                     self._cutout_segment_masks, strict=True)])
-            flags[masked] |= SEGMENTATION_FLAGS.MASKED_PIXELS
-
-        # Non-finite data values within the source segment
-        nonfinite = np.array(
-            [np.any(~np.isfinite(data_cut) & ~segm_mask)
-             for data_cut, segm_mask in zip(
-                 self._data_cutouts, self._cutout_segment_masks,
-                 strict=True)])
-        flags[nonfinite] |= SEGMENTATION_FLAGS.NON_FINITE_DATA
-
-        # Non-finite error values within the source segment
-        if self._error is not None:
-            nonfinite_err = np.array(
-                [np.any(~np.isfinite(err_cut) & ~segm_mask)
-                 for err_cut, segm_mask in zip(
-                     self._error_cutouts,
-                     self._cutout_segment_masks, strict=True)])
-            flags[nonfinite_err] |= SEGMENTATION_FLAGS.NON_FINITE_ERROR
+        # Input-masked, non-finite data, and non-finite error pixels
+        # within the source segment
+        pixel_flags = self._segment_pixel_flags
+        flags[(pixel_flags & 1) > 0] |= SEGMENTATION_FLAGS.MASKED_PIXELS
+        flags[(pixel_flags & 2) > 0] |= SEGMENTATION_FLAGS.NON_FINITE_DATA
+        flags[(pixel_flags & 4) > 0] |= SEGMENTATION_FLAGS.NON_FINITE_ERROR
 
         # All pixels within the source segment are masked
         flags[self._all_masked] |= SEGMENTATION_FLAGS.ALL_MASKED

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -30,13 +30,13 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   SHAPE_ELLIPSE,
                                                   batch_aperture_sums)
 from photutils.background import SExtractorBackground
-from photutils.morphology import gini as gini_func
 from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_centroid_win,
                                                    batch_flux_radius_prepare,
                                                    batch_flux_radius_solve,
                                                    batch_kron_radius,
                                                    batch_moment_err,
+                                                   batch_perimeter,
                                                    batch_quad_boxes,
                                                    batch_raw_moments,
                                                    batch_segment_gather)
@@ -60,6 +60,61 @@ __all__ = ['SourceCatalog']
 
 # Segmentation masking codes used by the batch Cython drivers
 _SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'correct': 3}
+
+
+def _batch_gini(packed, offsets, counts):
+    """
+    Compute the Gini coefficient of the packed pixel values of many
+    sources.
+
+    This is the vectorized form of `photutils.morphology.gini` applied
+    to each source's unmasked (finite) absolute pixel values: NaN for a
+    source with no pixels, 0.0 for a single pixel or a zero mean, and
+    otherwise the Lotz et al. (2004) sum over the sorted values.
+
+    Parameters
+    ----------
+    packed : 1D `~numpy.ndarray`
+        The packed pixel values of all sources (see
+        ``batch_segment_gather``), with a single placeholder value for
+        a source with no pixels.
+
+    offsets : 1D `~numpy.ndarray`
+        The start offset of each source in ``packed`` (length
+        ``n_sources + 1``).
+
+    counts : 1D `~numpy.ndarray`
+        The number of pixels of each source.
+
+    Returns
+    -------
+    result : 1D `~numpy.ndarray`
+        The Gini coefficient of each source.
+    """
+    sizes = np.diff(offsets)
+    starts = offsets[:-1]
+    # Sort the absolute values within each source in place (a single
+    # sort per source is much cheaper than one lexsort over all of the
+    # values); the placeholder values of empty sources are harmless
+    # because their results are set to NaN below
+    values = np.abs(np.nan_to_num(packed))
+    for start, stop in zip(starts, offsets[1:], strict=True):
+        values[start:stop].sort()
+    # 1-based rank of each value within its source
+    rank = np.arange(len(values)) - np.repeat(starts, sizes) + 1
+    n_pixels = np.repeat(counts, sizes)
+    kernel = (2.0 * rank - n_pixels - 1) * values
+
+    # Ignore RuntimeWarning from the empty and single-pixel sources
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        mean = np.add.reduceat(values, starts) / counts
+        normalization = mean * counts * (counts - 1)
+        result = np.add.reduceat(kernel, starts) / normalization
+    result[normalization == 0.0] = 0.0
+    result[counts == 1] = 0.0
+    result[counts == 0] = np.nan
+    return result
 
 
 # Remove in 4.0
@@ -1720,6 +1775,38 @@ class SourceCatalog:
         return {int(label): flags
                 for label, flags in zip(self.labels, decoded, strict=True)}
 
+    def _segment_gather(self, array):
+        """
+        Pack the unmasked values of ``array`` within each source
+        segment into one array (see ``batch_segment_gather``).
+
+        Parameters
+        ----------
+        array : 2D `~numpy.ndarray`
+            The C-contiguous float64 full-image array to gather from.
+
+        Returns
+        -------
+        packed : 1D `~numpy.ndarray`
+            The packed values of all sources, in row-major pixel order,
+            with a single NaN for a completely-masked source.
+
+        offsets : 1D `~numpy.ndarray`
+            The start offset of each source in ``packed`` (length
+            ``n_labels + 1``).
+
+        counts : 1D `~numpy.ndarray`
+            The number of unmasked segment pixels of each source.
+        """
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        return batch_segment_gather(
+            array, mask=arrays['mask'], segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax)
+
     def _segment_values(self, array):
         """
         Get a list of 1D arrays of the unmasked values of ``array``
@@ -1738,14 +1825,7 @@ class SourceCatalog:
         result : list of 1D `~numpy.ndarray`
             The per-source values, in row-major pixel order.
         """
-        arrays = self._get_batch_arrays()
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
-        packed, offsets, _ = batch_segment_gather(
-            array, mask=arrays['mask'], segm=arrays['segm'],
-            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
-                                        dtype=np.intp),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax)
+        packed, offsets, _ = self._segment_gather(array)
         return np.split(packed, offsets[1:-1])
 
     @staticmethod
@@ -3389,12 +3469,9 @@ class SourceCatalog:
         any data masking (i.e., a ``mask`` input to `SourceCatalog` or
         invalid ``data`` values).
         """
-        areas = []
-        for label, slices in zip(self.labels, self._slices_iter,
-                                 strict=True):
-            areas.append(np.count_nonzero(
-                self._segmentation_image[slices] == label))
-        return np.array(areas) << (u.pix**2)
+        segm = self._segmentation_image
+        areas = segm.areas[segm.get_indices(np.atleast_1d(self.labels))]
+        return np.asarray(areas, dtype=int) << (u.pix**2)
 
     @cached_property
     @use_detcat
@@ -3444,39 +3521,20 @@ class SourceCatalog:
         weights[[21, 33]] = np.sqrt(2.0)
         weights[[13, 23]] = (1 + np.sqrt(2.0)) / 2.0
 
-        perimeter = []
-        for mask in self._cutout_total_masks:
-            if np.all(mask):
-                perimeter.append(np.nan)
-                continue
-
-            ny, nx = mask.shape
-
-            # Pad source array with zeros (border_value=0)
-            padded = np.zeros((ny + 2, nx + 2), dtype=np.int8)
-            padded[1:-1, 1:-1] = ~mask
-
-            # Binary erosion with cross footprint (4-connectivity):
-            # a pixel is eroded if any 4-connected neighbor is 0
-            p = padded
-            eroded = (p[1:-1, 1:-1] & p[:-2, 1:-1] & p[2:, 1:-1]
-                      & p[1:-1, :-2] & p[1:-1, 2:])
-
-            # Border pixels are source pixels that were eroded away
-            border = np.zeros((ny + 2, nx + 2), dtype=np.int8)
-            border[1:-1, 1:-1] = padded[1:-1, 1:-1] & ~eroded
-
-            # Convolution with kernel [[10,2,10], [2,1,2], [10,2,10]]
-            b = border
-            conv = (10 * b[:-2, :-2] + 2 * b[:-2, 1:-1]
-                    + 10 * b[:-2, 2:] + 2 * b[1:-1, :-2]
-                    + b[1:-1, 1:-1] + 2 * b[1:-1, 2:]
-                    + 10 * b[2:, :-2] + 2 * b[2:, 1:-1]
-                    + 10 * b[2:, 2:])
-
-            hist = np.bincount(conv.ravel(), minlength=size)
-            perimeter.append(hist[:size] @ weights)
-
+        # Histogram of the convolved border-pixel patterns of each
+        # source (see batch_perimeter); the weights are applied with
+        # einsum so the per-source arithmetic is independent of the
+        # number of sources
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        hist = batch_perimeter(
+            arrays['mask'], segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax)
+        perimeter = np.einsum('nk,k->n', hist.astype(float), weights)
+        perimeter[self._all_masked] = np.nan
         return np.array(perimeter) * u.pix
 
     @cached_property
@@ -3888,7 +3946,9 @@ class SourceCatalog:
         from the calculation. If only a single finite pixel remains
         after filtering, the Gini coefficient is 0.0.
         """
-        return np.array([gini_func(arr) for arr in self._data_values])
+        packed, offsets, counts = self._segment_gather(
+            self._get_batch_arrays()['data'])
+        return _batch_gini(packed, offsets, counts)
 
     @cached_property
     def _local_background_apertures(self):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -306,9 +306,12 @@ class SourceCatalog:
 
     progress_bar : bool, optional
         Whether to display a progress bar when calculating properties.
-        All property calculations are now computed for all sources at
-        once in compiled code, so no progress bar is displayed. This
-        keyword is retained for backwards compatibility.
+
+        .. deprecated:: 3.1
+           This keyword argument is deprecated and will be removed in a
+           future version. All property calculations are now computed
+           for all sources at once in compiled code, so no progress bar
+           is displayed and this keyword has no effect.
 
     Notes
     -----
@@ -399,6 +402,7 @@ class SourceCatalog:
                                  '3.0', until='4.0')
     @deprecated_renamed_argument('detection_cat', 'detection_catalog', '3.0',
                                  until='4.0')
+    @deprecated_renamed_argument('progress_bar', None, '3.1', until='4.0')
     def __init__(self, data, segmentation_image, *, convolved_data=None,
                  error=None, mask=None, background=None, wcs=None,
                  local_bkg_width=0, aperture_mask_method='correct',

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -29,6 +29,7 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_VALID, SHAPE_CIRCLE,
                                                   SHAPE_ELLIPSE,
                                                   batch_aperture_sums)
+from photutils.aperture._batch_stats import batch_gini
 from photutils.aperture._segmentation import SEG_METHOD_CODES
 from photutils.background import SExtractorBackground
 from photutils.segmentation._batch_catalog import (batch_central_moments,
@@ -149,55 +150,6 @@ class _SegmentValues:
         if transform is not None:
             packed = transform(packed)
         return ufunc.reduceat(packed, self.offsets[:-1])
-
-
-def _batch_gini(values):
-    """
-    Compute the Gini coefficient of the segment pixel values of many
-    sources.
-
-    This is the vectorized form of `photutils.morphology.gini` applied
-    to each source's unmasked (finite) absolute pixel values: NaN for a
-    source with no pixels, 0.0 for a single pixel or a zero mean, and
-    otherwise the Lotz et al. (2004) sum over the sorted values.
-
-    Parameters
-    ----------
-    values : `_SegmentValues`
-        The packed segment pixel values of the sources.
-
-    Returns
-    -------
-    result : 1D `~numpy.ndarray`
-        The Gini coefficient of each source.
-    """
-    packed = values.packed
-    offsets = values.offsets
-    counts = values.counts
-    sizes = values.sizes
-    starts = offsets[:-1]
-    # Sort the absolute values within each source in place (a single
-    # sort per source is much cheaper than one lexsort over all of the
-    # values); the placeholder values of empty sources are harmless
-    # because their results are set to NaN below
-    values = np.abs(np.nan_to_num(packed))
-    for start, stop in zip(starts, offsets[1:], strict=True):
-        values[start:stop].sort()
-    # 1-based rank of each value within its source
-    rank = np.arange(len(values)) - np.repeat(starts, sizes) + 1
-    n_pixels = np.repeat(counts, sizes)
-    kernel = (2.0 * rank - n_pixels - 1) * values
-
-    # Ignore RuntimeWarning from the empty and single-pixel sources
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', RuntimeWarning)
-        mean = np.add.reduceat(values, starts) / counts
-        normalization = mean * counts * (counts - 1)
-        result = np.add.reduceat(kernel, starts) / normalization
-    result[normalization == 0.0] = 0.0
-    result[counts == 1] = 0.0
-    result[counts == 0] = np.nan
-    return result
 
 
 # Remove in 4.0
@@ -4008,7 +3960,11 @@ class SourceCatalog:
         from the calculation. If only a single finite pixel remains
         after filtering, the Gini coefficient is 0.0.
         """
-        return _batch_gini(self._data_values)
+        # The compiled kernel shared with ApertureStats takes the same
+        # packed layout (a completely masked source has a zero count and
+        # is set to NaN)
+        values = self._data_values
+        return batch_gini(values.packed, values.offsets[:-1], values.counts)
 
     @cached_property
     def _local_background_apertures(self):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -6,7 +6,6 @@ segmentation image.
 
 import functools
 import inspect
-import math
 import warnings
 from copy import deepcopy
 from functools import cached_property
@@ -34,6 +33,7 @@ from photutils.background import SExtractorBackground
 from photutils.morphology import gini as gini_func
 from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_centroid_win,
+                                                   batch_flux_radius_prepare,
                                                    batch_flux_radius_solve,
                                                    batch_kron_radius,
                                                    batch_moment_err,
@@ -41,7 +41,6 @@ from photutils.segmentation._batch_catalog import (batch_central_moments,
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
                                           decode_segmentation_flags)
-from photutils.segmentation.utils import _mask_to_mirrored_value
 from photutils.utils._deprecation import (_get_future_column_names,
                                           create_empty_deprecated_qtable,
                                           deprecated_getattr,
@@ -4990,117 +4989,47 @@ class SourceCatalog:
     @cached_property
     @use_detcat
     def _flux_radius_optimizer_args(self):
-        # NOTE: this cached property snapshots the current
-        # _aperture_mask_kwargs['flux_radius'] settings. Changing them
-        # (e.g., via _set_semode) after the first flux_radius call has
-        # no effect.
-        kron_flux = self._kron_photometry[:, 0]  # unitless
-        max_radius = self._max_circular_kron_radius
-        kwargs = self._aperture_mask_kwargs['flux_radius']
+        """
+        The prepared per-source arguments of the flux-radius root-find
+        (see ``batch_flux_radius_prepare``), always as a list with one
+        entry per source.
 
-        # Translate mask method keywords to circular_overlap_grid
-        # parameters once
-        method = kwargs.get('method', 'exact')
-        if method == 'exact':
-            use_exact = 1
-            subpixels = 1
-        elif method == 'center':
-            use_exact = 0
-            subpixels = 1
-        else:  # 'subpixel'
-            use_exact = 0
-            subpixels = kwargs.get('subpixels', 5)
+        Each entry is `None` for a source that cannot have a solution
+        or the list ``[clean_data, grid_params, kronflux,
+        max_radius]``. This cached property snapshots the current
+        ``_aperture_mask_kwargs['flux_radius']`` settings. Changing
+        them (e.g., via ``_set_semode``) after the first flux_radius
+        call has no effect.
+        """
+        kron_flux = np.ascontiguousarray(self._kron_photometry[:, 0],
+                                         dtype=np.float64)  # unitless
+        max_radius = np.ascontiguousarray(self._max_circular_kron_radius,
+                                          dtype=np.float64)
+        x_centroid = np.ascontiguousarray(np.atleast_1d(self.x_centroid),
+                                          dtype=np.float64)
+        y_centroid = np.ascontiguousarray(np.atleast_1d(self.y_centroid),
+                                          dtype=np.float64)
+        local_bkg = np.ascontiguousarray(self._local_background,
+                                         dtype=np.float64)
+        use_exact, subpixels = self._overlap_params(
+            self._aperture_mask_kwargs['flux_radius'])
 
-        # Pre-fetch arrays used inside the loop
-        data_arr = self._data
-        mask_arr = self._mask
-        segm_data = self._segmentation_image.data
-        data_shape = data_arr.shape
-        aperture_mask_method = self.aperture_mask_method
-        max_aper_size = max(data_arr.size, 1_000_000)
+        # Sources with a non-finite centroid, Kron flux, or maximum
+        # radius, or a zero Kron flux, have no solution
+        skip = (~np.isfinite(x_centroid) | ~np.isfinite(y_centroid)
+                | ~np.isfinite(kron_flux) | ~np.isfinite(max_radius)
+                | (kron_flux == 0)).astype(np.uint8)
 
-        labels = self.labels
-        if self.progress_bar:
-            desc = 'flux_radius prep'
-            labels = add_progress_bar(labels, desc=desc)
-
-        x_centroid = np.atleast_1d(self.x_centroid)
-        y_centroid = np.atleast_1d(self.y_centroid)
-
-        args = []
-        for label, xcen, ycen, kronflux, bkg, max_radius_ in zip(
-                labels, x_centroid, y_centroid,
-                kron_flux, self._local_background, max_radius, strict=True):
-
-            if (np.any(~np.isfinite((xcen, ycen, kronflux, max_radius_)))
-                    or kronflux == 0):
-                args.append(None)
-                continue
-
-            # Compute the bounding box for the max-radius aperture
-            # inline, replacing CircularAperture + _aperture_to_mask +
-            # _make_aperture_data
-            ixmin = math.floor(xcen - max_radius_ + 0.5)
-            ixmax = math.ceil(xcen + max_radius_ + 0.5)
-            iymin = math.floor(ycen - max_radius_ + 0.5)
-            iymax = math.ceil(ycen + max_radius_ + 0.5)
-
-            # OOM guard (same logic as _aperture_to_mask)
-            bbox_ny = iymax - iymin
-            bbox_nx = ixmax - ixmin
-            if bbox_ny * bbox_nx > max_aper_size:
-                args.append(None)
-                continue
-
-            # Clip to data boundaries
-            data_ymin = max(0, iymin)
-            data_ymax = min(data_shape[0], iymax)
-            data_xmin = max(0, ixmin)
-            data_xmax = min(data_shape[1], ixmax)
-            if data_ymin >= data_ymax or data_xmin >= data_xmax:
-                args.append(None)
-                continue
-
-            slc_lg = (slice(data_ymin, data_ymax), slice(data_xmin, data_xmax))
-            cutout_data = data_arr[slc_lg].astype(float) - bkg
-
-            # Build data mask (non-finite + user mask)
-            data_mask = ~np.isfinite(cutout_data)
-            if mask_arr is not None:
-                data_mask |= mask_arr[slc_lg]
-
-            # Cutout centroid position
-            cutout_xcen = xcen - data_xmin
-            cutout_ycen = ycen - data_ymin
-
-            # Handle neighboring sources
-            if aperture_mask_method != 'none':
-                seg_cut = segm_data[slc_lg]
-                segm_mask = (seg_cut != label) & (seg_cut != 0)
-                if aperture_mask_method == 'mask':
-                    data_mask = data_mask | segm_mask
-                elif aperture_mask_method == 'correct':
-                    cutout_data = _mask_to_mirrored_value(
-                        cutout_data, segm_mask,
-                        (cutout_xcen, cutout_ycen), mask=data_mask)
-
-            # Pre-zero masked pixels so the root-finding function can
-            # use a simple sum without masking
-            clean_data = cutout_data.copy()
-            clean_data[data_mask] = 0.0
-
-            # Pre-compute grid parameters for circular_overlap_grid
-            ny, nx = clean_data.shape
-            xmin_edge = -0.5 - cutout_xcen
-            xmax_edge = nx - 0.5 - cutout_xcen
-            ymin_edge = -0.5 - cutout_ycen
-            ymax_edge = ny - 0.5 - cutout_ycen
-            grid_params = (xmin_edge, xmax_edge, ymin_edge, ymax_edge,
-                           nx, ny, use_exact, subpixels)
-
-            args.append([clean_data, grid_params, kronflux, max_radius_])
-
-        return args
+        arrays = self._get_batch_arrays()
+        return batch_flux_radius_prepare(
+            arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            xcen=x_centroid, ycen=y_centroid, local_bkg=local_bkg,
+            kronflux=kron_flux, max_radius=max_radius, skip=skip,
+            seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],
+            use_exact=use_exact, subpixels=subpixels,
+            max_aper_size=max(self._data.size, 1_000_000))
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def flux_radius(self, fraction, name=None, overwrite=False):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -481,6 +481,16 @@ class SourceCatalog:
     `~photutils.segmentation.SourceCatalog.segment_flux` always includes
     the contribution of negative ``data`` values.
 
+    Most properties are computed for all sources at once in compiled
+    code that reads C-contiguous float64 copies of the ``data``,
+    ``error``, ``convolved_data``, and ``background`` arrays, a uint8
+    mask plane, and an intp copy of the segmentation array. These are
+    built on first use and kept for the lifetime of the catalog (they
+    are shared with sliced catalogs). Inputs that are already
+    C-contiguous float64 (or intp) arrays are used without a copy, so
+    for other input types (e.g., float32 or int32 arrays) the catalog
+    holds roughly twice the memory of its inputs.
+
     The input ``error`` array is assumed to include *all* sources
     of error, including the Poisson error of the sources.
     `~photutils.segmentation.SourceCatalog.segment_flux_err` is simply

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -163,11 +163,12 @@ def _batch_gini(values):
 
     The values of each source are sorted with NumPy in a Python loop
     rather than with the compiled ``batch_gini`` kernel shared with
-    `~photutils.aperture.ApertureStats`, whose per-source ``qsort``
-    (with a comparison callback) is 2-2.5 times slower than NumPy's
-    sort for sources of ~50 or more pixels; the kernel is faster only
-    for very small sources (e.g., 3 versus 26 ms for 100k four-pixel
-    sources, but 43 versus 22 ms for 10k 144-pixel sources).
+    `~photutils.aperture.ApertureStats`. NumPy's vectorized sort beats
+    the kernel's scalar introsort for sources of more than ~50 pixels
+    (e.g., 23 versus 31 ms for 10k 144-pixel sources and 50 versus 86
+    ms for 1k 2500-pixel sources); the kernel is faster only for very
+    small sources (2.5 versus 27 ms for 100k four-pixel sources), where
+    the per-source Python overhead of this loop dominates.
 
     Parameters
     ----------

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -4731,12 +4731,15 @@ class SourceCatalog:
         use_exact, subpixels = self._overlap_params(
             self._aperture_mask_kwargs['circ'])
 
-        (sums, sum_vars, _, overlap, _, _, _, _, _, fcounts,
-         _) = batch_aperture_sums(
+        result = batch_aperture_sums(
             arrays['data'], arrays['error'], arrays['mask'], positions,
             SHAPE_CIRCLE, np.array([radius], dtype=np.float64), radius,
             radius, 0.0, 0.0, use_exact, subpixels, seg_arr, seg_labels,
             seg_code, local_bkg, 0)
+        sums = result.sums
+        sum_vars = result.sum_vars
+        overlap = result.overlap
+        fcounts = result.flag_counts
 
         # Membership matches the previous cutout-based
         # ``in_aperture & ~mask`` rule: under 'correct', uncorrectable
@@ -4892,12 +4895,16 @@ class SourceCatalog:
             psrc = np.ascontiguousarray(psrc, dtype=np.float64)
             pos = np.ascontiguousarray(positions[idx])
             seg_labels = labels_arr[idx] if seg_code != 0 else None
-            (sums, sum_vars, _, overlap, _, _, _, _, _, fcounts,
-             weights_out) = batch_aperture_sums(
+            result = batch_aperture_sums(
                 arrays['data'], arrays['error'], arrays['mask'], pos,
                 shape_code, None, 0.0, 0.0, 0.0, 0.0, 1, 1, seg_arr,
                 seg_labels, seg_code, local_bkg[idx], 0,
                 params_per_source=psrc)
+            sums = result.sums
+            sum_vars = result.sum_vars
+            overlap = result.overlap
+            fcounts = result.flag_counts
+            weights_out = result.weights_out
 
             n_pix = fcounts[:, FLAG_COL_N_PIXELS]
             clipped = fcounts[:, FLAG_COL_BBOX_CLIPPED].astype(bool)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -16,7 +16,6 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
 from scipy.ndimage import map_coordinates
-from scipy.optimize import root_scalar
 
 from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture, RectangularAnnulus)
@@ -32,9 +31,9 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   SHAPE_ELLIPSE,
                                                   batch_aperture_sums)
 from photutils.background import SExtractorBackground
-from photutils.geometry import circular_overlap_grid
 from photutils.morphology import gini as gini_func
-from photutils.segmentation._batch_catalog import batch_centroid_win
+from photutils.segmentation._batch_catalog import (batch_centroid_win,
+                                                   batch_flux_radius_solve)
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
                                           decode_segmentation_flags)
@@ -5080,21 +5079,6 @@ class SourceCatalog:
             radius[mask] = self.kron_params[2]
         return radius
 
-    @staticmethod
-    def _flux_radius_fcn(radius, clean_data, grid_params, normflux):
-        """
-        Function whose root is found to compute the flux_radius.
-
-        Uses ``circular_overlap_grid`` directly on pre-computed cutout
-        data (with masked pixels zeroed) to avoid per-call aperture
-        object overhead.
-        """
-        xmin_e, xmax_e, ymin_e, ymax_e, nx, ny, exact, subpx = grid_params
-        weights = circular_overlap_grid(xmin_e, xmax_e, ymin_e, ymax_e,
-                                        nx, ny, radius, exact, subpx)
-        flux = np.sum(clean_data * weights)
-        return 1.0 - (flux / normflux)
-
     @cached_property
     @use_detcat
     def _flux_radius_optimizer_args(self):
@@ -5252,55 +5236,8 @@ class SourceCatalog:
             return self._make_scalar(result)
 
         args = self._flux_radius_optimizer_args
-        if self.progress_bar:
-            desc = 'flux_radius'
-            args = add_progress_bar(args, desc=desc)
-
-        radius = []
-        for flux_radius_args in args:
-            if flux_radius_args is None:
-                radius.append(np.nan)
-                continue
-
-            clean_data, grid_params, kronflux, max_radius = flux_radius_args
-            normflux = kronflux * fraction
-            fcn_args = (clean_data, grid_params, normflux)
-
-            # Try to find the root of self._flux_radius_func, which
-            # is bracketed by a min and max radius. A ValueError is
-            # raised if the bracket points do not have different signs,
-            # indicating no solution or multiple solutions (e.g., a
-            # multi-valued function). This can happen when at some
-            # radius, flux starts decreasing with increasing radius (due
-            # to negative data values), resulting in multiple possible
-            # solutions. If no solution is found, we iteratively
-            # decrease the max radius to narrow the bracket range until
-            # the root is found. If max radius drops below the min
-            # radius (0.1), then no solution is possible and NaN will be
-            # returned as the result.
-            found = False
-            min_radius = 0.1
-            max_radius_delta = 0.1 * max_radius
-            while max_radius > min_radius and found is False:
-                try:
-                    bracket = [min_radius, max_radius]
-                    result = root_scalar(self._flux_radius_fcn,
-                                         args=fcn_args, bracket=bracket,
-                                         method='brentq')
-                    result = result.root
-                    found = True
-                except ValueError:
-                    # ValueError is raised if the bracket points do not
-                    # have different signs
-                    max_radius -= max_radius_delta
-
-            # No solution found between min_radius and max_radius
-            if found is False:
-                result = np.nan
-
-            radius.append(result)
-
-        result = np.array(radius) << u.pix
+        radius = batch_flux_radius_solve(args, fraction=fraction)
+        result = radius << u.pix
         self._flux_radius_cache[fraction] = result
 
         if name is not None:

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -4744,6 +4744,58 @@ class SourceCatalog:
 
         return flux, flux_err
 
+    def _kron_aperture_params(self, kron_params):
+        """
+        Return the Kron aperture geometry of each source as arrays.
+
+        This is the array form of the apertures made by
+        ``_make_kron_apertures`` (see `kron_aperture`), without
+        constructing aperture objects.
+
+        Parameters
+        ----------
+        kron_params : tuple
+            The validated Kron parameters.
+
+        Returns
+        -------
+        xcen, ycen : 1D `~numpy.ndarray`
+            The aperture centers.
+
+        major, minor : 1D `~numpy.ndarray`
+            The semimajor and semiminor axes of the elliptical
+            apertures (the scaled Kron radius times the isophotal
+            axes).
+
+        theta : 1D `~numpy.ndarray`
+            The ellipse orientation in radians.
+
+        circular : 1D `~numpy.ndarray` (bool)
+            `True` where the aperture is instead the circle with the
+            minimum circular radius ``kron_params[2]`` (i.e., where the
+            Kron radius is zero).
+
+        defined : 1D `~numpy.ndarray` (bool)
+            `False` where the aperture is undefined (`None` in
+            `kron_aperture`): where the source is completely masked or
+            its centroid or elliptical shape parameters are not finite.
+        """
+        # NOTE: if kron_radius = NaN, scale = NaN and the aperture is
+        # undefined
+        kron_radius = self._calc_kron_radius(kron_params)
+        scale = kron_radius.value * kron_params[0]
+        xcen = np.atleast_1d(self.x_centroid)
+        ycen = np.atleast_1d(self.y_centroid)
+        major = np.atleast_1d(self.semimajor_axis.value) * scale
+        minor = np.atleast_1d(self.semiminor_axis.value) * scale
+        theta = np.atleast_1d(self.orientation.to_value(u.radian))
+        defined = (~self._all_masked & np.isfinite(xcen) & np.isfinite(ycen)
+                   & np.isfinite(major) & np.isfinite(minor)
+                   & np.isfinite(theta))
+        # kron_radius = 0 -> scale = 0 -> major/minor = 0
+        circular = defined & (major == 0) & (minor == 0)
+        return xcen, ycen, major, minor, theta, circular, defined
+
     def _calc_kron_photometry(self, *, kron_params=None):
         """
         Calculate the flux and flux error in the Kron aperture (without
@@ -4752,11 +4804,17 @@ class SourceCatalog:
         See the `SourceCatalog` ``aperture_mask_method`` keyword for
         options to mask neighboring sources.
 
-        If the Kron aperture is `None`, then ``np.nan`` will be
-        returned.
+        If the Kron aperture is undefined (`None` in `kron_aperture`),
+        then ``np.nan`` will be returned.
 
         If ``detection_catalog`` is input, then its `centroid` values
         will be used.
+
+        Parameters
+        ----------
+        kron_params : tuple or `None`, optional
+            The Kron parameters. If `None`, the apertures are those
+            of `kron_aperture` (from the detection catalog, if input).
 
         Returns
         -------
@@ -4765,61 +4823,51 @@ class SourceCatalog:
             `~photutils.segmentation.decode_segmentation_flags`).
         """
         if kron_params is None:
-            kron_aperture = self._array('kron_aperture')
+            # The geometry of the kron_aperture property, which is
+            # taken from the detection catalog if input
+            source = (self if self._detection_catalog is None
+                      else self._detection_catalog)
+            kron_params = source.kron_params
         else:
+            source = self
             kron_params = self._validate_kron_params(kron_params)
-            kron_aperture = self._make_kron_apertures(kron_params)
+        (xcen, ycen, major, minor, theta, circular,
+         defined) = source._kron_aperture_params(kron_params)
 
-        n_src = len(kron_aperture)
+        n_src = len(xcen)
         flux = np.full(n_src, np.nan)
         flux_err = np.full(n_src, np.nan)
         kron_flags = np.zeros(n_src, dtype=int)
+        kron_flags[~defined] = SEGMENTATION_FLAGS.KRON_UNDEFINED
 
+        # Exclude apertures whose bounding box would be unreasonably
+        # large (out-of-memory guard)
         max_size = max(self._data.size, 1_000_000)
-        _floor = math.floor
+        circ_radius = kron_params[2] if len(kron_params) == 3 else 0.0
+        # Ignore RuntimeWarning from non-finite values of undefined
+        # apertures
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            cos_t = np.cos(theta)
+            sin_t = np.sin(theta)
+            x_ext = np.sqrt((major * cos_t) ** 2 + (minor * sin_t) ** 2)
+            y_ext = np.sqrt((major * sin_t) ** 2 + (minor * cos_t) ** 2)
+            x_ext = np.where(circular, circ_radius, x_ext)
+            y_ext = np.where(circular, circ_radius, y_ext)
+            nx = (np.floor(xcen + x_ext + 1.5)
+                  - np.floor(xcen - x_ext + 0.5))
+            ny = (np.floor(ycen + y_ext + 1.5)
+                  - np.floor(ycen - y_ext + 0.5))
+            oversized = defined & (nx * ny > max_size)
+        kron_flags[oversized] = SEGMENTATION_FLAGS.KRON_UNDEFINED
+        usable = defined & ~oversized
 
-        # Pre-filter undefined and oversized apertures, and group the
-        # rest by aperture shape for the batch driver
-        circ_idx = []
-        circ_params = []
-        ell_idx = []
-        ell_params = []
-        positions = np.zeros((n_src, 2))
-        for i, aperture in enumerate(kron_aperture):
-            if aperture is None:
-                kron_flags[i] = SEGMENTATION_FLAGS.KRON_UNDEFINED
-                continue
-            xcen, ycen = aperture.positions
-            positions[i] = (xcen, ycen)
-            if isinstance(aperture, CircularAperture):
-                r = aperture.r
-                nx = _floor(xcen + r + 1.5) - _floor(xcen - r + 0.5)
-                ny = _floor(ycen + r + 1.5) - _floor(ycen - r + 0.5)
-                if nx * ny > max_size:
-                    kron_flags[i] = SEGMENTATION_FLAGS.KRON_UNDEFINED
-                    continue
-                circ_idx.append(i)
-                circ_params.append((r,))
-            else:
-                a = aperture.a
-                b = aperture.b
-                theta_val = aperture.theta
-                theta = (theta_val.to_value(u.radian)
-                         if hasattr(theta_val, 'to')
-                         else float(theta_val))
-                cos_t = math.cos(theta)
-                sin_t = math.sin(theta)
-                x_ext = math.sqrt((a * cos_t) ** 2 + (b * sin_t) ** 2)
-                y_ext = math.sqrt((a * sin_t) ** 2 + (b * cos_t) ** 2)
-                nx = (_floor(xcen + x_ext + 1.5)
-                      - _floor(xcen - x_ext + 0.5))
-                ny = (_floor(ycen + y_ext + 1.5)
-                      - _floor(ycen - y_ext + 0.5))
-                if nx * ny > max_size:
-                    kron_flags[i] = SEGMENTATION_FLAGS.KRON_UNDEFINED
-                    continue
-                ell_idx.append(i)
-                ell_params.append((a, b, theta))
+        # Group the apertures by shape for the batch driver
+        circ_idx = np.flatnonzero(usable & circular)
+        ell_idx = np.flatnonzero(usable & ~circular)
+        circ_params = np.full((len(circ_idx), 1), circ_radius)
+        ell_params = np.column_stack((major, minor, theta))[ell_idx]
+        positions = np.column_stack((xcen, ycen)).astype(float)
 
         arrays = self._get_batch_arrays()
         seg_code = _SEG_METHOD_CODES[self.aperture_mask_method]
@@ -4830,13 +4878,12 @@ class SourceCatalog:
                                          dtype=np.float64)
         has_error = self._error is not None
 
-        for idx, params_list, shape_code in (
+        for idx, psrc, shape_code in (
                 (circ_idx, circ_params, SHAPE_CIRCLE),
                 (ell_idx, ell_params, SHAPE_ELLIPSE)):
-            if not idx:
+            if idx.size == 0:
                 continue
-            idx = np.array(idx)
-            psrc = np.ascontiguousarray(params_list, dtype=np.float64)
+            psrc = np.ascontiguousarray(psrc, dtype=np.float64)
             pos = np.ascontiguousarray(positions[idx])
             seg_labels = labels_arr[idx] if seg_code != 0 else None
             (sums, sum_vars, _, overlap, _, _, _, _, _, fcounts,

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -23,6 +23,7 @@ from photutils.aperture import (BoundingBox, CircularAperture,
 from photutils.background import SExtractorBackground
 from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
 from photutils.morphology import gini as gini_func
+from photutils.segmentation._batch_catalog import batch_centroid_win
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
                                           decode_segmentation_flags)
@@ -41,6 +42,10 @@ from photutils.utils._wcs_helpers import compute_pixel_to_sky_jacobians
 from photutils.utils.cutouts import CutoutImage
 
 __all__ = ['SourceCatalog']
+
+
+# Segmentation masking codes used by the batch Cython drivers
+_SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'correct': 3}
 
 
 # Remove in 4.0
@@ -288,7 +293,7 @@ class SourceCatalog:
     progress_bar : bool, optional
         Whether to display a progress bar when calculating
         some properties (e.g., ``kron_radius``, ``kron_flux``,
-        ``flux_radius``, ``circular_photometry``, ``centroid_win``,
+        ``flux_radius``, ``circular_photometry``,
         ``centroid_quad``). The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
 
@@ -448,6 +453,7 @@ class SourceCatalog:
 
         self._custom_properties = []
         self._flux_radius_cache = {}
+        self._batch_arrays_cache = None
         self.meta = _get_meta()
         self._update_meta()
 
@@ -627,7 +633,7 @@ class SourceCatalog:
         init_attr = ('_data', '_segmentation_image', '_error', '_mask',
                      '_background', 'wcs', '_data_unit', '_convolved_data',
                      'local_bkg_width', 'aperture_mask_method',
-                     'kron_params', 'progress_bar')
+                     'kron_params', 'progress_bar', '_batch_arrays_cache')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
@@ -782,6 +788,39 @@ class SourceCatalog:
         if isinstance(value, np.ndarray):
             return value[np.newaxis, ...]
         return [value]
+
+    def _get_batch_arrays(self):
+        """
+        Return the cached C-contiguous full-image arrays used by the
+        batch Cython drivers.
+
+        The dict holds float64 ``data`` and ``error`` arrays, a uint8
+        ``mask`` plane (bit 1 = input mask, bit 2 = non-finite data),
+        and an intp ``segm`` array. The arrays are read-only inputs
+        shared by reference with sliced catalogs (see ``__getitem__``).
+
+        Returns
+        -------
+        result : dict
+            A dict with keys ``'data'``, ``'error'``, ``'mask'``, and
+            ``'segm'``. The ``'error'`` value is `None` if no error
+            array was input.
+        """
+        if self._batch_arrays_cache is None:
+            data = np.ascontiguousarray(self._data, dtype=np.float64)
+            error = None
+            if self._error is not None:
+                error = np.ascontiguousarray(self._error, dtype=np.float64)
+            mask_plane = np.zeros(data.shape, dtype=np.uint8)
+            if self._mask is not None:
+                mask_plane[self._mask] |= 1
+            mask_plane[~np.isfinite(data)] |= 2
+            segm = np.ascontiguousarray(
+                self._segmentation_image.data, dtype=np.intp)
+            self._batch_arrays_cache = {'data': data, 'error': error,
+                                        'mask': mask_plane,
+                                        'segm': segm}
+        return self._batch_arrays_cache
 
     @cached_property
     def isscalar(self):
@@ -2152,222 +2191,6 @@ class SourceCatalog:
         return np.transpose((xcen_win, ycen_win, win_err_var_x,
                              win_err_var_y, win_err_cov_xy, fallback))
 
-    def _iterate_centroid_win(self, label, xcen, ycen, rad_hl,
-                              nan_hl_source, *, data_arr, mask_arr,
-                              error_arr, segm_data, data_shape,
-                              do_correct, do_segm_mask, compute_err,
-                              max_aper_size):
-        """
-        Compute the windowed centroid for a single source.
-
-        Parameters
-        ----------
-        label : int
-            The source label.
-
-        xcen : float
-            Initial x centroid (isophotal).
-
-        ycen : float
-            Initial y centroid (isophotal).
-
-        rad_hl : float
-            Half-light radius for this source.
-
-        nan_hl_source : bool
-            Whether the half-light radius is NaN.
-
-        data_arr : `~numpy.ndarray`
-            The 2D data array.
-
-        mask_arr : `~numpy.ndarray` or `None`
-            The 2D boolean mask array.
-
-        error_arr : `~numpy.ndarray` or `None`
-            The 2D error array.
-
-        segm_data : `~numpy.ndarray`
-            The segmentation image data array.
-
-        data_shape : tuple of int
-            Shape of the data array.
-
-        do_correct : bool
-            Whether to apply mirror correction for masked pixels.
-
-        do_segm_mask : bool
-            Whether to mask pixels outside the source segment.
-
-        compute_err : bool
-            Whether to compute position errors.
-
-        max_aper_size : int
-            Maximum aperture size (OOM guard).
-
-        Returns
-        -------
-        result : tuple of float
-            Tuple of (xcen, ycen, weighted_flux, cen_mom_xx,
-            cen_mom_yy, cen_mom_xy, err_sum, err_var_x, err_var_y,
-            err_cov_xy). The error terms are the raw (unnormalized)
-            weighted sums from the last iteration (see
-            ``_normalize_centroid_win_err``).
-        """
-        nan_result = (np.nan, np.nan, 0.0, 0.0, 0.0, 0.0,
-                      np.nan, np.nan, np.nan, np.nan)
-        if nan_hl_source or math.isnan(xcen) or math.isnan(ycen):
-            return nan_result
-
-        sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
-        inv_2sigma2 = -1.0 / (2.0 * sigma * sigma)
-        radius = 4.0 * sigma
-        radius_sq = radius * radius
-
-        # Compute the full (unclipped) bounding box for the aperture
-        # using the initial centroid. The radius is fixed, so the
-        # bbox size stays the same across iterations even if the
-        # center shifts slightly.
-        bbox_halfsize = int(radius + 1.5)
-        full_ny = full_nx = 2 * bbox_halfsize + 1
-
-        # OOM guard
-        if full_ny * full_nx > max_aper_size:
-            return nan_result
-
-        # Cache for cutout data when the integer bbox doesn't change
-        prev_ixcen = prev_iycen = None
-        cached_data = cached_mask = cached_var = None
-
-        max_iters = 16
-        centroid_threshold = 0.0001
-        iter_ = 0
-        dcen = 1.0
-        weighted_flux = 0.0
-        dx_mom = dy_mom = 0.0
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            while iter_ < max_iters and dcen > centroid_threshold:
-                # Compute integer bounding box
-                ixmin = int(xcen + 0.5) - bbox_halfsize
-                ixmax = ixmin + full_nx
-                iymin = int(ycen + 0.5) - bbox_halfsize
-                iymax = iymin + full_ny
-
-                # Clip to data boundaries
-                slc_y = slice(max(0, iymin), min(data_shape[0], iymax))
-                slc_x = slice(max(0, ixmin), min(data_shape[1], ixmax))
-                if (slc_y.start >= slc_y.stop
-                        or slc_x.start >= slc_x.stop):
-                    xcen = np.nan
-                    ycen = np.nan
-                    break
-
-                cur_ixcen = int(xcen + 0.5)
-                cur_iycen = int(ycen + 0.5)
-
-                # Recompute cutout data only when the integer center
-                # changes to avoid redundant _mask_to_mirrored_value
-                # calls
-                if cur_ixcen != prev_ixcen or cur_iycen != prev_iycen:
-                    prev_ixcen = cur_ixcen
-                    prev_iycen = cur_iycen
-
-                    data = data_arr[slc_y, slc_x].astype(float)
-                    data_mask = ~np.isfinite(data)
-                    if mask_arr is not None:
-                        data_mask |= mask_arr[slc_y, slc_x]
-
-                    cutout_xycen = (xcen - max(0, ixmin),
-                                    ycen - max(0, iymin))
-
-                    if do_segm_mask:
-                        seg_cut = segm_data[slc_y, slc_x]
-                        segm_mask = ((seg_cut != label)
-                                     & (seg_cut != 0))
-                        if self.aperture_mask_method == 'mask':
-                            data_mask = data_mask | segm_mask
-
-                    if do_correct:
-                        data = _mask_to_mirrored_value(
-                            data, segm_mask, cutout_xycen,
-                            mask=data_mask)
-
-                    cached_data = data
-                    cached_mask = data_mask
-
-                    if compute_err:
-                        var = error_arr[slc_y, slc_x].astype(float)**2
-                        if do_correct:
-                            # Pixels replaced by mirrored data values
-                            # also use the mirrored pixel's variance
-                            var = _mask_to_mirrored_value(
-                                var, segm_mask, cutout_xycen,
-                                mask=data_mask)
-                        var[data_mask] = 0.0
-                        cached_var = var
-
-                # Centroid position in cutout coordinates
-                cx = xcen - max(0, ixmin)
-                cy = ycen - max(0, iymin)
-
-                ny = slc_y.stop - slc_y.start
-                nx = slc_x.stop - slc_x.start
-
-                # Build coordinate grids relative to centroid
-                # (reused for circle mask, Gaussian, and moments)
-                xvals = np.arange(nx) - cx
-                yvals = np.arange(ny) - cy
-                xx = xvals[np.newaxis, :]
-                yy = yvals[:, np.newaxis]
-
-                # Inline binary circle mask
-                rr2 = xx * xx + yy * yy
-                aper_weights = (rr2 <= radius_sq).astype(float)
-
-                # Inline Gaussian weight
-                gweight = np.exp(rr2 * inv_2sigma2)
-
-                # Apply weights and mask
-                weighted = (cached_data * aper_weights * gweight)
-                weighted[cached_mask] = 0.0
-
-                # Inline moment computation
-                weighted_flux = np.sum(weighted)
-                dx_mom = np.sum(weighted * xx) / weighted_flux
-                dy_mom = np.sum(weighted * yy) / weighted_flux
-
-                dcen = math.sqrt(dx_mom * dx_mom
-                                 + dy_mom * dy_mom)
-                xcen += dx_mom * 2.0
-                ycen += dy_mom * 2.0
-                iter_ += 1
-
-            # Compute the windowed central 2nd-order moments (for
-            # the fallback checks) and the raw error
-            # sums from the last iteration, relative to
-            # the pre-update center.
-            cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
-            err_sum = err_var_x = err_var_y = err_cov_xy = np.nan
-            if np.isfinite(weighted_flux) and weighted_flux > 0:
-                cen_mom_xx = (np.sum(weighted * xx * xx)
-                              / weighted_flux - dx_mom * dx_mom)
-                cen_mom_yy = (np.sum(weighted * yy * yy)
-                              / weighted_flux - dy_mom * dy_mom)
-                cen_mom_xy = (np.sum(weighted * xx * yy)
-                              / weighted_flux - dx_mom * dy_mom)
-
-                if compute_err:
-                    weighted_var = ((aper_weights * gweight)**2
-                                    * cached_var)
-                    err_sum = np.sum(weighted_var)
-                    err_var_x = np.sum(weighted_var * xx * xx)
-                    err_var_y = np.sum(weighted_var * yy * yy)
-                    err_cov_xy = np.sum(weighted_var * xx * yy)
-
-        return (xcen, ycen, weighted_flux, cen_mom_xx,
-                cen_mom_yy, cen_mom_xy,
-                err_sum, err_var_x, err_var_y, err_cov_xy)
-
     @cached_property
     @use_detcat
     def _centroid_win_results(self):
@@ -2403,49 +2226,31 @@ class SourceCatalog:
 
         compute_err = self._error is not None
 
-        labels = self.labels
-        if self.progress_bar:
-            desc = 'centroid_win'
-            labels = add_progress_bar(labels, desc=desc)
-
         # Centroids as iterable arrays regardless of scalar state
-        x_centroid = np.atleast_1d(self.x_centroid)
-        y_centroid = np.atleast_1d(self.y_centroid)
+        x_centroid = np.atleast_1d(self.x_centroid).astype(float)
+        y_centroid = np.atleast_1d(self.y_centroid).astype(float)
 
-        # Pre-fetch arrays used in the inner loop
-        data_arr = self._data
-        mask_arr = self._mask
-        error_arr = self._error
-        segm_data = self._segmentation_image.data
-        data_shape = data_arr.shape
-        do_correct = self.aperture_mask_method == 'correct'
-        do_segm_mask = self.aperture_mask_method != 'none'
-        max_aper_size = max(data_arr.size, 1_000_000)
-
-        iter_kwargs = {
-            'data_arr': data_arr,
-            'mask_arr': mask_arr,
-            'error_arr': error_arr,
-            'segm_data': segm_data,
-            'data_shape': data_shape,
-            'do_correct': do_correct,
-            'do_segm_mask': do_segm_mask,
-            'compute_err': compute_err,
-            'max_aper_size': max_aper_size,
-        }
-
-        results = []
-        for label, xcen, ycen, rad_hl, nan_hl_source in zip(
-                labels, x_centroid, y_centroid, radius_hl, nan_hl,
-                strict=True):
-            results.append(self._iterate_centroid_win(
-                label, xcen, ycen, rad_hl, nan_hl_source, **iter_kwargs))
+        sigma = 2.0 * radius_hl * gaussian_fwhm_to_sigma
+        # np.isnan (not ~np.isfinite) for parity with the previous
+        # per-source math.isnan checks
+        skip = (nan_hl | np.isnan(x_centroid)
+                | np.isnan(y_centroid)).astype(np.uint8)
+        arrays = self._get_batch_arrays()
+        results = batch_centroid_win(
+            arrays['data'], error=arrays['error'],
+            mask=arrays['mask'], segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            xcen0=x_centroid, ycen0=y_centroid, sigma=sigma,
+            skip=skip,
+            seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],
+            compute_err=int(compute_err),
+            max_aper_size=max(self._data.size, 1_000_000))
 
         (xcen_win, ycen_win, win_weighted_flux,
          win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
          win_err_sum, win_err_var_x, win_err_var_y,
-         win_err_cov_xy) = (np.array(col)
-                            for col in zip(*results, strict=True))
+         win_err_cov_xy) = results.T.copy()
 
         # Normalize error terms by step_factor^2 / weighted_flux^2
         if compute_err:

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -29,6 +29,7 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_VALID, SHAPE_CIRCLE,
                                                   SHAPE_ELLIPSE,
                                                   batch_aperture_sums)
+from photutils.aperture._segmentation import SEG_METHOD_CODES
 from photutils.background import SExtractorBackground
 from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_centroid_win,
@@ -56,10 +57,6 @@ from photutils.utils._wcs_helpers import compute_pixel_to_sky_jacobians
 from photutils.utils.cutouts import CutoutImage
 
 __all__ = ['SourceCatalog']
-
-
-# Segmentation masking codes used by the batch Cython drivers
-_SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'correct': 3}
 
 
 class _SegmentValues:
@@ -2430,7 +2427,7 @@ class SourceCatalog:
             labels=self._batch_labels(),
             xcen0=x_centroid, ycen0=y_centroid, sigma=sigma,
             skip=skip,
-            seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],
+            seg_method=SEG_METHOD_CODES[self.aperture_mask_method],
             compute_err=int(compute_err),
             max_aper_size=max(self._data.size, 1_000_000))
 
@@ -4373,7 +4370,7 @@ class SourceCatalog:
             xcen=xcen, ycen=ycen, semimajor=semimajor,
             semiminor=semiminor, theta=theta, cxx=cxx, cxy=cxy, cyy=cyy,
             skip=skip,
-            seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],
+            seg_method=SEG_METHOD_CODES[self.aperture_mask_method],
             scale=scale, min_circ_radius=min_circ_radius,
             max_aper_size=max(self._data.size, 1_000_000))
         flux_numer = sums[:, 0]
@@ -4710,7 +4707,7 @@ class SourceCatalog:
             return flux, flux_err
 
         arrays = self._get_batch_arrays()
-        seg_code = _SEG_METHOD_CODES[self.aperture_mask_method]
+        seg_code = SEG_METHOD_CODES[self.aperture_mask_method]
         seg_arr = None
         seg_labels = None
         if seg_code != 0:
@@ -4870,7 +4867,7 @@ class SourceCatalog:
         positions = np.column_stack((xcen, ycen)).astype(float)
 
         arrays = self._get_batch_arrays()
-        seg_code = _SEG_METHOD_CODES[self.aperture_mask_method]
+        seg_code = SEG_METHOD_CODES[self.aperture_mask_method]
         seg_arr = arrays['segm'] if seg_code != 0 else None
         labels_arr = self._batch_labels()
         local_bkg = np.ascontiguousarray(self._local_background,
@@ -5113,7 +5110,7 @@ class SourceCatalog:
             labels=self._batch_labels(),
             xcen=x_centroid, ycen=y_centroid, local_bkg=local_bkg,
             kronflux=kron_flux, max_radius=max_radius, skip=skip,
-            seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],
+            seg_method=SEG_METHOD_CODES[self.aperture_mask_method],
             use_exact=use_exact, subpixels=subpixels,
             max_aper_size=max(self._data.size, 1_000_000))
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -846,8 +846,11 @@ class SourceCatalog:
             value = [value]
         setattr(newcls, attr, value)
 
-        # Slice the flux_radius cache values
-        newcls._flux_radius_cache = {key: value[index]
+        # Slice the flux_radius cache values. Like the other private
+        # per-source attributes, the cached arrays keep a length-1
+        # leading axis for a scalar catalog.
+        cache_index = [index] if newcls.isscalar else index
+        newcls._flux_radius_cache = {key: value[cache_index]
                                      for key, value
                                      in self._flux_radius_cache.items()}
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -4013,89 +4013,6 @@ class SourceCatalog:
             bkg <<= self._data_unit
         return bkg
 
-    def _aperture_to_mask(self, aperture, **kwargs):
-        """
-        Call ``aperture.to_mask()``, but first check that the aperture
-        bounding box is not larger than the input data to prevent
-        out-of-memory errors from pathologically large apertures.
-
-        The aperture mask is allocated at the full (unclipped) bounding
-        box size by ``to_mask()``, before ``get_overlap_slices`` clips
-        it to the data shape. For pathological apertures (e.g., from
-        huge Kron radii), this allocation can cause out-of-memory
-        issues.
-
-        Returns `None` if the aperture mask would be unreasonably large.
-        """
-        bbox = aperture.bbox
-        # Limit the aperture mask size to prevent OOM errors
-        max_size = max(self._data.size, 1_000_000)
-        if bbox.shape[0] * bbox.shape[1] > max_size:
-            return None
-        return aperture.to_mask(**kwargs)
-
-    def _make_aperture_data(self, label, x_centroid, y_centroid, aperture_bbox,
-                            local_background, *, make_error=True):
-        """
-        Make cutouts of data, error, and mask arrays for aperture
-        photometry (e.g., circular or Kron).
-
-        Neighboring sources can be included, masked, or corrected based
-        on the ``aperture_mask_method`` keyword.
-
-        The last returned value is a dictionary of the cutout masks
-        needed to compute the aperture quality flags. Its ``segm_mask``
-        and ``uncorrected_mask`` values are `None` where they do not
-        apply (i.e., for an ``aperture_mask_method`` of "none" and for a
-        method other than "correct", respectively).
-        """
-        # Make cutouts of the data based on the aperture bbox
-        slc_lg, slc_sm = aperture_bbox.get_overlap_slices(self._data.shape)
-        if slc_lg is None:
-            return (None,) * 6
-
-        data = self._data[slc_lg].astype(float) - local_background
-
-        mask_cutout = None if self._mask is None else self._mask[slc_lg]
-        data_mask = self._make_cutout_data_mask(data, mask_cutout)
-
-        if make_error and self._error is not None:
-            error = self._error[slc_lg]
-        else:
-            error = None
-
-        # Calculate cutout centroid position
-        cutout_xycen = (x_centroid - max(0, aperture_bbox.ixmin),
-                        y_centroid - max(0, aperture_bbox.iymin))
-
-        # Mask or correct neighboring sources
-        segm_mask = None
-        uncorrected_mask = None
-        if self.aperture_mask_method == 'none':
-            mask = data_mask
-        else:
-            segment_img = self._segmentation_image.data[slc_lg]
-            segm_mask = np.logical_and(segment_img != label,
-                                       segment_img != 0)
-            if self.aperture_mask_method == 'mask':
-                mask = data_mask | segm_mask
-            else:
-                mask = data_mask
-
-        if self.aperture_mask_method == 'correct':
-            data, uncorrected_mask = _mask_to_mirrored_value(
-                data, segm_mask, cutout_xycen, mask=mask,
-                return_uncorrected=True)
-            if error is not None:
-                error = _mask_to_mirrored_value(error, segm_mask, cutout_xycen,
-                                                mask=mask)
-
-        flag_masks = {'data_mask': data_mask,
-                      'segm_mask': segm_mask,
-                      'uncorrected_mask': uncorrected_mask}
-
-        return data, error, mask, cutout_xycen, slc_sm, flag_masks
-
     def _make_circular_apertures(self, radius):
         """
         Make circular aperture for each source.
@@ -4248,11 +4165,7 @@ class SourceCatalog:
             msg = 'radius must be > 0'
             raise ValueError(msg)
 
-        apertures = self._make_circular_apertures(radius)
-        kwargs = self._aperture_mask_kwargs['circ']
-        flux, flux_err = self._aperture_photometry(apertures,
-                                                   desc='circular_photometry',
-                                                   **kwargs)
+        flux, flux_err = self._calc_circular_photometry(radius)
 
         if self._data_unit is not None:
             flux <<= self._data_unit
@@ -4724,78 +4637,110 @@ class SourceCatalog:
                 patches.append(aperture._to_patch(origin=origin, **kwargs))
         return self._make_scalar(patches)
 
-    def _aperture_photometry(self, apertures, *, desc='', **kwargs):
+    @staticmethod
+    def _overlap_params(kwargs):
         """
-        Perform aperture photometry on cutouts of the data and optional
-        error arrays.
-
-        The appropriate ``aperture_mask_method`` is applied to the
-        cutouts to handle neighboring sources.
+        Translate aperture ``to_mask`` keyword arguments to the
+        ``(use_exact, subpixels)`` overlap parameters of the batch
+        drivers.
 
         Parameters
         ----------
-        apertures : list of `PixelAperture`
-            A list of the apertures.
-
-        desc : str, optional
-            The description displayed before the progress bar.
-
-        **kwargs : dict, optional
-            Additional keyword arguments passed to the aperture
-            ``to_mask`` method.
+        kwargs : dict
+            The ``to_mask`` keyword arguments (``method`` and, for the
+            subpixel method, ``subpixels``).
 
         Returns
         -------
-        flux, flux_err : 1D `~numpy.ndaray`
-            The flux and flux error arrays.
+        use_exact, subpixels : int
+            The overlap parameters.
         """
-        labels = self.labels
-        if self.progress_bar:
-            labels = add_progress_bar(labels, desc=desc)
+        method = kwargs.get('method', 'exact')
+        if method == 'exact':
+            return 1, 1
+        if method == 'center':
+            return 0, 1
+        return 0, kwargs.get('subpixels', 5)
 
-        flux = []
-        flux_err = []
-        for label, aperture, bkg in zip(labels, apertures,
-                                        self._local_background, strict=True):
-            # Return NaN for completely masked sources or sources where
-            # the centroid is not finite
-            if aperture is None:
-                flux.append(np.nan)
-                flux_err.append(np.nan)
-                continue
+    def _calc_circular_photometry(self, radius):
+        """
+        Calculate the flux and flux error (without units) in a circular
+        aperture of the given radius centered on each source centroid.
 
-            xcen, ycen = aperture.positions
-            aperture_mask = self._aperture_to_mask(aperture, **kwargs)
-            if aperture_mask is None:
-                flux.append(np.nan)
-                flux_err.append(np.nan)
-                continue
+        See the `SourceCatalog` ``aperture_mask_method`` keyword for
+        options to mask neighboring sources.
 
-            # Prepare cutouts of the data based on the aperture size
-            data, error, mask, _, slc_sm, _ = self._make_aperture_data(
-                label, xcen, ycen, aperture_mask.bbox, bkg)
+        If ``detection_catalog`` is input, then its `centroid` values
+        will be used.
 
-            aperture_weights = aperture_mask.data[slc_sm]
-            pixel_mask = (aperture_weights > 0) & ~mask  # good pixels
-            # Ignore RuntimeWarning for invalid data or error values
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
-                values = (aperture_weights * data)[pixel_mask]
-                flux_ = np.nan if values.shape == (0,) else np.sum(values)
-                flux.append(flux_)
+        Parameters
+        ----------
+        radius : float
+            The radius of the circle in pixels.
 
-                if error is None:
-                    flux_err_ = np.nan
-                else:
-                    values = (aperture_weights**2 * error**2)[pixel_mask]
-                    if values.shape == (0,):
-                        flux_err_ = np.nan
-                    else:
-                        flux_err_ = np.sqrt(np.sum(values))
-                flux_err.append(flux_err_)
+        Returns
+        -------
+        flux, flux_err : 1D `~numpy.ndarray`
+            The aperture flux and flux error arrays. NaN where the
+            source is completely masked, its centroid is not finite, the
+            aperture does not overlap the data or has no contributing
+            pixels, or the aperture is unreasonably large.
+        """
+        xcen = np.atleast_1d(self.x_centroid).astype(float)
+        ycen = np.atleast_1d(self.y_centroid).astype(float)
+        n_src = len(xcen)
+        flux = np.full(n_src, np.nan)
+        flux_err = np.full(n_src, np.nan)
 
-        flux = np.array(flux)
-        flux_err = np.array(flux_err)
+        # Exclude undefined apertures (completely masked sources and
+        # non-finite centroids) and apertures whose bounding box would
+        # be unreasonably large (out-of-memory guard)
+        max_size = max(self._data.size, 1_000_000)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            nx = (np.floor(xcen + radius + 1.5)
+                  - np.floor(xcen - radius + 0.5))
+            ny = (np.floor(ycen + radius + 1.5)
+                  - np.floor(ycen - radius + 0.5))
+            valid = (~self._all_masked & np.isfinite(xcen)
+                     & np.isfinite(ycen) & np.isfinite(radius)
+                     & (nx * ny <= max_size))
+        idx = np.flatnonzero(valid)
+        if idx.size == 0:
+            return flux, flux_err
+
+        arrays = self._get_batch_arrays()
+        seg_code = _SEG_METHOD_CODES[self.aperture_mask_method]
+        seg_arr = None
+        seg_labels = None
+        if seg_code != 0:
+            seg_arr = arrays['segm']
+            seg_labels = np.ascontiguousarray(
+                np.atleast_1d(self.labels), dtype=np.intp)[idx]
+        positions = np.ascontiguousarray(
+            np.column_stack((xcen[idx], ycen[idx])))
+        local_bkg = np.ascontiguousarray(self._local_background,
+                                         dtype=np.float64)[idx]
+        use_exact, subpixels = self._overlap_params(
+            self._aperture_mask_kwargs['circ'])
+
+        (sums, sum_vars, _, overlap, _, _, _, _, _, fcounts,
+         _) = batch_aperture_sums(
+            arrays['data'], arrays['error'], arrays['mask'], positions,
+            SHAPE_CIRCLE, np.array([radius], dtype=np.float64), radius,
+            radius, 0.0, 0.0, use_exact, subpixels, seg_arr, seg_labels,
+            seg_code, local_bkg, 0)
+
+        # Membership matches the previous cutout-based
+        # ``in_aperture & ~mask`` rule: under 'correct', uncorrectable
+        # neighbor pixels stay members (with value zero)
+        members = fcounts[:, FLAG_COL_VALID].copy()
+        if seg_code == 3:
+            members += fcounts[:, FLAG_COL_UNCORRECTED]
+        good = overlap & (members > 0)
+        flux[idx] = np.where(good, sums, np.nan)
+        if self._error is not None:
+            flux_err[idx] = np.where(good, np.sqrt(sum_vars), np.nan)
 
         return flux, flux_err
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -446,10 +446,10 @@ class SourceCatalog:
         Whether to display a progress bar when calculating properties.
 
         .. deprecated:: 3.1
-           This keyword argument is deprecated and will be removed in a
-           future version. All property calculations are now computed
-           for all sources at once in compiled code, so no progress bar
-           is displayed and this keyword has no effect.
+           This keyword argument is deprecated and will be removed in
+           version 4.0. All property calculations are now computed for
+           all sources at once in compiled code, so no progress bar is
+           displayed and this keyword has no effect.
 
     Notes
     -----

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -32,8 +32,11 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   batch_aperture_sums)
 from photutils.background import SExtractorBackground
 from photutils.morphology import gini as gini_func
-from photutils.segmentation._batch_catalog import (batch_centroid_win,
-                                                   batch_flux_radius_solve)
+from photutils.segmentation._batch_catalog import (batch_central_moments,
+                                                   batch_centroid_win,
+                                                   batch_flux_radius_solve,
+                                                   batch_moment_err,
+                                                   batch_raw_moments)
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
                                           decode_segmentation_flags)
@@ -814,7 +817,8 @@ class SourceCatalog:
         result : dict
             A dict with keys ``'data'``, ``'error'``, ``'mask'``, and
             ``'segm'``. The ``'error'`` value is `None` if no error
-            array was input.
+            array was input. A ``'convdata'`` key is added lazily by
+            ``_get_batch_convdata``.
         """
         if self._batch_arrays_cache is None:
             data = np.ascontiguousarray(self._data, dtype=np.float64)
@@ -831,6 +835,33 @@ class SourceCatalog:
                                         'mask': mask_plane,
                                         'segm': segm}
         return self._batch_arrays_cache
+
+    def _get_batch_convdata(self):
+        """
+        Return the cached C-contiguous float64 convolved-data array
+        used by the batch moment kernels.
+        """
+        arrays = self._get_batch_arrays()
+        if 'convdata' not in arrays:
+            arrays['convdata'] = np.ascontiguousarray(
+                self._convolved_data, dtype=np.float64)
+        return arrays['convdata']
+
+    def _get_batch_bboxes(self):
+        """
+        Return the per-source segment bounding boxes as
+        ``(iymin, iymax, ixmin, ixmax)`` intp arrays.
+        """
+        slices = self._slices_iter
+        iymin = np.array([slc[0].start for slc in slices],
+                         dtype=np.intp)
+        iymax = np.array([slc[0].stop for slc in slices],
+                         dtype=np.intp)
+        ixmin = np.array([slc[1].start for slc in slices],
+                         dtype=np.intp)
+        ixmax = np.array([slc[1].stop for slc in slices],
+                         dtype=np.intp)
+        return iymin, iymax, ixmin, ixmax
 
     @cached_property
     def isscalar(self):
@@ -1145,38 +1176,6 @@ class SourceCatalog:
                                 self._cutout_data_masks, strict=True):
             masks.append(mask1 | mask2)
         return masks
-
-    @cached_property
-    def _moment_data_cutouts(self):
-        """
-        A list of 2D `~numpy.ndarray` cutouts from the (convolved) data.
-
-        The following pixels are set to zero in these arrays:
-
-        * pixels outside the source segment
-        * any masked pixels from the input ``mask``
-        * invalid convolved data values (NaN and inf)
-        * negative convolved data values; negative pixels (especially
-          at large radii) can give image moments that have negative
-          variances.
-
-        These arrays are used to derive moment-based properties.
-        """
-        cutouts = []
-        for convdata_cutout, mask_cutout, segmmask_cutout in zip(
-                self._convdata_cutouts, self._mask_cutouts,
-                self._cutout_segment_masks, strict=True):
-
-            convdata_mask = (~np.isfinite(convdata_cutout)
-                             | (convdata_cutout < 0) | segmmask_cutout)
-
-            if self._mask is not None:
-                convdata_mask |= mask_cutout
-
-            cutout = convdata_cutout.copy()
-            cutout[convdata_mask] = 0.0
-            cutouts.append(cutout)
-        return cutouts
 
     def _prepare_cutouts(self, arrays, *, units=True, masked=False,
                          dtype=None):
@@ -1794,15 +1793,15 @@ class SourceCatalog:
         """
         Spatial moments up to 3rd order of the source.
         """
-        result = []
-        for arr in self._moment_data_cutouts:
-            ny, nx = arr.shape
-            y = np.arange(ny, dtype=float)
-            x = np.arange(nx, dtype=float)
-            yp = np.column_stack([np.ones(ny), y, y * y, y ** 3])
-            xp = np.column_stack([np.ones(nx), x, x * x, x ** 3])
-            result.append(yp.T @ arr @ xp)
-        return np.array(result)
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        return batch_raw_moments(
+            self._get_batch_convdata(), mask=arrays['mask'],
+            segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax)
 
     @cached_property
     @use_detcat
@@ -1811,18 +1810,18 @@ class SourceCatalog:
         Central moments (translation invariant) of the source up to 3rd
         order.
         """
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         cutout_centroid = self._array('cutout_centroid')
-        result = []
-        for arr, xcen, ycen in zip(self._moment_data_cutouts,
-                                   cutout_centroid[:, 0],
-                                   cutout_centroid[:, 1], strict=True):
-            ny, nx = arr.shape
-            yc = np.arange(ny, dtype=float) - ycen
-            xc = np.arange(nx, dtype=float) - xcen
-            yp = np.column_stack([np.ones(ny), yc, yc * yc, yc ** 3])
-            xp = np.column_stack([np.ones(nx), xc, xc * xc, xc ** 3])
-            result.append(yp.T @ arr @ xp)
-        return np.array(result)
+        return batch_central_moments(
+            self._get_batch_convdata(), mask=arrays['mask'],
+            segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax,
+            xcen=np.ascontiguousarray(cutout_centroid[:, 0]),
+            ycen=np.ascontiguousarray(cutout_centroid[:, 1]))
 
     @cached_property
     @use_detcat
@@ -1894,61 +1893,65 @@ class SourceCatalog:
         if self._error is None:
             return np.full((self.n_labels, 2, 2), np.nan)
 
+        arrays = self._get_batch_arrays()
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         cutout_centroid = self._array('cutout_centroid')
-        is_singular = self._singular_covariance_mask
 
-        var_arr = []
+        # The accumulators are the summed pixel variance and its
+        # dx**2, dy**2, and dx*dy weighted sums. The variance is zeroed
+        # at masked pixels and at pixels that were excluded from the
+        # moment data (e.g., non-finite or negative convolved values),
+        # so that pixels that do not contribute flux weight also do not
+        # contribute error variance.
+        acc = batch_moment_err(
+            arrays['error'], convdata=self._get_batch_convdata(),
+            mask=arrays['mask'], segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+            bbox_ixmax=ixmax,
+            xcen=np.ascontiguousarray(cutout_centroid[:, 0]),
+            ycen=np.ascontiguousarray(cutout_centroid[:, 1]))
+
+        # The total flux is the zeroth raw moment of the moment data.
+        total_flux = self._array('moments')[:, 0, 0]
+        is_singular = np.atleast_1d(self._singular_covariance_mask)
         pixel_var = 1.0 / 12.0
-        for (moment_data, error_cutout, total_mask, xcen, ycen,
-             singular) in zip(
-                self._moment_data_cutouts, self._error_cutouts,
-                self._cutout_total_masks, cutout_centroid[:, 0],
-                cutout_centroid[:, 1], is_singular, strict=True):
 
-            total_flux = np.sum(moment_data)
-            if not np.isfinite(total_flux) or total_flux <= 0:
-                var_arr.append((np.nan, np.nan, np.nan))
-                continue
-
-            err_sq = error_cutout.astype(float)**2
-            # Zero the variance at masked pixels and at pixels that
-            # were excluded from the moment data (e.g., non-finite or
-            # negative convolved values), so that pixels that do not
-            # contribute flux weight also do not contribute error
-            # variance.
-            err_sq[total_mask | (moment_data == 0)] = 0.0
-
-            yy, xx = np.mgrid[0:err_sq.shape[0], 0:err_sq.shape[1]]
-            dx = xx - xcen
-            dy = yy - ycen
-
+        # Ignore divide-by-zero and invalid-value RuntimeWarnings for
+        # sources with non-positive or non-finite total flux; those
+        # values are replaced by NaN below.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             # Propagate the error through the centroid formula.
-            norm = 1.0 / (total_flux**2)
-            err_var_x = np.sum(err_sq * dx**2) * norm
-            err_var_y = np.sum(err_sq * dy**2) * norm
-            err_cov_xy = np.sum(err_sq * dx * dy) * norm
+            norm = 1.0 / total_flux**2
+            err_var_x = acc[:, 1] * norm
+            err_var_y = acc[:, 2] * norm
+            err_cov_xy = acc[:, 3] * norm
 
             # Singularity correction for point-like sources. If the
             # error covariance matrix is nearly singular, add the
-            # variance of a uniform
-            # distribution across a single pixel (1/12) scaled by the
-            # summed pixel variance. The correction is added to the
-            # variances only, never to the covariance.
-            if singular:
-                err_sum_norm = np.sum(err_sq) * pixel_var * norm
-                if (err_var_x * err_var_y
-                        - err_cov_xy**2) < err_sum_norm**2:
-                    err_var_x += err_sum_norm
-                    err_var_y += err_sum_norm
+            # variance of a uniform distribution across a single pixel
+            # (1/12) scaled by the summed pixel variance. The
+            # correction is added to the variances only, never to the
+            # covariance.
+            err_sum_norm = acc[:, 0] * pixel_var * norm
+            singular = (is_singular
+                        & ((err_var_x * err_var_y - err_cov_xy**2)
+                           < err_sum_norm**2))
+            err_var_x[singular] += err_sum_norm[singular]
+            err_var_y[singular] += err_sum_norm[singular]
 
-            var_arr.append((err_var_x, err_var_y, err_cov_xy))
+            bad = ~np.isfinite(total_flux) | (total_flux <= 0)
+            err_var_x[bad] = np.nan
+            err_var_y[bad] = np.nan
+            err_cov_xy[bad] = np.nan
 
-        var_arr = np.array(var_arr)
-        cov = np.empty((len(var_arr), 2, 2))
-        cov[:, 0, 0] = var_arr[:, 0]
-        cov[:, 1, 1] = var_arr[:, 1]
-        cov[:, 0, 1] = var_arr[:, 2]
-        cov[:, 1, 0] = var_arr[:, 2]
+        cov = np.empty((len(err_var_x), 2, 2))
+        cov[:, 0, 0] = err_var_x
+        cov[:, 1, 1] = err_var_y
+        cov[:, 0, 1] = err_cov_xy
+        cov[:, 1, 0] = err_cov_xy
         return cov
 
     def _sky_err_from_cov(self, pix_cov, xycen):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -35,6 +35,7 @@ from photutils.morphology import gini as gini_func
 from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_centroid_win,
                                                    batch_flux_radius_solve,
+                                                   batch_kron_radius,
                                                    batch_moment_err,
                                                    batch_raw_moments)
 from photutils.segmentation.core import SegmentationImage
@@ -4248,148 +4249,60 @@ class SourceCatalog:
         any minimum Kron or circular radius.
         """
         scale = 6.0
+        xcen = np.ascontiguousarray(self._array('x_centroid'),
+                                    dtype=np.float64)
+        ycen = np.ascontiguousarray(self._array('y_centroid'),
+                                    dtype=np.float64)
+        semimajor = np.ascontiguousarray(
+            self._array('semimajor_axis').value, dtype=np.float64)
+        semiminor = np.ascontiguousarray(
+            self._array('semiminor_axis').value, dtype=np.float64)
+        theta = np.ascontiguousarray(
+            self._array('orientation').to_value(u.radian),
+            dtype=np.float64)
+        cxx = np.ascontiguousarray(self._array('ellipse_cxx').value,
+                                   dtype=np.float64)
+        cxy = np.ascontiguousarray(self._array('ellipse_cxy').value,
+                                   dtype=np.float64)
+        cyy = np.ascontiguousarray(self._array('ellipse_cyy').value,
+                                   dtype=np.float64)
 
-        xcen_arr = self._array('x_centroid')
-        ycen_arr = self._array('y_centroid')
-        a_arr = self._array('semimajor_axis').value * scale
-        b_arr = self._array('semiminor_axis').value * scale
-        theta_arr = self._array('orientation').to_value(u.radian)
-        cxx_arr = self._array('ellipse_cxx').value
-        cxy_arr = self._array('ellipse_cxy').value
-        cyy_arr = self._array('ellipse_cyy').value
-        all_masked = self._all_masked
+        # Completely masked sources and sources with a non-finite
+        # centroid or shape have no measured Kron radius (NaN)
+        skip = (self._all_masked | ~np.isfinite(xcen) | ~np.isfinite(ycen)
+                | ~np.isfinite(semimajor * scale)
+                | ~np.isfinite(semiminor * scale)
+                | ~np.isfinite(theta)).astype(np.uint8)
 
-        data_full = self._data
-        data_shape = data_full.shape
-        mask_full = self._mask
-        segm_data = self._segmentation_image.data
-        max_size = max(data_full.size, 1_000_000)
         kron_min = self.kron_params[1]
         min_circ_radius = (self.kron_params[2]
                            if len(self.kron_params) == 3 else 0.0)
-        aperture_mask_method = self.aperture_mask_method
 
-        labels = self.labels
-        if self.progress_bar:
-            desc = 'kron_radius'
-            labels = add_progress_bar(labels, desc=desc)
+        arrays = self._get_batch_arrays()
+        sums = batch_kron_radius(
+            arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
+            labels=np.ascontiguousarray(np.atleast_1d(self.labels),
+                                        dtype=np.intp),
+            xcen=xcen, ycen=ycen, semimajor=semimajor,
+            semiminor=semiminor, theta=theta, cxx=cxx, cxy=cxy, cyy=cyy,
+            skip=skip,
+            seg_method=_SEG_METHOD_CODES[self.aperture_mask_method],
+            scale=scale, min_circ_radius=min_circ_radius,
+            max_aper_size=max(self._data.size, 1_000_000))
+        flux_numer = sums[:, 0]
+        flux_denom = sums[:, 1]
 
-        kron_radius = []
-        for (label, xc, yc, a, b, theta, cxx_, cxy_, cyy_,
-             masked) in zip(labels, xcen_arr, ycen_arr, a_arr, b_arr,
-                            theta_arr, cxx_arr, cxy_arr, cyy_arr,
-                            all_masked, strict=True):
-            if masked or not (math.isfinite(xc) and math.isfinite(yc)
-                              and math.isfinite(a) and math.isfinite(b)
-                              and math.isfinite(theta)):
-                kron_radius.append(np.nan)
-                continue
+        # Ignore RuntimeWarning from undefined (NaN) sums and from a
+        # zero denominator
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            kron_radius = flux_numer / flux_denom
+            # Set the Kron radius to the minimum Kron radius if the
+            # numerator or denominator is not positive (NaN comparisons
+            # are False, so undefined sources stay NaN)
+            kron_radius[(flux_numer <= 0) | (flux_denom <= 0)] = kron_min
 
-            # Circular aperture fallback when semimajor/semiminor are
-            # zero (matching _make_elliptical_apertures behavior)
-            use_circular = (a == 0 and b == 0)
-            if use_circular:
-                if min_circ_radius <= 0:
-                    kron_radius.append(np.nan)
-                    continue
-                half_w = min_circ_radius
-                half_h = min_circ_radius
-            else:
-                cos_theta = math.cos(theta)
-                sin_theta = math.sin(theta)
-                half_w = math.sqrt(a * a * cos_theta * cos_theta
-                                   + b * b * sin_theta * sin_theta)
-                half_h = math.sqrt(a * a * sin_theta * sin_theta
-                                   + b * b * cos_theta * cos_theta)
-
-            # Compute bounding box from ellipse/circle parameters
-            ixmin = math.floor(xc - half_w + 0.5)
-            ixmax = math.floor(xc + half_w + 0.5) + 1
-            iymin = math.floor(yc - half_h + 0.5)
-            iymax = math.floor(yc + half_h + 0.5) + 1
-
-            # OOM guard
-            if (ixmax - ixmin) * (iymax - iymin) > max_size:
-                kron_radius.append(np.nan)
-                continue
-
-            # Compute overlap slices with data boundaries
-            dx_min = max(0, -ixmin)
-            dy_min = max(0, -iymin)
-            dx_max = max(0, ixmax - data_shape[1])
-            dy_max = max(0, iymax - data_shape[0])
-            lg_xmin = ixmin + dx_min
-            lg_xmax = ixmax - dx_max
-            lg_ymin = iymin + dy_min
-            lg_ymax = iymax - dy_max
-            if lg_xmin >= lg_xmax or lg_ymin >= lg_ymax:
-                kron_radius.append(np.nan)
-                continue
-
-            slc_lg = (slice(lg_ymin, lg_ymax), slice(lg_xmin, lg_xmax))
-
-            # Cutout data (local background explicitly zero for SE
-            # agreement)
-            data = data_full[slc_lg].astype(float)
-
-            # Build data mask (non-finite + input mask)
-            data_mask = ~np.isfinite(data)
-            if mask_full is not None:
-                data_mask |= mask_full[slc_lg]
-
-            # Mask or correct neighboring sources
-            if aperture_mask_method != 'none':
-                seg_cut = segm_data[slc_lg]
-                segm_mask = (seg_cut != label) & (seg_cut != 0)
-                if aperture_mask_method == 'mask':
-                    mask = data_mask | segm_mask
-                else:
-                    mask = data_mask
-                if aperture_mask_method == 'correct':
-                    cutout_xycen = (xc - max(0, ixmin), yc - max(0, iymin))
-                    data = _mask_to_mirrored_value(data, segm_mask,
-                                                   cutout_xycen,
-                                                   mask=mask)
-            else:
-                mask = data_mask
-
-            # Coordinate arrays (ogrid-style broadcasting avoids
-            # allocating full 2D meshgrid arrays)
-            ny, nx = data.shape
-            xval = np.arange(nx) - (xc - lg_xmin)
-            yval = np.arange(ny) - (yc - lg_ymin)
-            yy = yval[:, np.newaxis]
-            xx = xval[np.newaxis, :]
-
-            # Elliptical radius
-            rr_sq = cxx_ * xx * xx + cxy_ * xx * yy + cyy_ * yy * yy
-            rr = np.sqrt(np.maximum(rr_sq, 0.0))
-
-            # Aperture mask: for method='center', pixels whose center
-            # falls inside the ellipse (rr <= scale) or circle
-            if use_circular:
-                dx = xx
-                dy = yy
-                pixel_mask = ((dx * dx + dy * dy)
-                              <= min_circ_radius * min_circ_radius) & ~mask
-            else:
-                pixel_mask = (rr <= scale) & ~mask
-
-            # Ignore RuntimeWarning for invalid data values
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
-                flux_numer = np.sum(data[pixel_mask] * rr[pixel_mask])
-                flux_denom = np.sum(data[pixel_mask])
-
-            # Set Kron radius to the minimum Kron radius if numerator or
-            # denominator is negative
-            if flux_numer <= 0 or flux_denom <= 0:
-                kron_radius.append(kron_min)
-                continue
-
-            kron_radius.append(flux_numer / flux_denom)
-
-        return np.array(kron_radius)
+        return kron_radius
 
     def _calc_kron_radius(self, kron_params):
         """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -837,8 +837,13 @@ class SourceCatalog:
         else:
             setattr(newcls, attr, getattr(self, attr)[index])
 
+        # _slices is always stored as a list (one tuple of slices per
+        # source), even for a scalar catalog. The public ``slices``
+        # property is collapsed by __getattribute__.
         attr = '_slices'
         value = self._index_object_list(getattr(self, attr), index)
+        if newcls.isscalar:
+            value = [value]
         setattr(newcls, attr, value)
 
         # Slice the flux_radius cache values
@@ -1047,8 +1052,8 @@ class SourceCatalog:
         A 2D array (rather than a tuple of arrays) so that the cached
         value is sliced along the source axis by ``__getitem__``.
         """
-        bboxes = np.empty((len(self._slices_iter), 4), dtype=np.intp)
-        for i, (slc_y, slc_x) in enumerate(self._slices_iter):
+        bboxes = np.empty((len(self._slices), 4), dtype=np.intp)
+        for i, (slc_y, slc_x) in enumerate(self._slices):
             bboxes[i] = (slc_y.start, slc_y.stop, slc_x.start, slc_x.stop)
         return bboxes
 
@@ -1259,7 +1264,7 @@ class SourceCatalog:
         """
         A list of data cutouts using the segmentation image slices.
         """
-        return [self._data[slc] for slc in self._slices_iter]
+        return [self._data[slc] for slc in self._slices]
 
     @cached_property
     def _segmentation_image_cutouts(self):
@@ -1268,7 +1273,7 @@ class SourceCatalog:
         image slices.
         """
         return [self._segmentation_image.data[slc]
-                for slc in self._slices_iter]
+                for slc in self._slices]
 
     @cached_property
     def _mask_cutouts(self):
@@ -1279,7 +1284,7 @@ class SourceCatalog:
         """
         if self._mask is None:
             return self._null_objects
-        return [self._mask[slc] for slc in self._slices_iter]
+        return [self._mask[slc] for slc in self._slices]
 
     @cached_property
     def _error_cutouts(self):
@@ -1290,7 +1295,7 @@ class SourceCatalog:
         """
         if self._error is None:
             return self._null_objects
-        return [self._error[slc] for slc in self._slices_iter]
+        return [self._error[slc] for slc in self._slices]
 
     @cached_property
     def _convdata_cutouts(self):
@@ -1298,7 +1303,7 @@ class SourceCatalog:
         A list of convolved data cutouts using the segmentation image
         slices.
         """
-        return [self._convolved_data[slc] for slc in self._slices_iter]
+        return [self._convolved_data[slc] for slc in self._slices]
 
     @cached_property
     def _background_cutouts(self):
@@ -1308,7 +1313,7 @@ class SourceCatalog:
         """
         if self._background is None:
             return self._null_objects
-        return [self._background[slc] for slc in self._slices_iter]
+        return [self._background[slc] for slc in self._slices]
 
     @staticmethod
     def _make_cutout_data_mask(data_cutout, mask_cutout):
@@ -1530,17 +1535,6 @@ class SourceCatalog:
         a single-source catalog.
         """
         return self._slices
-
-    @cached_property
-    def _slices_iter(self):
-        """
-        A tuple of slice objects defining the minimal bounding box of
-        the source, always as an iterable.
-        """
-        _slices = self.slices
-        if self.isscalar:
-            _slices = (_slices,)
-        return _slices
 
     @cached_property
     def segment_cutout(self):
@@ -1780,7 +1774,7 @@ class SourceCatalog:
         ny, nx = self._data.shape
         edge = np.array([(slc[0].start == 0 or slc[1].start == 0
                           or slc[0].stop == ny or slc[1].stop == nx)
-                         for slc in self._slices_iter])
+                         for slc in self._slices])
         flags[edge] |= SEGMENTATION_FLAGS.EDGE_TOUCH
 
         # Input-masked, non-finite data, and non-finite error pixels
@@ -3109,7 +3103,7 @@ class SourceCatalog:
         """
         return [BoundingBox(ixmin=slc[1].start, ixmax=slc[1].stop,
                             iymin=slc[0].start, iymax=slc[0].stop)
-                for slc in self._slices_iter]
+                for slc in self._slices]
 
     @cached_property
     @use_detcat
@@ -3130,7 +3124,7 @@ class SourceCatalog:
         The minimum ``x`` pixel index within the minimal bounding box
         containing the source segment.
         """
-        return np.array([slc[1].start for slc in self._slices_iter])
+        return np.array([slc[1].start for slc in self._slices])
 
     @cached_property
     @use_detcat
@@ -3141,7 +3135,7 @@ class SourceCatalog:
 
         Note that this value is inclusive, unlike numpy slice indices.
         """
-        return np.array([slc[1].stop - 1 for slc in self._slices_iter])
+        return np.array([slc[1].stop - 1 for slc in self._slices])
 
     @cached_property
     @use_detcat
@@ -3150,7 +3144,7 @@ class SourceCatalog:
         The minimum ``y`` pixel index within the minimal bounding box
         containing the source segment.
         """
-        return np.array([slc[0].start for slc in self._slices_iter])
+        return np.array([slc[0].start for slc in self._slices])
 
     @cached_property
     @use_detcat
@@ -3161,7 +3155,7 @@ class SourceCatalog:
 
         Note that this value is inclusive, unlike numpy slice indices.
         """
-        return np.array([slc[0].stop - 1 for slc in self._slices_iter])
+        return np.array([slc[0].stop - 1 for slc in self._slices])
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/tests/_batch_scene.py
+++ b/photutils/segmentation/tests/_batch_scene.py
@@ -6,8 +6,9 @@ Shared synthetic scene for the batch-driver comparator tests.
 import numpy as np
 
 from photutils.segmentation import SourceCatalog, detect_sources
+from photutils.segmentation.utils import _mask_to_mirrored_value
 
-__all__ = ['make_batch_scene', 'make_catalog']
+__all__ = ['make_batch_scene', 'make_catalog', 'reference_aperture_data']
 
 
 def make_batch_scene(*, seed=0):
@@ -85,3 +86,88 @@ def make_catalog(scene, *, aperture_mask_method='correct',
         error=scene['error'] if with_error else None,
         mask=scene['mask'] if with_mask else None,
         aperture_mask_method=aperture_mask_method)
+
+
+def reference_aperture_data(cat, label, x_centroid, y_centroid,
+                            aperture_bbox, local_background, *,
+                            make_error=True):
+    """
+    Make cutouts of the data, error, and mask arrays for aperture
+    photometry.
+
+    This is a verbatim port of the per-source ``_make_aperture_data``
+    method that the batch Cython drivers replaced. It is the
+    numerical reference for the neighbor handling of the drivers.
+
+    Parameters
+    ----------
+    cat : `~photutils.segmentation.SourceCatalog`
+        The source catalog.
+
+    label : int
+        The source label.
+
+    x_centroid, y_centroid : float
+        The aperture center.
+
+    aperture_bbox : `~photutils.aperture.BoundingBox`
+        The aperture bounding box.
+
+    local_background : float
+        The local background to subtract.
+
+    make_error : bool, optional
+        Whether to return the error cutout.
+
+    Returns
+    -------
+    result : tuple
+        The ``(data, error, mask, cutout_xycen, slc_sm, flag_masks)``
+        values, or ``(None,) * 6`` if the bounding box does not overlap
+        the data.
+    """
+    slc_lg, slc_sm = aperture_bbox.get_overlap_slices(cat._data.shape)
+    if slc_lg is None:
+        return (None,) * 6
+
+    data = cat._data[slc_lg].astype(float) - local_background
+
+    mask_cutout = None if cat._mask is None else cat._mask[slc_lg]
+    data_mask = ~np.isfinite(data)
+    if mask_cutout is not None:
+        data_mask |= mask_cutout
+
+    if make_error and cat._error is not None:
+        error = cat._error[slc_lg]
+    else:
+        error = None
+
+    cutout_xycen = (x_centroid - max(0, aperture_bbox.ixmin),
+                    y_centroid - max(0, aperture_bbox.iymin))
+
+    segm_mask = None
+    uncorrected_mask = None
+    if cat.aperture_mask_method == 'none':
+        mask = data_mask
+    else:
+        segment_img = cat._segmentation_image.data[slc_lg]
+        segm_mask = np.logical_and(segment_img != label,
+                                   segment_img != 0)
+        if cat.aperture_mask_method == 'mask':
+            mask = data_mask | segm_mask
+        else:
+            mask = data_mask
+
+    if cat.aperture_mask_method == 'correct':
+        data, uncorrected_mask = _mask_to_mirrored_value(
+            data, segm_mask, cutout_xycen, mask=mask,
+            return_uncorrected=True)
+        if error is not None:
+            error = _mask_to_mirrored_value(error, segm_mask, cutout_xycen,
+                                            mask=mask)
+
+    flag_masks = {'data_mask': data_mask,
+                  'segm_mask': segm_mask,
+                  'uncorrected_mask': uncorrected_mask}
+
+    return data, error, mask, cutout_xycen, slc_sm, flag_masks

--- a/photutils/segmentation/tests/_batch_scene.py
+++ b/photutils/segmentation/tests/_batch_scene.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from photutils.segmentation import SourceCatalog, detect_sources
 
-__all__ = ['make_batch_scene']
+__all__ = ['make_batch_scene', 'make_catalog']
 
 
 def make_batch_scene(*, seed=0):

--- a/photutils/segmentation/tests/_batch_scene.py
+++ b/photutils/segmentation/tests/_batch_scene.py
@@ -1,0 +1,87 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Shared synthetic scene for the batch-driver comparator tests.
+"""
+
+import numpy as np
+
+from photutils.segmentation import SourceCatalog, detect_sources
+
+__all__ = ['make_batch_scene']
+
+
+def make_batch_scene(*, seed=0):
+    """
+    Make a deterministic test scene exercising the batch-driver edge
+    cases.
+
+    The scene contains isolated sources, close/overlapping pairs
+    (neighbor-segment handling), sources touching every image edge (bbox
+    clipping), masked pixels inside sources and spanning a close pair
+    (mirror-correction rejection), and non-finite data values inside a
+    source.
+
+    Parameters
+    ----------
+    seed : int, optional
+        The seed for the random number generator used for the
+        background noise.
+
+    Returns
+    -------
+    result : dict
+        Keys ``data``, ``error``, ``mask``, ``segm`` (a
+        `~photutils.segmentation.SegmentationImage`).
+    """
+    rng = np.random.default_rng(seed)
+    ny = nx = 151
+    yy, xx = np.mgrid[0:ny, 0:nx]
+    data = rng.normal(0.0, 0.1, (ny, nx))
+    positions = [(20, 20), (24, 26), (75, 75), (75, 81), (140, 20),
+                 (5, 100), (100, 4), (147, 147), (50, 120), (120, 50),
+                 (100, 100)]
+    for i, (xc, yc) in enumerate(positions):
+        amp = 5.0 + i
+        sig = 1.5 + 0.2 * (i % 4)
+        data += amp * np.exp(-((xx - xc) ** 2 + (yy - yc) ** 2)
+                             / (2 * sig ** 2))
+    error = np.full((ny, nx), 0.1)
+    error[::17, ::13] = 0.3
+    mask = np.zeros((ny, nx), dtype=bool)
+    mask[18:20, 22:24] = True  # inside a source of a close pair
+    mask[73:75, 72:84] = True  # spans a close pair
+    data[77, 78] = np.nan  # non-finite inside a source
+    data[75, 83] = np.inf
+    segm = detect_sources(data, 1.0, n_pixels=5)
+    return {'data': data, 'error': error, 'mask': mask, 'segm': segm}
+
+
+def make_catalog(scene, *, aperture_mask_method='correct',
+                 with_error=True, with_mask=True):
+    """
+    Make a `SourceCatalog` from a scene with the given options.
+
+    Parameters
+    ----------
+    scene : dict
+        A scene from `make_batch_scene`.
+
+    aperture_mask_method : {'correct', 'mask', 'none'}, optional
+        The segmentation masking method.
+
+    with_error : bool, optional
+        Whether to pass the scene error array to the catalog.
+
+    with_mask : bool, optional
+        Whether to pass the scene mask array to the catalog.
+
+    Returns
+    -------
+    result : `~photutils.segmentation.SourceCatalog`
+        The source catalog.
+    """
+    return SourceCatalog(
+        scene['data'], scene['segm'],
+        error=scene['error'] if with_error else None,
+        mask=scene['mask'] if with_mask else None,
+        aperture_mask_method=aperture_mask_method)

--- a/photutils/segmentation/tests/test_batch_centroid_quad.py
+++ b/photutils/segmentation/tests/test_batch_centroid_quad.py
@@ -1,0 +1,299 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch quadratic centroid path.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from photutils.segmentation import SegmentationImage, SourceCatalog
+from photutils.segmentation._batch_catalog import batch_quad_boxes
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+
+
+def _centroid_quad_var(coeffs, xm_rel, ym_rel, pinv, box_var):
+    # Verbatim port of the previous ``_centroid_quad_var`` method
+    c10, c01, c11, c20, c02 = coeffs[1:]
+    det = 4.0 * c20 * c02 - c11 * c11
+    grad_x = np.array(
+        [0.0,
+         -2.0 * c02 / det,
+         c11 / det,
+         (c01 + 2.0 * c11 * xm_rel) / det,
+         -4.0 * c02 * xm_rel / det,
+         (-2.0 * c10 - 4.0 * c20 * xm_rel) / det])
+    grad_y = np.array(
+        [0.0,
+         c11 / det,
+         -2.0 * c20 / det,
+         (c10 + 2.0 * c11 * ym_rel) / det,
+         (-2.0 * c01 - 4.0 * c02 * ym_rel) / det,
+         -4.0 * c20 * ym_rel / det])
+    u_x = grad_x @ pinv
+    u_y = grad_y @ pinv
+    var_x = np.sum(u_x**2 * box_var)
+    var_y = np.sum(u_y**2 * box_var)
+    cov_xy = np.sum(u_x * u_y * box_var)
+    return var_x, var_y, cov_xy
+
+
+def _reference_centroid_quad_results(cat):
+    """
+    Compute the quadratic centroid results of each source.
+
+    This is a verbatim port of the per-source Python implementation
+    of ``_centroid_quad_results`` that the batch path replaces. It is
+    the numerical reference for the batch path.
+    """
+    xi = np.arange(3)
+    x, y = np.meshgrid(xi, xi)
+    x = x.ravel()
+    y = y.ravel()
+    coeff_matrix = np.empty((9, 6), dtype=float)
+    coeff_matrix[:, 0] = 1
+    coeff_matrix[:, 1] = x
+    coeff_matrix[:, 2] = y
+    coeff_matrix[:, 3] = x * y
+    coeff_matrix[:, 4] = x * x
+    coeff_matrix[:, 5] = y * y
+    pinv = np.linalg.pinv(coeff_matrix)
+
+    compute_err = cat._error is not None
+
+    _nan = np.nan
+    nan_result = (_nan, _nan, _nan, _nan, _nan)
+    results = []
+
+    for cutout, error_cutout, mask in zip(cat._data_cutouts,
+                                          cat._error_cutouts,
+                                          cat._cutout_total_masks,
+                                          strict=True):
+        ny, nx = cutout.shape
+
+        if ny < 3 or nx < 3:
+            results.append(nan_result)
+            continue
+
+        if np.all(mask):
+            results.append(nan_result)
+            continue
+
+        cutout = np.array(cutout, dtype=float)
+        cutout[mask] = 0.0
+
+        yidx, xidx = np.unravel_index(np.argmax(cutout), cutout.shape)
+
+        if xidx == 0 or xidx == nx - 1 or yidx == 0 or yidx == ny - 1:
+            results.append((float(xidx), float(yidx), _nan, _nan,
+                            _nan))
+            continue
+
+        xidx0 = xidx - 1
+        yidx0 = yidx - 1
+        cutout_flat = cutout[yidx0:yidx0 + 3, xidx0:xidx0 + 3].ravel()
+
+        c = pinv @ cutout_flat
+        c10, c01, c11, c20, c02 = c[1], c[2], c[3], c[4], c[5]
+
+        det = 4.0 * c20 * c02 - c11 * c11
+        if det <= 0 or c20 > 0:
+            results.append(nan_result)
+            continue
+
+        xm_rel = (c01 * c11 - 2.0 * c02 * c10) / det
+        ym_rel = (c10 * c11 - 2.0 * c20 * c01) / det
+        xm = xm_rel + xidx0
+        ym = ym_rel + yidx0
+
+        if not (0.0 < xm < (nx - 1.0) and 0.0 < ym < (ny - 1.0)):
+            results.append(nan_result)
+            continue
+
+        var_x = var_y = cov_xy = _nan
+        if compute_err:
+            box_var = (error_cutout[yidx0:yidx0 + 3, xidx0:xidx0 + 3]
+                       .astype(float).ravel()**2)
+            box_var[mask[yidx0:yidx0 + 3,
+                         xidx0:xidx0 + 3].ravel()] = 0.0
+            var_x, var_y, cov_xy = _centroid_quad_var(
+                c, xm_rel, ym_rel, pinv, box_var)
+
+        results.append((xm, ym, var_x, var_y, cov_xy))
+
+    results = np.array(results)
+
+    nan_mask = (np.isnan(results[:, 0]) | np.isnan(results[:, 1]))
+    if np.any(nan_mask):
+        cutout_centroid = cat._array('cutout_centroid')
+        results[nan_mask, 0:2] = cutout_centroid[nan_mask]
+        iso_cov = cat._centroid_err_cov
+        results[nan_mask, 2] = iso_cov[nan_mask, 0, 0]
+        results[nan_mask, 3] = iso_cov[nan_mask, 1, 1]
+        results[nan_mask, 4] = iso_cov[nan_mask, 0, 1]
+
+    return results
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('with_error', [True, False])
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_matches_reference(scene, with_error, with_mask):
+    cat = make_catalog(scene, with_error=with_error, with_mask=with_mask)
+    expected = _reference_centroid_quad_results(cat)
+    assert_allclose(cat._centroid_quad_results, expected, rtol=1e-12,
+                    equal_nan=True)
+    assert_allclose(cat.centroid_quad_err[:, 0],
+                    np.sqrt(expected[:, 2]), rtol=1e-12, equal_nan=True)
+
+
+def _edge_case_catalog():
+    # Sources exercising every status of the box gather: a cutout
+    # smaller than 3x3, a fully masked source, a peak on the cutout
+    # edge, a negative source whose peak is a masked (zero) pixel, a
+    # rejected (non-maximum) fit, a normal source, and a corner peak
+    data = np.zeros((60, 60))
+    yy, xx = np.mgrid[0:60, 0:60]
+    segm_data = np.zeros(data.shape, dtype=int)
+    error = np.full(data.shape, 0.3)
+    mask = np.zeros(data.shape, dtype=bool)
+
+    # Label 1: 2x2 segment (too small)
+    data[2:4, 2:4] = 5.0
+    segm_data[2:4, 2:4] = 1
+    # Label 2: fully masked 5x5 segment
+    data[2:7, 10:15] = 5.0
+    segm_data[2:7, 10:15] = 2
+    mask[2:7, 10:15] = True
+    # Label 3: peak on the cutout edge (a ramp)
+    data[10:15, 2:7] = xx[10:15, 2:7]
+    segm_data[10:15, 2:7] = 3
+    # Label 4: negative source with one masked interior pixel, whose
+    # zero value becomes the peak of the zero-filled cutout
+    data[10:17, 10:17] = -5.0 - ((xx[10:17, 10:17] - 13) ** 2
+                                 + (yy[10:17, 10:17] - 13) ** 2)
+    segm_data[10:17, 10:17] = 4
+    mask[12, 12] = True
+    # Label 5: an interior peak whose 3x3 box has high corners, so the
+    # fitted quadratic has a positive x curvature and is rejected
+    data[22:25, 22:25] = [[8.0, 0.0, 8.0], [0.0, 10.0, 0.0],
+                          [8.0, 0.0, 8.0]]
+    segm_data[20:27, 20:27] = 5
+    # Label 6: normal Gaussian source
+    data[30:45, 30:45] = 20.0 * np.exp(
+        -((xx[30:45, 30:45] - 37.3) ** 2 + (yy[30:45, 30:45] - 37.6) ** 2)
+        / 8.0)
+    segm_data[30:45, 30:45] = 6
+    # Label 7: peak at the cutout corner with a NaN data value
+    data[50:55, 50:55] = 1.0
+    data[50, 50] = 10.0
+    data[52, 52] = np.nan
+    segm_data[50:55, 50:55] = 7
+
+    return SourceCatalog(data, SegmentationImage(segm_data), error=error,
+                         mask=mask)
+
+
+def test_edge_cases():
+    cat = _edge_case_catalog()
+    expected = _reference_centroid_quad_results(cat)
+    assert_allclose(cat._centroid_quad_results, expected, rtol=1e-12,
+                    equal_nan=True)
+
+    # Check that the intended branches were exercised: the box
+    # statuses, the rejected fit, and the fallback to the isophotal
+    # centroid
+    arrays = cat._get_batch_arrays()
+    iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()
+    status, peak, boxes, box_var = batch_quad_boxes(
+        arrays['data'], error=arrays['error'], mask=arrays['mask'],
+        segm=arrays['segm'],
+        labels=np.ascontiguousarray(cat.labels, dtype=np.intp),
+        bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
+        bbox_ixmax=ixmax, compute_err=1)
+    assert_array_equal(status, [1, 2, 3, 0, 0, 0, 3])
+    assert_array_equal(peak[0], [-1, -1])
+    assert_array_equal(peak[3], [2, 2])  # the masked (zero) pixel
+    assert np.all(boxes[3] <= 0)
+    assert box_var[3, 4] == 0  # the masked center pixel
+    assert np.all(box_var[5] == 0.3**2)
+    # Edge peaks report the peak position without errors
+    assert_allclose(cat._centroid_quad_results[2, :2], peak[2])
+    assert np.all(np.isnan(cat._centroid_quad_results[2, 2:]))
+    assert_allclose(cat._centroid_quad_results[6, :2], peak[6])
+    # The rejected fit falls back to the isophotal centroid
+    assert_array_equal(peak[4], [3, 3])
+    assert_allclose(cat._centroid_quad_results[4, :2],
+                    cat.cutout_centroid[4])
+
+
+def _driver_inputs(cat):
+    arrays = cat._get_batch_arrays()
+    iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()
+    return {'data': arrays['data'], 'error': arrays['error'],
+            'mask': arrays['mask'], 'segm': arrays['segm'],
+            'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
+            'bbox_iymin': iymin, 'bbox_iymax': iymax,
+            'bbox_ixmin': ixmin, 'bbox_ixmax': ixmax, 'compute_err': 1}
+
+
+def _call_driver(inp):
+    return batch_quad_boxes(inp.pop('data'), **inp)
+
+
+@pytest.mark.parametrize('name', ['bbox_iymin', 'bbox_iymax', 'bbox_ixmin',
+                                  'bbox_ixmax'])
+def test_length_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1]
+    with pytest.raises(ValueError, match='same length as labels'):
+        _call_driver(inp)
+
+
+@pytest.mark.parametrize('name', ['error', 'mask', 'segm'])
+def test_shape_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1, :]
+    with pytest.raises(ValueError, match='same shape as data'):
+        _call_driver(inp)
+
+
+def test_compute_err_without_error(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp['error'] = None
+    with pytest.raises(ValueError, match='error must be provided'):
+        _call_driver(inp)
+
+
+def test_no_error_boxes(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp['error'] = None
+    inp['compute_err'] = 0
+    _, _, _, box_var = _call_driver(inp)
+    assert np.all(box_var == 0)
+
+
+def test_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    expected = _call_driver(dict(inp))
+
+    def run(_):
+        return _call_driver(dict(inp))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(run, range(8)))
+    for result in results:
+        for got, want in zip(result, expected, strict=True):
+            assert_array_equal(got, want)

--- a/photutils/segmentation/tests/test_batch_centroid_win.py
+++ b/photutils/segmentation/tests/test_batch_centroid_win.py
@@ -386,6 +386,29 @@ def test_catalog_centroid_win(scene):
     assert cat[1:3]._batch_arrays_cache is cat._batch_arrays_cache
 
 
+def test_batch_arrays_shared_before_build(scene):
+    """
+    Test that a catalog sliced before the batch arrays are built shares
+    them with its parent, whichever of the two builds them first.
+    """
+    cat = make_catalog(scene)
+    child = cat[1:4]
+    scalar = cat[2]
+    assert 'data' not in cat._batch_arrays_cache
+    assert child._batch_arrays_cache is cat._batch_arrays_cache
+    assert scalar._batch_arrays_cache is cat._batch_arrays_cache
+
+    # Building on a slice populates the parent (and other slices)
+    arrays = scalar._get_batch_arrays()
+    assert cat._batch_arrays_cache['data'] is arrays['data']
+    assert child._get_batch_arrays() is arrays
+    assert cat._get_batch_arrays() is arrays
+
+    # The lazily added arrays are shared the same way
+    convdata = child._get_batch_convdata()
+    assert cat._get_batch_convdata() is convdata
+
+
 def test_detection_catalog(scene):
     """
     Test that the detection catalog is used when requested.

--- a/photutils/segmentation/tests/test_batch_centroid_win.py
+++ b/photutils/segmentation/tests/test_batch_centroid_win.py
@@ -12,6 +12,7 @@ import pytest
 from astropy.stats import gaussian_fwhm_to_sigma
 from numpy.testing import assert_allclose
 
+from photutils.segmentation import SourceCatalog
 from photutils.segmentation._batch_catalog import batch_centroid_win
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
@@ -330,3 +331,53 @@ def test_thread_safety(scene):
         results = list(executor.map(lambda _: run(), range(16)))
     for res in results:
         assert_allclose(res, expected, rtol=0, atol=0, equal_nan=True)
+
+
+def test_catalog_centroid_win(scene):
+    """
+    Test the SourceCatalog.centroid_win property against the batch driver.
+    """
+    cat = make_catalog(scene)
+    results = cat._centroid_win_results
+    assert results.shape == (cat.n_labels, 6)
+
+    # Slicing: cached values slice along the source axis
+    sub = cat[2:5]
+    assert_allclose(sub.centroid_win, cat.centroid_win[2:5],
+                    rtol=0, atol=0, equal_nan=True)
+
+    # Scalar catalog
+    scalar = cat[3]
+    assert scalar.isscalar
+    assert_allclose(np.atleast_2d(scalar.centroid_win),
+                    cat.centroid_win[3:4], rtol=0, atol=0,
+                    equal_nan=True)
+
+    # The full-image cast bundle is shared by reference with slices
+    cat._get_batch_arrays()
+    assert cat[1:3]._batch_arrays_cache is cat._batch_arrays_cache
+
+
+def test_detection_catalog(scene):
+    """
+    Test that the detection catalog is used when requested.
+    """
+    cat_det = make_catalog(scene)
+    cat = SourceCatalog(scene['data'] * 1.5, scene['segm'],
+                        error=scene['error'], mask=scene['mask'],
+                        detection_catalog=cat_det)
+    assert_allclose(cat.centroid_win, cat_det.centroid_win,
+                    rtol=0, atol=0, equal_nan=True)
+
+
+def test_catalog_centroid_win_precomputed_slice(scene):
+    """
+    Test that slicing a catalog after computing centroid_win is
+    equivalent to computing centroid_win after slicing the catalog.
+    """
+    cat1 = make_catalog(scene)
+    _ = cat1.centroid_win  # trigger cache, then slice
+    cat2 = make_catalog(scene)
+    sub2 = cat2[1:4]  # slice, then compute
+    assert_allclose(cat1[1:4].centroid_win, sub2.centroid_win,
+                    rtol=0, atol=0, equal_nan=True)

--- a/photutils/segmentation/tests/test_batch_centroid_win.py
+++ b/photutils/segmentation/tests/test_batch_centroid_win.py
@@ -12,13 +12,12 @@ import pytest
 from astropy.stats import gaussian_fwhm_to_sigma
 from numpy.testing import assert_allclose
 
+from photutils.aperture._segmentation import SEG_METHOD_CODES
 from photutils.segmentation import SourceCatalog
 from photutils.segmentation._batch_catalog import batch_centroid_win
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
 from photutils.segmentation.utils import _mask_to_mirrored_value
-
-SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'correct': 3}
 
 
 def _reference_iterate_centroid_win(label, xcen, ycen, rad_hl,
@@ -202,21 +201,12 @@ def scene():
     return make_batch_scene()
 
 
-def _driver_inputs(cat, scene):
+def _driver_inputs(cat):
     """
     Build the batch_centroid_win inputs for a catalog, mirroring the
     wiring in SourceCatalog._centroid_win_results.
     """
-    data = np.ascontiguousarray(scene['data'], dtype=np.float64)
-    mask_plane = np.zeros(data.shape, dtype=np.uint8)
-    if cat._mask is not None:
-        mask_plane[cat._mask] |= 1
-    mask_plane[~np.isfinite(data)] |= 2
-    error = None
-    if cat._error is not None:
-        error = np.ascontiguousarray(scene['error'], dtype=np.float64)
-    segm = np.ascontiguousarray(scene['segm'].data, dtype=np.intp)
-
+    arrays = cat._get_batch_arrays()
     radius_hl = cat.flux_radius(0.5).value.copy()
     nan_hl = ~np.isfinite(radius_hl)
     small = np.isfinite(radius_hl) & (radius_hl < 0.5)
@@ -227,8 +217,8 @@ def _driver_inputs(cat, scene):
     # np.isnan (not ~np.isfinite) for parity with the previous
     # per-source math.isnan checks
     skip = (nan_hl | np.isnan(xcen0) | np.isnan(ycen0)).astype(np.uint8)
-    return {'data': data, 'error': error, 'mask': mask_plane,
-            'segm': segm,
+    return {'data': arrays['data'], 'error': arrays['error'],
+            'mask': arrays['mask'], 'segm': arrays['segm'],
             'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
             'xcen0': xcen0, 'ycen0': ycen0, 'sigma': sigma,
             'skip': skip, 'radius_hl': radius_hl, 'nan_hl': nan_hl}
@@ -240,7 +230,7 @@ def _driver_inputs(cat, scene):
 def test_matches_reference(scene, method, with_error, with_mask):
     cat = make_catalog(scene, aperture_mask_method=method,
                        with_error=with_error, with_mask=with_mask)
-    inp = _driver_inputs(cat, scene)
+    inp = _driver_inputs(cat)
     max_aper_size = max(scene['data'].size, 1_000_000)
     result = batch_centroid_win(
         inp['data'], error=inp['error'], mask=inp['mask'],
@@ -275,7 +265,7 @@ def test_matches_reference(scene, method, with_error, with_mask):
 
 def test_skip_rows(scene):
     cat = make_catalog(scene)
-    inp = _driver_inputs(cat, scene)
+    inp = _driver_inputs(cat)
     skip = np.ones_like(inp['skip'])
     result = batch_centroid_win(
         inp['data'], error=inp['error'], mask=inp['mask'],
@@ -291,7 +281,7 @@ def test_skip_rows(scene):
 
 def test_oom_guard(scene):
     cat = make_catalog(scene)
-    inp = _driver_inputs(cat, scene)
+    inp = _driver_inputs(cat)
     result = batch_centroid_win(
         inp['data'], error=inp['error'], mask=inp['mask'],
         segm=inp['segm'], labels=inp['labels'], xcen0=inp['xcen0'],
@@ -302,7 +292,7 @@ def test_oom_guard(scene):
 
 def test_compute_err_without_error(scene):
     cat = make_catalog(scene, with_error=False)
-    inp = _driver_inputs(cat, scene)
+    inp = _driver_inputs(cat)
     match = 'error must be provided when compute_err is set'
     with pytest.raises(ValueError, match=match):
         batch_centroid_win(
@@ -324,7 +314,7 @@ def _call_driver(inp):
 @pytest.mark.parametrize('name', ['xcen0', 'ycen0', 'sigma', 'skip'])
 def test_length_guard(scene, name):
     cat = make_catalog(scene)
-    inp = _driver_inputs(cat, scene)
+    inp = _driver_inputs(cat)
     inp[name] = np.ascontiguousarray(inp[name][:-1])
     match = f'{name} must have the same length as labels'
     with pytest.raises(ValueError, match=match):
@@ -334,7 +324,7 @@ def test_length_guard(scene, name):
 @pytest.mark.parametrize('name', ['mask', 'segm', 'error'])
 def test_shape_guard(scene, name):
     cat = make_catalog(scene)
-    inp = _driver_inputs(cat, scene)
+    inp = _driver_inputs(cat)
     inp[name] = np.ascontiguousarray(inp[name][:-1])
     match = f'{name} must have the same shape as data'
     with pytest.raises(ValueError, match=match):
@@ -343,7 +333,7 @@ def test_shape_guard(scene, name):
 
 def test_thread_safety(scene):
     cat = make_catalog(scene)
-    inp = _driver_inputs(cat, scene)
+    inp = _driver_inputs(cat)
     max_aper_size = max(scene['data'].size, 1_000_000)
 
     def run():

--- a/photutils/segmentation/tests/test_batch_centroid_win.py
+++ b/photutils/segmentation/tests/test_batch_centroid_win.py
@@ -1,0 +1,332 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch centroid_win Cython driver.
+"""
+
+import math
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+from astropy.stats import gaussian_fwhm_to_sigma
+from numpy.testing import assert_allclose
+
+from photutils.segmentation._batch_catalog import batch_centroid_win
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+from photutils.segmentation.utils import _mask_to_mirrored_value
+
+SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'correct': 3}
+
+
+def _reference_iterate_centroid_win(label, xcen, ycen, rad_hl,
+                                    nan_hl_source, *, data_arr,
+                                    mask_arr, error_arr, segm_data,
+                                    data_shape, do_correct,
+                                    do_segm_mask, compute_err,
+                                    max_aper_size,
+                                    aperture_mask_method):
+    """
+    Compute the windowed centroid for a single source.
+
+    This is a verbatim port of the per-source Python implementation that
+    the batch Cython driver replaces. It is the numerical reference for
+    the driver.
+
+    Returns
+    -------
+    result : tuple of float
+        Tuple of (xcen, ycen, weighted_flux, cen_mom_xx, cen_mom_yy,
+        cen_mom_xy, err_sum, err_var_x, err_var_y, err_cov_xy).
+    """
+    nan_result = (np.nan, np.nan, 0.0, 0.0, 0.0, 0.0,
+                  np.nan, np.nan, np.nan, np.nan)
+    if nan_hl_source or math.isnan(xcen) or math.isnan(ycen):
+        return nan_result
+
+    sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
+    inv_2sigma2 = -1.0 / (2.0 * sigma * sigma)
+    radius = 4.0 * sigma
+    radius_sq = radius * radius
+
+    # Compute the full (unclipped) bounding box for the aperture
+    # using the initial centroid. The radius is fixed, so the
+    # bbox size stays the same across iterations even if the
+    # center shifts slightly.
+    bbox_halfsize = int(radius + 1.5)
+    full_ny = full_nx = 2 * bbox_halfsize + 1
+
+    # OOM guard
+    if full_ny * full_nx > max_aper_size:
+        return nan_result
+
+    # Cache for cutout data when the integer bbox doesn't change
+    prev_ixcen = prev_iycen = None
+    cached_data = cached_mask = cached_var = None
+
+    max_iters = 16
+    centroid_threshold = 0.0001
+    iter_ = 0
+    dcen = 1.0
+    weighted_flux = 0.0
+    dx_mom = dy_mom = 0.0
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        while iter_ < max_iters and dcen > centroid_threshold:
+            # Compute integer bounding box
+            ixmin = int(xcen + 0.5) - bbox_halfsize
+            ixmax = ixmin + full_nx
+            iymin = int(ycen + 0.5) - bbox_halfsize
+            iymax = iymin + full_ny
+
+            # Clip to data boundaries
+            slc_y = slice(max(0, iymin), min(data_shape[0], iymax))
+            slc_x = slice(max(0, ixmin), min(data_shape[1], ixmax))
+            if (slc_y.start >= slc_y.stop
+                    or slc_x.start >= slc_x.stop):
+                xcen = np.nan
+                ycen = np.nan
+                break
+
+            cur_ixcen = int(xcen + 0.5)
+            cur_iycen = int(ycen + 0.5)
+
+            # Recompute cutout data only when the integer center
+            # changes to avoid redundant _mask_to_mirrored_value
+            # calls
+            if cur_ixcen != prev_ixcen or cur_iycen != prev_iycen:
+                prev_ixcen = cur_ixcen
+                prev_iycen = cur_iycen
+
+                data = data_arr[slc_y, slc_x].astype(float)
+                data_mask = ~np.isfinite(data)
+                if mask_arr is not None:
+                    data_mask |= mask_arr[slc_y, slc_x]
+
+                cutout_xycen = (xcen - max(0, ixmin),
+                                ycen - max(0, iymin))
+
+                if do_segm_mask:
+                    seg_cut = segm_data[slc_y, slc_x]
+                    segm_mask = ((seg_cut != label)
+                                 & (seg_cut != 0))
+                    if aperture_mask_method == 'mask':
+                        data_mask = data_mask | segm_mask
+
+                if do_correct:
+                    data = _mask_to_mirrored_value(
+                        data, segm_mask, cutout_xycen,
+                        mask=data_mask)
+
+                cached_data = data
+                cached_mask = data_mask
+
+                if compute_err:
+                    var = error_arr[slc_y, slc_x].astype(float)**2
+                    if do_correct:
+                        # Pixels replaced by mirrored data values
+                        # also use the mirrored pixel's variance
+                        var = _mask_to_mirrored_value(
+                            var, segm_mask, cutout_xycen,
+                            mask=data_mask)
+                    var[data_mask] = 0.0
+                    cached_var = var
+
+            # Centroid position in cutout coordinates
+            cx = xcen - max(0, ixmin)
+            cy = ycen - max(0, iymin)
+
+            ny = slc_y.stop - slc_y.start
+            nx = slc_x.stop - slc_x.start
+
+            # Build coordinate grids relative to centroid
+            # (reused for circle mask, Gaussian, and moments)
+            xvals = np.arange(nx) - cx
+            yvals = np.arange(ny) - cy
+            xx = xvals[np.newaxis, :]
+            yy = yvals[:, np.newaxis]
+
+            # Inline binary circle mask
+            rr2 = xx * xx + yy * yy
+            aper_weights = (rr2 <= radius_sq).astype(float)
+
+            # Inline Gaussian weight
+            gweight = np.exp(rr2 * inv_2sigma2)
+
+            # Apply weights and mask
+            weighted = (cached_data * aper_weights * gweight)
+            weighted[cached_mask] = 0.0
+
+            # Inline moment computation
+            weighted_flux = np.sum(weighted)
+            dx_mom = np.sum(weighted * xx) / weighted_flux
+            dy_mom = np.sum(weighted * yy) / weighted_flux
+
+            dcen = math.sqrt(dx_mom * dx_mom
+                             + dy_mom * dy_mom)
+            xcen += dx_mom * 2.0
+            ycen += dy_mom * 2.0
+            iter_ += 1
+
+        # Compute the windowed central 2nd-order moments (for
+        # the fallback checks) and the raw error
+        # sums from the last iteration, relative to
+        # the pre-update center.
+        cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
+        err_sum = err_var_x = err_var_y = err_cov_xy = np.nan
+        if np.isfinite(weighted_flux) and weighted_flux > 0:
+            cen_mom_xx = (np.sum(weighted * xx * xx)
+                          / weighted_flux - dx_mom * dx_mom)
+            cen_mom_yy = (np.sum(weighted * yy * yy)
+                          / weighted_flux - dy_mom * dy_mom)
+            cen_mom_xy = (np.sum(weighted * xx * yy)
+                          / weighted_flux - dx_mom * dy_mom)
+
+            if compute_err:
+                weighted_var = ((aper_weights * gweight)**2
+                                * cached_var)
+                err_sum = np.sum(weighted_var)
+                err_var_x = np.sum(weighted_var * xx * xx)
+                err_var_y = np.sum(weighted_var * yy * yy)
+                err_cov_xy = np.sum(weighted_var * xx * yy)
+
+    return (xcen, ycen, weighted_flux, cen_mom_xx,
+            cen_mom_yy, cen_mom_xy,
+            err_sum, err_var_x, err_var_y, err_cov_xy)
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+def _driver_inputs(cat, scene):
+    """
+    Build the batch_centroid_win inputs for a catalog, mirroring the
+    wiring in SourceCatalog._centroid_win_results.
+    """
+    data = np.ascontiguousarray(scene['data'], dtype=np.float64)
+    mask_plane = np.zeros(data.shape, dtype=np.uint8)
+    if cat._mask is not None:
+        mask_plane[cat._mask] |= 1
+    mask_plane[~np.isfinite(data)] |= 2
+    error = None
+    if cat._error is not None:
+        error = np.ascontiguousarray(scene['error'], dtype=np.float64)
+    segm = np.ascontiguousarray(scene['segm'].data, dtype=np.intp)
+
+    radius_hl = cat.flux_radius(0.5).value.copy()
+    nan_hl = ~np.isfinite(radius_hl)
+    small = np.isfinite(radius_hl) & (radius_hl < 0.5)
+    radius_hl[small] = 0.5
+    sigma = 2.0 * radius_hl * gaussian_fwhm_to_sigma
+    xcen0 = np.atleast_1d(cat.x_centroid).astype(np.float64)
+    ycen0 = np.atleast_1d(cat.y_centroid).astype(np.float64)
+    # np.isnan (not ~np.isfinite) for parity with the previous
+    # per-source math.isnan checks
+    skip = (nan_hl | np.isnan(xcen0) | np.isnan(ycen0)).astype(np.uint8)
+    return {'data': data, 'error': error, 'mask': mask_plane,
+            'segm': segm,
+            'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
+            'xcen0': xcen0, 'ycen0': ycen0, 'sigma': sigma,
+            'skip': skip, 'radius_hl': radius_hl, 'nan_hl': nan_hl}
+
+
+@pytest.mark.parametrize('method', ['correct', 'mask', 'none'])
+@pytest.mark.parametrize('with_error', [True, False])
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_matches_reference(scene, method, with_error, with_mask):
+    cat = make_catalog(scene, aperture_mask_method=method,
+                       with_error=with_error, with_mask=with_mask)
+    inp = _driver_inputs(cat, scene)
+    max_aper_size = max(scene['data'].size, 1_000_000)
+    result = batch_centroid_win(
+        inp['data'], error=inp['error'], mask=inp['mask'],
+        segm=inp['segm'], labels=inp['labels'], xcen0=inp['xcen0'],
+        ycen0=inp['ycen0'], sigma=inp['sigma'], skip=inp['skip'],
+        seg_method=SEG_METHOD_CODES[method],
+        compute_err=int(with_error), max_aper_size=max_aper_size)
+
+    assert result.shape == (len(inp['labels']), 10)
+    ref_kwargs = {
+        'data_arr': scene['data'],
+        'mask_arr': scene['mask'] if with_mask else None,
+        'error_arr': scene['error'] if with_error else None,
+        'segm_data': scene['segm'].data,
+        'data_shape': scene['data'].shape,
+        'do_correct': method == 'correct',
+        'do_segm_mask': method != 'none',
+        'compute_err': with_error,
+        'max_aper_size': max_aper_size,
+        'aperture_mask_method': method,
+    }
+    for i, label in enumerate(inp['labels']):
+        ref = _reference_iterate_centroid_win(
+            label, inp['xcen0'][i], inp['ycen0'][i],
+            inp['radius_hl'][i], inp['nan_hl'][i], **ref_kwargs)
+        # atol covers cancellation-limited near-zero central moments;
+        # positions and flux are far from zero and are effectively
+        # checked at rtol
+        assert_allclose(result[i], np.array(ref), rtol=1e-12,
+                        atol=1e-10, equal_nan=True)
+
+
+def test_skip_rows(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat, scene)
+    skip = np.ones_like(inp['skip'])
+    result = batch_centroid_win(
+        inp['data'], error=inp['error'], mask=inp['mask'],
+        segm=inp['segm'], labels=inp['labels'], xcen0=inp['xcen0'],
+        ycen0=inp['ycen0'], sigma=inp['sigma'], skip=skip,
+        seg_method=3, compute_err=1,
+        max_aper_size=scene['data'].size)
+    expected = np.array([np.nan, np.nan, 0.0, 0.0, 0.0, 0.0,
+                         np.nan, np.nan, np.nan, np.nan])
+    for row in result:
+        assert_allclose(row, expected, equal_nan=True)
+
+
+def test_oom_guard(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat, scene)
+    result = batch_centroid_win(
+        inp['data'], error=inp['error'], mask=inp['mask'],
+        segm=inp['segm'], labels=inp['labels'], xcen0=inp['xcen0'],
+        ycen0=inp['ycen0'], sigma=inp['sigma'], skip=inp['skip'],
+        seg_method=3, compute_err=1, max_aper_size=4)
+    assert np.all(np.isnan(result[:, 0]))
+
+
+def test_compute_err_without_error(scene):
+    cat = make_catalog(scene, with_error=False)
+    inp = _driver_inputs(cat, scene)
+    match = 'error must be provided when compute_err is set'
+    with pytest.raises(ValueError, match=match):
+        batch_centroid_win(
+            inp['data'], error=None, mask=inp['mask'],
+            segm=inp['segm'], labels=inp['labels'],
+            xcen0=inp['xcen0'], ycen0=inp['ycen0'],
+            sigma=inp['sigma'], skip=inp['skip'], seg_method=3,
+            compute_err=1, max_aper_size=scene['data'].size)
+
+
+def test_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat, scene)
+    max_aper_size = max(scene['data'].size, 1_000_000)
+
+    def run():
+        return batch_centroid_win(
+            inp['data'], error=inp['error'], mask=inp['mask'],
+            segm=inp['segm'], labels=inp['labels'],
+            xcen0=inp['xcen0'], ycen0=inp['ycen0'],
+            sigma=inp['sigma'], skip=inp['skip'], seg_method=3,
+            compute_err=1, max_aper_size=max_aper_size)
+
+    expected = run()
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: run(), range(16)))
+    for res in results:
+        assert_allclose(res, expected, rtol=0, atol=0, equal_nan=True)

--- a/photutils/segmentation/tests/test_batch_centroid_win.py
+++ b/photutils/segmentation/tests/test_batch_centroid_win.py
@@ -313,6 +313,34 @@ def test_compute_err_without_error(scene):
             compute_err=1, max_aper_size=scene['data'].size)
 
 
+def _call_driver(inp):
+    return batch_centroid_win(
+        inp['data'], error=inp['error'], mask=inp['mask'],
+        segm=inp['segm'], labels=inp['labels'], xcen0=inp['xcen0'],
+        ycen0=inp['ycen0'], sigma=inp['sigma'], skip=inp['skip'],
+        seg_method=3, compute_err=1, max_aper_size=inp['data'].size)
+
+
+@pytest.mark.parametrize('name', ['xcen0', 'ycen0', 'sigma', 'skip'])
+def test_length_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat, scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same length as labels'
+    with pytest.raises(ValueError, match=match):
+        _call_driver(inp)
+
+
+@pytest.mark.parametrize('name', ['mask', 'segm', 'error'])
+def test_shape_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat, scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same shape as data'
+    with pytest.raises(ValueError, match=match):
+        _call_driver(inp)
+
+
 def test_thread_safety(scene):
     cat = make_catalog(scene)
     inp = _driver_inputs(cat, scene)

--- a/photutils/segmentation/tests/test_batch_circular.py
+++ b/photutils/segmentation/tests/test_batch_circular.py
@@ -1,0 +1,175 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch circular photometry path.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from photutils.aperture import CircularAperture
+from photutils.segmentation import SegmentationImage, SourceCatalog
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog,
+                                                       reference_aperture_data)
+
+
+def _reference_aperture_to_mask(cat, aperture, **kwargs):
+    # Verbatim port of the previous ``_aperture_to_mask`` method
+    bbox = aperture.bbox
+    max_size = max(cat._data.size, 1_000_000)
+    if bbox.shape[0] * bbox.shape[1] > max_size:
+        return None
+    return aperture.to_mask(**kwargs)
+
+
+def _reference_aperture_photometry(cat, apertures, **kwargs):
+    """
+    Compute the aperture flux and flux error for each source.
+
+    This is a verbatim port of the per-source ``_aperture_photometry``
+    method that the batch Cython driver replaces. It is the numerical
+    reference for the driver.
+    """
+    flux = []
+    flux_err = []
+    for label, aperture, bkg in zip(cat.labels, apertures,
+                                    cat._local_background, strict=True):
+        if aperture is None:
+            flux.append(np.nan)
+            flux_err.append(np.nan)
+            continue
+
+        xcen, ycen = aperture.positions
+        aperture_mask = _reference_aperture_to_mask(cat, aperture, **kwargs)
+        if aperture_mask is None:
+            flux.append(np.nan)
+            flux_err.append(np.nan)
+            continue
+
+        data, error, mask, _, slc_sm, _ = reference_aperture_data(
+            cat, label, xcen, ycen, aperture_mask.bbox, bkg)
+
+        aperture_weights = aperture_mask.data[slc_sm]
+        pixel_mask = (aperture_weights > 0) & ~mask
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            values = (aperture_weights * data)[pixel_mask]
+            flux_ = np.nan if values.shape == (0,) else np.sum(values)
+            flux.append(flux_)
+
+            if error is None:
+                flux_err_ = np.nan
+            else:
+                values = (aperture_weights**2 * error**2)[pixel_mask]
+                if values.shape == (0,):
+                    flux_err_ = np.nan
+                else:
+                    flux_err_ = np.sqrt(np.sum(values))
+            flux_err.append(flux_err_)
+
+    return np.array(flux), np.array(flux_err)
+
+
+def _reference_circular_photometry(cat, radius):
+    apertures = cat._make_circular_apertures(radius)
+    kwargs = cat._aperture_mask_kwargs['circ']
+    return _reference_aperture_photometry(cat, apertures, **kwargs)
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('method', ['correct', 'mask', 'none'])
+@pytest.mark.parametrize('with_error', [True, False])
+@pytest.mark.parametrize('with_mask', [True, False])
+@pytest.mark.parametrize('radius', [1.5, 4.0, 12.0])
+def test_matches_reference(scene, method, with_error, with_mask, radius):
+    cat = make_catalog(scene, aperture_mask_method=method,
+                       with_error=with_error, with_mask=with_mask)
+    ref_flux, ref_err = _reference_circular_photometry(cat, radius)
+    flux, flux_err = cat.circular_photometry(radius)
+    assert_allclose(flux, ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(flux_err, ref_err, rtol=1e-12, equal_nan=True)
+
+
+@pytest.mark.parametrize('kwargs', [{'method': 'center'},
+                                    {'method': 'subpixel', 'subpixels': 5}])
+def test_overlap_methods(scene, kwargs):
+    cat = make_catalog(scene)
+    cat._aperture_mask_kwargs['circ'] = kwargs
+    ref_flux, ref_err = _reference_circular_photometry(cat, 4.0)
+    flux, flux_err = cat.circular_photometry(4.0)
+    assert_allclose(flux, ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(flux_err, ref_err, rtol=1e-12, equal_nan=True)
+
+
+def test_local_background(scene):
+    cat = SourceCatalog(scene['data'], scene['segm'], error=scene['error'],
+                        mask=scene['mask'], local_bkg_width=6)
+    ref_flux, ref_err = _reference_circular_photometry(cat, 4.0)
+    flux, flux_err = cat.circular_photometry(4.0)
+    assert_allclose(flux, ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(flux_err, ref_err, rtol=1e-12, equal_nan=True)
+
+
+def test_all_masked_and_nonfinite_centroid(scene):
+    # A fully masked source has no centroid and a NaN flux; a source
+    # whose centroid is non-finite is also NaN
+    data = scene['data'].copy()
+    mask = scene['mask'].copy()
+    segm = scene['segm']
+    slc = segm.slices[0]
+    mask[slc] |= segm.data[slc] == segm.labels[0]
+    cat = SourceCatalog(data, segm, mask=mask, error=scene['error'])
+    ref_flux, ref_err = _reference_circular_photometry(cat, 3.0)
+    flux, flux_err = cat.circular_photometry(3.0)
+    assert np.isnan(flux[0])
+    assert np.isnan(flux_err[0])
+    assert_allclose(flux, ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(flux_err, ref_err, rtol=1e-12, equal_nan=True)
+
+
+def test_oom_guard_and_off_image():
+    # A circle whose bounding box exceeds the 1M-pixel guard is NaN,
+    # and a centroid far outside the data gives a NaN flux
+    data = np.zeros((21, 21))
+    data[8:13, 8:13] = 10.0
+    segm_data = np.zeros((21, 21), dtype=int)
+    segm_data[8:13, 8:13] = 1
+    segm = SegmentationImage(segm_data)
+    cat = SourceCatalog(data, segm)
+    assert_allclose(cat.circular_photometry(3.0)[0],
+                    _reference_circular_photometry(cat, 3.0)[0])
+    flux, flux_err = cat.circular_photometry(600.0)
+    assert np.isnan(flux[0])
+    assert np.isnan(flux_err[0])
+
+    cat.__dict__['x_centroid'] = np.array([500.0])
+    cat.__dict__['y_centroid'] = np.array([500.0])
+    flux, flux_err = cat.circular_photometry(3.0)
+    assert np.isnan(flux[0])
+    assert np.isnan(flux_err[0])
+
+
+def test_scalar_catalog(scene):
+    cat = make_catalog(scene)[0]
+    ref_flux, ref_err = _reference_circular_photometry(cat, 4.0)
+    flux, flux_err = cat.circular_photometry(4.0)
+    assert np.isscalar(flux)
+    assert np.isscalar(flux_err)
+    assert_allclose(flux, ref_flux[0], rtol=1e-12)
+    assert_allclose(flux_err, ref_err[0], rtol=1e-12)
+
+
+def test_aperture_objects_unchanged(scene):
+    # The public make_circular_apertures helper still returns the
+    # aperture objects (None where undefined)
+    cat = make_catalog(scene)
+    apertures = cat.make_circular_apertures(3.0)
+    assert len(apertures) == cat.n_labels
+    assert all(isinstance(aper, CircularAperture) for aper in apertures)

--- a/photutils/segmentation/tests/test_batch_flux_radius.py
+++ b/photutils/segmentation/tests/test_batch_flux_radius.py
@@ -3,6 +3,7 @@
 Tests for the batch flux_radius solve driver.
 """
 
+import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -113,3 +114,19 @@ def test_bracket_shrink_and_no_solution(scene):
                  entry[1], entry[2], entry[3]]]
     assert np.isnan(batch_flux_radius_solve(hopeless,
                                             fraction=0.5)[0])
+
+
+def test_catalog_flux_radius(scene):
+    cat = make_catalog(scene)
+    expected = _reference_solve(cat._flux_radius_optimizer_args, 0.5)
+    result = cat.flux_radius(0.5)
+    assert result.unit == u.pix
+    assert_allclose(result.value, expected, rtol=1e-12,
+                    equal_nan=True)
+
+    # Cache round-trip and named property
+    cat.flux_radius(0.3, name='r30')
+    assert_allclose(cat.r30.value,
+                    _reference_solve(
+                        cat._flux_radius_optimizer_args, 0.3),
+                    rtol=1e-12, equal_nan=True)

--- a/photutils/segmentation/tests/test_batch_flux_radius.py
+++ b/photutils/segmentation/tests/test_batch_flux_radius.py
@@ -1,0 +1,115 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch flux_radius solve driver.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.optimize import root_scalar
+
+from photutils.geometry import circular_overlap_grid
+from photutils.segmentation._batch_catalog import batch_flux_radius_solve
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+
+
+def _reference_solve(args_list, fraction):
+    # Verbatim port of the pre-change flux_radius solve loop
+    # (catalog.py:5465-5507) and _flux_radius_fcn (catalog.py:
+    # 5289-5302), operating on the optimizer-args entries
+    def fcn(radius, clean_data, grid_params, normflux):
+        xmin_e, xmax_e, ymin_e, ymax_e, nx, ny, exact, subpx = \
+            grid_params
+        weights = circular_overlap_grid(xmin_e, xmax_e, ymin_e,
+                                        ymax_e, nx, ny, radius,
+                                        exact, subpx)
+        return 1.0 - (np.sum(clean_data * weights) / normflux)
+
+    radius = []
+    for entry in args_list:
+        if entry is None:
+            radius.append(np.nan)
+            continue
+        clean_data, grid_params, kronflux, max_radius = entry
+        normflux = kronflux * fraction
+        found = False
+        min_radius = 0.1
+        max_radius_delta = 0.1 * max_radius
+        while max_radius > min_radius and found is False:
+            try:
+                result = root_scalar(
+                    fcn, args=(clean_data, grid_params, normflux),
+                    bracket=[min_radius, max_radius],
+                    method='brentq')
+                result = result.root
+                found = True
+            except ValueError:
+                max_radius -= max_radius_delta
+        if found is False:
+            result = np.nan
+        radius.append(result)
+    return np.array(radius)
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('method', ['correct', 'mask', 'none'])
+@pytest.mark.parametrize('fraction', [0.2, 0.5, 0.9])
+def test_matches_reference(scene, method, fraction):
+    cat = make_catalog(scene, aperture_mask_method=method)
+    args = cat._flux_radius_optimizer_args
+    expected = _reference_solve(args, fraction)
+    result = batch_flux_radius_solve(args, fraction=fraction)
+    assert_allclose(result, expected, rtol=1e-12, equal_nan=True)
+
+
+def test_none_entries(scene):
+    cat = make_catalog(scene)
+    args = list(cat._flux_radius_optimizer_args)
+    args[0] = None
+    result = batch_flux_radius_solve(args, fraction=0.5)
+    assert np.isnan(result[0])
+    assert_allclose(result, _reference_solve(args, 0.5), rtol=1e-12,
+                    equal_nan=True)
+
+
+def test_bracket_shrink_and_no_solution(scene):
+    # Force the shrink path: negative data beyond a ring makes the
+    # enclosed flux non-monotonic, so the initial bracket has equal
+    # signs at both ends
+    cat = make_catalog(scene)
+    entry = [e for e in cat._flux_radius_optimizer_args
+             if e is not None][0]
+    clean_data = entry[0].copy()
+    yc = entry[0].shape[0] / 2
+    xc = entry[0].shape[1] / 2
+    yy, xx = np.mgrid[0:entry[0].shape[0], 0:entry[0].shape[1]]
+    rr = np.hypot(xx - xc, yy - yc)
+    clean_data[rr > 3] = -np.abs(clean_data[rr > 3]) - 1.0
+    forced = [[np.ascontiguousarray(clean_data), entry[1], entry[2],
+               entry[3]]]
+    assert_allclose(batch_flux_radius_solve(forced, fraction=0.5),
+                    _reference_solve(forced, 0.5), rtol=1e-12,
+                    equal_nan=True)
+
+    # A milder outer ring, where shrinking the bracket does reveal a
+    # sign change and a root is found on a later retry
+    shrink_data = entry[0].copy()
+    shrink_data[rr > 3] = -1.0
+    shrink = [[np.ascontiguousarray(shrink_data), entry[1], entry[2],
+               entry[3]]]
+    expected = _reference_solve(shrink, 0.5)
+    assert np.isfinite(expected[0])
+    assert_allclose(batch_flux_radius_solve(shrink, fraction=0.5),
+                    expected, rtol=1e-12)
+
+    # And a hopeless case that shrinks to no solution -> NaN
+    hopeless = [[np.ascontiguousarray(np.full_like(clean_data,
+                                                   -1.0)),
+                 entry[1], entry[2], entry[3]]]
+    assert np.isnan(batch_flux_radius_solve(hopeless,
+                                            fraction=0.5)[0])

--- a/photutils/segmentation/tests/test_batch_flux_radius.py
+++ b/photutils/segmentation/tests/test_batch_flux_radius.py
@@ -16,9 +16,8 @@ from photutils.segmentation.tests._batch_scene import (make_batch_scene,
 
 
 def _reference_solve(args_list, fraction):
-    # Verbatim port of the pre-change flux_radius solve loop
-    # (catalog.py:5465-5507) and _flux_radius_fcn (catalog.py:
-    # 5289-5302), operating on the optimizer-args entries
+    # Verbatim port of the pre-change ``flux_radius`` solve loop and
+    # ``_flux_radius_fcn``, operating on the optimizer-args entries
     def fcn(radius, clean_data, grid_params, normflux):
         xmin_e, xmax_e, ymin_e, ymax_e, nx, ny, exact, subpx = \
             grid_params
@@ -124,7 +123,7 @@ def test_catalog_flux_radius(scene):
     assert_allclose(result.value, expected, rtol=1e-12,
                     equal_nan=True)
 
-    # Cache round-trip and named property
+    # Named property
     cat.flux_radius(0.3, name='r30')
     assert_allclose(cat.r30.value,
                     _reference_solve(

--- a/photutils/segmentation/tests/test_batch_flux_radius.py
+++ b/photutils/segmentation/tests/test_batch_flux_radius.py
@@ -3,16 +3,136 @@
 Tests for the batch flux_radius solve driver.
 """
 
+import math
+from concurrent.futures import ThreadPoolExecutor
+
 import astropy.units as u
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 from scipy.optimize import root_scalar
 
 from photutils.geometry import circular_overlap_grid
-from photutils.segmentation._batch_catalog import batch_flux_radius_solve
+from photutils.segmentation import SourceCatalog
+from photutils.segmentation._batch_catalog import (batch_flux_radius_prepare,
+                                                   batch_flux_radius_solve)
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
+from photutils.segmentation.utils import _mask_to_mirrored_value
+
+
+def _reference_optimizer_args(cat):
+    """
+    Prepare the per-source flux-radius root-find arguments.
+
+    This is a verbatim port of the per-source Python implementation
+    of ``_flux_radius_optimizer_args`` that the batch Cython
+    preparation replaces. It is the numerical reference for the
+    preparation.
+    """
+    kron_flux = cat._kron_photometry[:, 0]  # unitless
+    max_radius = cat._max_circular_kron_radius
+    kwargs = cat._aperture_mask_kwargs['flux_radius']
+
+    method = kwargs.get('method', 'exact')
+    if method == 'exact':
+        use_exact = 1
+        subpixels = 1
+    elif method == 'center':
+        use_exact = 0
+        subpixels = 1
+    else:  # 'subpixel'
+        use_exact = 0
+        subpixels = kwargs.get('subpixels', 5)
+
+    data_arr = cat._data
+    mask_arr = cat._mask
+    segm_data = cat._segmentation_image.data
+    data_shape = data_arr.shape
+    aperture_mask_method = cat.aperture_mask_method
+    max_aper_size = max(data_arr.size, 1_000_000)
+
+    x_centroid = np.atleast_1d(cat.x_centroid)
+    y_centroid = np.atleast_1d(cat.y_centroid)
+
+    args = []
+    for label, xcen, ycen, kronflux, bkg, max_radius_ in zip(
+            cat.labels, x_centroid, y_centroid,
+            kron_flux, cat._local_background, max_radius, strict=True):
+
+        if (np.any(~np.isfinite((xcen, ycen, kronflux, max_radius_)))
+                or kronflux == 0):
+            args.append(None)
+            continue
+
+        ixmin = math.floor(xcen - max_radius_ + 0.5)
+        ixmax = math.ceil(xcen + max_radius_ + 0.5)
+        iymin = math.floor(ycen - max_radius_ + 0.5)
+        iymax = math.ceil(ycen + max_radius_ + 0.5)
+
+        bbox_ny = iymax - iymin
+        bbox_nx = ixmax - ixmin
+        if bbox_ny * bbox_nx > max_aper_size:
+            args.append(None)
+            continue
+
+        data_ymin = max(0, iymin)
+        data_ymax = min(data_shape[0], iymax)
+        data_xmin = max(0, ixmin)
+        data_xmax = min(data_shape[1], ixmax)
+        if data_ymin >= data_ymax or data_xmin >= data_xmax:
+            args.append(None)
+            continue
+
+        slc_lg = (slice(data_ymin, data_ymax), slice(data_xmin, data_xmax))
+        cutout_data = data_arr[slc_lg].astype(float) - bkg
+
+        data_mask = ~np.isfinite(cutout_data)
+        if mask_arr is not None:
+            data_mask |= mask_arr[slc_lg]
+
+        cutout_xcen = xcen - data_xmin
+        cutout_ycen = ycen - data_ymin
+
+        if aperture_mask_method != 'none':
+            seg_cut = segm_data[slc_lg]
+            segm_mask = (seg_cut != label) & (seg_cut != 0)
+            if aperture_mask_method == 'mask':
+                data_mask = data_mask | segm_mask
+            elif aperture_mask_method == 'correct':
+                cutout_data = _mask_to_mirrored_value(
+                    cutout_data, segm_mask,
+                    (cutout_xcen, cutout_ycen), mask=data_mask)
+
+        clean_data = cutout_data.copy()
+        clean_data[data_mask] = 0.0
+
+        ny, nx = clean_data.shape
+        xmin_edge = -0.5 - cutout_xcen
+        xmax_edge = nx - 0.5 - cutout_xcen
+        ymin_edge = -0.5 - cutout_ycen
+        ymax_edge = ny - 0.5 - cutout_ycen
+        grid_params = (xmin_edge, xmax_edge, ymin_edge, ymax_edge,
+                       nx, ny, use_exact, subpixels)
+
+        args.append([clean_data, grid_params, kronflux, max_radius_])
+
+    return args
+
+
+def _assert_args_equal(args, expected):
+    assert len(args) == len(expected)
+    for entry, ref in zip(args, expected, strict=True):
+        if ref is None:
+            assert entry is None
+            continue
+        assert entry is not None
+        assert_array_equal(entry[0], ref[0])
+        assert entry[0].dtype == np.float64
+        assert entry[0].flags.c_contiguous
+        assert entry[1] == ref[1]
+        assert entry[2] == ref[2]
+        assert entry[3] == ref[3]
 
 
 def _reference_solve(args_list, fraction):
@@ -113,6 +233,114 @@ def test_bracket_shrink_and_no_solution(scene):
                  entry[1], entry[2], entry[3]]]
     assert np.isnan(batch_flux_radius_solve(hopeless,
                                             fraction=0.5)[0])
+
+
+@pytest.mark.parametrize('method', ['correct', 'mask', 'none'])
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_prepare_matches_reference(scene, method, with_mask):
+    cat = make_catalog(scene, aperture_mask_method=method,
+                       with_mask=with_mask)
+    expected = _reference_optimizer_args(cat)
+    assert sum(entry is not None for entry in expected) > 0
+    _assert_args_equal(cat._flux_radius_optimizer_args, expected)
+
+
+@pytest.mark.parametrize('kwargs', [{'method': 'center'},
+                                    {'method': 'subpixel', 'subpixels': 5}])
+def test_prepare_overlap_methods(scene, kwargs):
+    cat = make_catalog(scene)
+    cat._aperture_mask_kwargs['flux_radius'] = kwargs
+    _assert_args_equal(cat._flux_radius_optimizer_args,
+                       _reference_optimizer_args(cat))
+    assert_allclose(cat.flux_radius(0.5).value,
+                    _reference_solve(_reference_optimizer_args(cat), 0.5),
+                    rtol=1e-12, equal_nan=True)
+
+
+def test_prepare_local_background(scene):
+    cat = SourceCatalog(scene['data'], scene['segm'], error=scene['error'],
+                        mask=scene['mask'], local_bkg_width=6)
+    assert np.any(cat._local_background != 0)
+    _assert_args_equal(cat._flux_radius_optimizer_args,
+                       _reference_optimizer_args(cat))
+
+
+def test_prepare_skipped_sources(scene):
+    # A non-finite centroid, a zero Kron flux, and an off-image centroid
+    # have no solution, and an oversized bounding box is skipped
+    cat = make_catalog(scene)
+    _ = cat._kron_photometry
+    xcen = cat.x_centroid.copy()
+    xcen[0] = np.nan
+    xcen[1] = 5000.0
+    cat.__dict__['x_centroid'] = xcen
+    kron = cat._kron_photometry.copy()
+    kron[2, 0] = 0.0
+    cat.__dict__['_kron_photometry'] = kron
+    expected = _reference_optimizer_args(cat)
+    assert expected[0] is None
+    assert expected[1] is None
+    assert expected[2] is None
+    _assert_args_equal(cat._flux_radius_optimizer_args, expected)
+
+    cat = make_catalog(scene)
+    _ = cat._kron_photometry
+    cat.__dict__['_max_circular_kron_radius'] = np.full(cat.n_labels,
+                                                        2000.0)
+    assert all(entry is None for entry in cat._flux_radius_optimizer_args)
+
+
+def _prepare_inputs(cat):
+    arrays = cat._get_batch_arrays()
+    n_src = cat.n_labels
+    return {'data': arrays['data'], 'mask': arrays['mask'],
+            'segm': arrays['segm'],
+            'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
+            'xcen': np.ascontiguousarray(cat.x_centroid, dtype=float),
+            'ycen': np.ascontiguousarray(cat.y_centroid, dtype=float),
+            'local_bkg': np.zeros(n_src),
+            'kronflux': np.ones(n_src),
+            'max_radius': np.full(n_src, 5.0),
+            'skip': np.zeros(n_src, dtype=np.uint8),
+            'seg_method': 3, 'use_exact': 1, 'subpixels': 1,
+            'max_aper_size': 1_000_000}
+
+
+def _call_prepare(inp):
+    return batch_flux_radius_prepare(inp.pop('data'), **inp)
+
+
+@pytest.mark.parametrize('name', ['xcen', 'ycen', 'local_bkg', 'kronflux',
+                                  'max_radius', 'skip'])
+def test_prepare_length_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _prepare_inputs(cat)
+    inp[name] = inp[name][:-1]
+    with pytest.raises(ValueError, match='same length as labels'):
+        _call_prepare(inp)
+
+
+@pytest.mark.parametrize('name', ['mask', 'segm'])
+def test_prepare_shape_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _prepare_inputs(cat)
+    inp[name] = inp[name][:-1, :]
+    with pytest.raises(ValueError, match='same shape as data'):
+        _call_prepare(inp)
+
+
+def test_prepare_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _prepare_inputs(cat)
+    expected = _call_prepare(dict(inp))
+
+    def run(_):
+        return _call_prepare(dict(inp))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(run, range(8)))
+    for result in results:
+        _assert_args_equal(result, expected)
 
 
 def test_catalog_flux_radius(scene):

--- a/photutils/segmentation/tests/test_batch_flux_radius.py
+++ b/photutils/segmentation/tests/test_batch_flux_radius.py
@@ -20,6 +20,11 @@ from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
 from photutils.segmentation.utils import _mask_to_mirrored_value
 
+# The batch solver accumulates the flux in a different order from the
+# reference, which perturbs the Brent iteration path, so the roots can
+# differ by up to the solver's absolute tolerance (xtol = 2e-12 pixels)
+RADIUS_ATOL = 4e-12
+
 
 def _reference_optimizer_args(cat):
     """
@@ -184,7 +189,8 @@ def test_matches_reference(scene, method, fraction):
     args = cat._flux_radius_optimizer_args
     expected = _reference_solve(args, fraction)
     result = batch_flux_radius_solve(args, fraction=fraction)
-    assert_allclose(result, expected, rtol=1e-12, equal_nan=True)
+    assert_allclose(result, expected, rtol=1e-12, atol=RADIUS_ATOL,
+                    equal_nan=True)
 
 
 def test_none_entries(scene):
@@ -194,7 +200,7 @@ def test_none_entries(scene):
     result = batch_flux_radius_solve(args, fraction=0.5)
     assert np.isnan(result[0])
     assert_allclose(result, _reference_solve(args, 0.5), rtol=1e-12,
-                    equal_nan=True)
+                    atol=RADIUS_ATOL, equal_nan=True)
 
 
 def test_bracket_shrink_and_no_solution(scene):
@@ -214,7 +220,7 @@ def test_bracket_shrink_and_no_solution(scene):
                entry[3]]]
     assert_allclose(batch_flux_radius_solve(forced, fraction=0.5),
                     _reference_solve(forced, 0.5), rtol=1e-12,
-                    equal_nan=True)
+                    atol=RADIUS_ATOL, equal_nan=True)
 
     # A milder outer ring, where shrinking the bracket does reveal a
     # sign change and a root is found on a later retry
@@ -225,7 +231,7 @@ def test_bracket_shrink_and_no_solution(scene):
     expected = _reference_solve(shrink, 0.5)
     assert np.isfinite(expected[0])
     assert_allclose(batch_flux_radius_solve(shrink, fraction=0.5),
-                    expected, rtol=1e-12)
+                    expected, rtol=1e-12, atol=RADIUS_ATOL)
 
     # And a hopeless case that shrinks to no solution -> NaN
     hopeless = [[np.ascontiguousarray(np.full_like(clean_data,
@@ -254,7 +260,7 @@ def test_prepare_overlap_methods(scene, kwargs):
                        _reference_optimizer_args(cat))
     assert_allclose(cat.flux_radius(0.5).value,
                     _reference_solve(_reference_optimizer_args(cat), 0.5),
-                    rtol=1e-12, equal_nan=True)
+                    rtol=1e-12, atol=RADIUS_ATOL, equal_nan=True)
 
 
 def test_prepare_local_background(scene):
@@ -348,7 +354,7 @@ def test_catalog_flux_radius(scene):
     expected = _reference_solve(cat._flux_radius_optimizer_args, 0.5)
     result = cat.flux_radius(0.5)
     assert result.unit == u.pix
-    assert_allclose(result.value, expected, rtol=1e-12,
+    assert_allclose(result.value, expected, rtol=1e-12, atol=RADIUS_ATOL,
                     equal_nan=True)
 
     # Named property
@@ -356,4 +362,4 @@ def test_catalog_flux_radius(scene):
     assert_allclose(cat.r30.value,
                     _reference_solve(
                         cat._flux_radius_optimizer_args, 0.3),
-                    rtol=1e-12, equal_nan=True)
+                    rtol=1e-12, atol=RADIUS_ATOL, equal_nan=True)

--- a/photutils/segmentation/tests/test_batch_kron.py
+++ b/photutils/segmentation/tests/test_batch_kron.py
@@ -274,7 +274,8 @@ def test_uncorrectable_members_give_zero_flux():
         0.0, 1, 1, arrays['segm'], np.array([1], dtype=np.intp), 3,
         np.zeros(1), 0,
         params_per_source=np.array([[aperture.a, aperture.b,
-                                     aperture.theta.to_value(u.rad)]]))[9]
+                                     aperture.theta.to_value(u.rad)]]),
+    ).flag_counts
     assert fcounts[0, FLAG_COL_VALID] == 0
     assert fcounts[0, FLAG_COL_UNCORRECTED] > 0
 

--- a/photutils/segmentation/tests/test_batch_kron.py
+++ b/photutils/segmentation/tests/test_batch_kron.py
@@ -19,7 +19,8 @@ from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
 from photutils.segmentation import SegmentationImage, SourceCatalog
 from photutils.segmentation.flags import SEGMENTATION_FLAGS
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
-                                                       make_catalog)
+                                                       make_catalog,
+                                                       reference_aperture_data)
 
 
 def _reference_kron_photometry(cat, kron_aperture):
@@ -105,8 +106,8 @@ def _reference_kron_photometry(cat, kron_aperture):
 
         bbox = BoundingBox(ixmin, ixmax, iymin, iymax)
         (data, error, mask, _, slc_sm,
-         flag_masks) = cat._make_aperture_data(label, xcen, ycen, bbox,
-                                               bkg)
+         flag_masks) = reference_aperture_data(cat, label, xcen, ycen,
+                                               bbox, bkg)
         if data is None:
             flux.append(np.nan)
             flux_err.append(np.nan)

--- a/photutils/segmentation/tests/test_batch_kron.py
+++ b/photutils/segmentation/tests/test_batch_kron.py
@@ -12,8 +12,11 @@ import pytest
 from numpy.testing import assert_allclose
 
 from photutils.aperture import BoundingBox, CircularAperture
+from photutils.aperture._batch_photometry import (FLAG_COL_UNCORRECTED,
+                                                  FLAG_COL_VALID, SHAPE_CIRCLE,
+                                                  batch_aperture_sums)
 from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
-from photutils.segmentation import SourceCatalog
+from photutils.segmentation import SegmentationImage, SourceCatalog
 from photutils.segmentation.flags import SEGMENTATION_FLAGS
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
@@ -214,3 +217,80 @@ def test_mixed_aperture_types(scene):
         assert_allclose(np.asarray(got, dtype=float),
                         np.asarray(want, dtype=float), rtol=1e-12,
                         equal_nan=True)
+
+
+def _make_uncorrectable_catalog(method):
+    """
+    Make a catalog whose first source has a Kron aperture lying
+    entirely on a neighboring segment.
+
+    Every pixel of that aperture is on the neighboring segment and so
+    is its mirror across the aperture center, so under the 'correct'
+    method none of them can be corrected and the aperture has no valid
+    members.
+
+    Returns
+    -------
+    result : `~photutils.segmentation.SourceCatalog`
+        The source catalog.
+    """
+    yy, xx = np.mgrid[0:41, 0:41]
+    data = 0.5 + 20.0 * np.exp(-((xx - 6) ** 2 + (yy - 6) ** 2) / 8.0)
+    data += 30.0 * np.exp(-((xx - 25) ** 2 + (yy - 25) ** 2) / 50.0)
+    segm_data = np.zeros(data.shape, dtype=int)
+    segm_data[3:10, 3:10] = 1
+    segm_data[16:35, 16:35] = 2
+    cat = SourceCatalog(data, SegmentationImage(segm_data),
+                        error=np.full(data.shape, 0.5),
+                        aperture_mask_method=method)
+    _ = cat.kron_aperture  # cache before overriding
+    apertures = list(cat._array('kron_aperture'))
+    apertures[0] = CircularAperture((25.0, 25.0), r=3.0)
+    cat.__dict__['kron_aperture'] = apertures
+    return cat
+
+
+def test_uncorrectable_members_give_zero_flux():
+    cat = _make_uncorrectable_catalog('correct')
+
+    # Check that the construction gives an aperture whose only members
+    # are uncorrectable neighbor pixels
+    arrays = cat._get_batch_arrays()
+    fcounts = batch_aperture_sums(
+        arrays['data'], arrays['error'], arrays['mask'],
+        np.array([[25.0, 25.0]]), SHAPE_CIRCLE, None, 0.0, 0.0, 0.0,
+        0.0, 1, 1, arrays['segm'], np.array([1], dtype=np.intp), 3,
+        np.zeros(1), 0, params_per_source=np.array([[3.0]]))[9]
+    assert fcounts[0, FLAG_COL_VALID] == 0
+    assert fcounts[0, FLAG_COL_UNCORRECTED] > 0
+
+    flux, flux_err, kron_flags = cat._calc_kron_photometry()
+    ref_flux, ref_err, ref_flags = _reference_kron_photometry(
+        cat, cat._array('kron_aperture'))
+
+    # Uncorrectable neighbor pixels stay members with a value of zero,
+    # so the flux is 0.0 rather than NaN
+    assert flux[0] == 0.0
+    assert flux_err[0] == 0.0
+    assert (kron_flags[0]
+            & SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS) != 0
+    assert_allclose(flux, ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(flux_err, ref_err, rtol=1e-12, equal_nan=True)
+    assert np.array_equal(kron_flags, ref_flags)
+
+
+def test_uncorrectable_members_masked_give_nan_flux():
+    cat = _make_uncorrectable_catalog('mask')
+    flux, flux_err, kron_flags = cat._calc_kron_photometry()
+    ref_flux, ref_err, ref_flags = _reference_kron_photometry(
+        cat, cat._array('kron_aperture'))
+
+    # The 'mask' method excludes the neighbor pixels outright, leaving
+    # the aperture with no members at all
+    assert np.isnan(flux[0])
+    assert np.isnan(flux_err[0])
+    assert (kron_flags[0]
+            & SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS) == 0
+    assert_allclose(flux, ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(flux_err, ref_err, rtol=1e-12, equal_nan=True)
+    assert np.array_equal(kron_flags, ref_flags)

--- a/photutils/segmentation/tests/test_batch_kron.py
+++ b/photutils/segmentation/tests/test_batch_kron.py
@@ -1,0 +1,216 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch Kron photometry path.
+"""
+
+import math
+import warnings
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from photutils.aperture import BoundingBox, CircularAperture
+from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
+from photutils.segmentation import SourceCatalog
+from photutils.segmentation.flags import SEGMENTATION_FLAGS
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+
+
+def _reference_kron_photometry(cat, kron_aperture):
+    """
+    Compute the Kron flux, flux error, and flags for each source.
+
+    This is a verbatim port of the per-source Python implementation
+    that the batch Cython driver replaces. It is the numerical
+    reference for the driver.
+
+    Returns
+    -------
+    flux, flux_err, kron_flags : tuple of `~numpy.ndarray`
+        The Kron flux, flux error, and bitwise quality flags.
+    """
+    labels = cat.labels
+
+    _floor = math.floor
+    max_size = max(cat._data.size, 1_000_000)
+    ny_img, nx_img = cat._data.shape
+
+    flux = []
+    flux_err = []
+    kron_flags = []
+    for label, aperture, bkg in zip(labels, kron_aperture,
+                                    cat._local_background, strict=True):
+        if aperture is None:
+            flux.append(np.nan)
+            flux_err.append(np.nan)
+            kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
+            continue
+
+        xcen, ycen = aperture.positions
+
+        # Compute the aperture mask directly, bypassing the
+        # aperture's to_mask() method and ApertureMask/BoundingBox
+        # property overhead.
+        if isinstance(aperture, CircularAperture):
+            r = aperture.r
+            ixmin = _floor(xcen - r + 0.5)
+            ixmax = _floor(xcen + r + 1.5)
+            iymin = _floor(ycen - r + 0.5)
+            iymax = _floor(ycen + r + 1.5)
+            nx = ixmax - ixmin
+            ny = iymax - iymin
+            if nx * ny > max_size:
+                flux.append(np.nan)
+                flux_err.append(np.nan)
+                kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
+                continue
+            edges = (ixmin - 0.5 - xcen, ixmax - 0.5 - xcen,
+                     iymin - 0.5 - ycen, iymax - 0.5 - ycen)
+            mask_data = circular_overlap_grid(
+                edges[0], edges[1], edges[2], edges[3],
+                nx, ny, r, 1, 1)
+        else:
+            a = aperture.a
+            b = aperture.b
+            theta_val = aperture.theta
+            theta_rad = (theta_val.to_value(u.radian)
+                         if hasattr(theta_val, 'to')
+                         else float(theta_val))
+            cos_t = math.cos(theta_rad)
+            sin_t = math.sin(theta_rad)
+            x_ext = math.sqrt((a * cos_t) ** 2 + (b * sin_t) ** 2)
+            y_ext = math.sqrt((a * sin_t) ** 2 + (b * cos_t) ** 2)
+            ixmin = _floor(xcen - x_ext + 0.5)
+            ixmax = _floor(xcen + x_ext + 1.5)
+            iymin = _floor(ycen - y_ext + 0.5)
+            iymax = _floor(ycen + y_ext + 1.5)
+            nx = ixmax - ixmin
+            ny = iymax - iymin
+            if nx * ny > max_size:
+                flux.append(np.nan)
+                flux_err.append(np.nan)
+                kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
+                continue
+            edges = (ixmin - 0.5 - xcen, ixmax - 0.5 - xcen,
+                     iymin - 0.5 - ycen, iymax - 0.5 - ycen)
+            mask_data = elliptical_overlap_grid(
+                edges[0], edges[1], edges[2], edges[3],
+                nx, ny, a, b, theta_rad, 1, 1)
+
+        bbox = BoundingBox(ixmin, ixmax, iymin, iymax)
+        (data, error, mask, _, slc_sm,
+         flag_masks) = cat._make_aperture_data(label, xcen, ycen, bbox,
+                                               bkg)
+        if data is None:
+            flux.append(np.nan)
+            flux_err.append(np.nan)
+            kron_flags.append(SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
+            continue
+
+        aperture_weights = mask_data[slc_sm]
+        in_aperture = aperture_weights > 0
+        pixel_mask = in_aperture & ~mask
+
+        kron_flag = 0
+        # The aperture bounding box extends beyond the data array.
+        # The box corners can have zero aperture weight, so compare
+        # the number of nonzero-weight pixels within the data to the
+        # total number in the aperture. The overlap is partial only
+        # if at least one nonzero-weight pixel falls both inside and
+        # outside of the data.
+        if (ixmin < 0 or iymin < 0 or ixmax > nx_img
+                or iymax > ny_img):
+            n_inside = np.count_nonzero(in_aperture)
+            if n_inside == 0:
+                kron_flag |= SEGMENTATION_FLAGS.KRON_NO_OVERLAP
+            elif n_inside != np.count_nonzero(mask_data):
+                kron_flag |= SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP
+
+        if np.any(flag_masks['data_mask'] & in_aperture):
+            kron_flag |= SEGMENTATION_FLAGS.KRON_MASKED_PIXELS
+
+        segm_mask = flag_masks['segm_mask']
+        if segm_mask is not None and np.any(segm_mask & in_aperture):
+            kron_flag |= SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS
+
+        uncorrected_mask = flag_masks['uncorrected_mask']
+        if (uncorrected_mask is not None
+                and np.any(uncorrected_mask & in_aperture)):
+            kron_flag |= SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS
+
+        kron_flags.append(kron_flag)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            values = (aperture_weights * data)[pixel_mask]
+            flux_ = np.nan if values.shape == (0,) else np.sum(values)
+            flux.append(flux_)
+
+            if error is None:
+                flux_err_ = np.nan
+            else:
+                values = (aperture_weights**2 * error**2)[pixel_mask]
+                if values.shape == (0,):
+                    flux_err_ = np.nan
+                else:
+                    flux_err_ = np.sqrt(np.sum(values))
+            flux_err.append(flux_err_)
+
+    flux = np.array(flux)
+    flux_err = np.array(flux_err)
+    kron_flags = np.array(kron_flags, dtype=int)
+
+    return flux, flux_err, kron_flags
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('method', ['correct', 'mask', 'none'])
+@pytest.mark.parametrize('with_error', [True, False])
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_matches_reference(scene, method, with_error, with_mask):
+    cat = make_catalog(scene, aperture_mask_method=method,
+                       with_error=with_error, with_mask=with_mask)
+    kron_aperture = cat._array('kron_aperture')
+    ref_flux, ref_err, ref_flags = _reference_kron_photometry(
+        cat, kron_aperture)
+    flux, flux_err, kron_flags = cat._calc_kron_photometry()
+    assert_allclose(flux, ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(flux_err, ref_err, rtol=1e-12, equal_nan=True)
+    assert np.array_equal(kron_flags, ref_flags)
+
+
+def test_custom_kron_params(scene):
+    cat = make_catalog(scene)
+    result = cat.kron_photometry((1.8, 1.0))
+    apertures = cat._make_kron_apertures(
+        cat._validate_kron_params((1.8, 1.0)))
+    ref_flux, ref_err, _ = _reference_kron_photometry(cat, apertures)
+    assert_allclose(result[0], ref_flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(result[1], ref_err, rtol=1e-12, equal_nan=True)
+
+
+def test_mixed_aperture_types(scene):
+    # A minimum circular radius makes the sources whose scaled Kron
+    # ellipse is smaller than that radius circular, while the larger
+    # sources stay elliptical; then both driver groups run in one
+    # _calc_kron_photometry call
+    cat = SourceCatalog(scene['data'], scene['segm'],
+                        error=scene['error'], mask=scene['mask'],
+                        aperture_mask_method='correct',
+                        kron_params=(2.5, 1.4, 5.0))
+    apertures = cat._array('kron_aperture')
+    types = {type(ap).__name__ for ap in apertures if ap is not None}
+    assert types == {'CircularAperture', 'EllipticalAperture'}
+    ref = _reference_kron_photometry(cat, apertures)
+    result = cat._calc_kron_photometry()
+    for got, want in zip(result, ref, strict=True):
+        assert_allclose(np.asarray(got, dtype=float),
+                        np.asarray(want, dtype=float), rtol=1e-12,
+                        equal_nan=True)

--- a/photutils/segmentation/tests/test_batch_kron.py
+++ b/photutils/segmentation/tests/test_batch_kron.py
@@ -13,7 +13,8 @@ from numpy.testing import assert_allclose
 
 from photutils.aperture import BoundingBox, CircularAperture
 from photutils.aperture._batch_photometry import (FLAG_COL_UNCORRECTED,
-                                                  FLAG_COL_VALID, SHAPE_CIRCLE,
+                                                  FLAG_COL_VALID,
+                                                  SHAPE_ELLIPSE,
                                                   batch_aperture_sums)
 from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
 from photutils.segmentation import SegmentationImage, SourceCatalog
@@ -225,15 +226,19 @@ def _make_uncorrectable_catalog(method):
     Make a catalog whose first source has a Kron aperture lying
     entirely on a neighboring segment.
 
-    Every pixel of that aperture is on the neighboring segment and so
-    is its mirror across the aperture center, so under the 'correct'
-    method none of them can be corrected and the aperture has no valid
-    members.
+    The first source's centroid is moved to the center of the
+    neighboring segment after its Kron radius is measured, so its Kron
+    ellipse and the mirror of every pixel across the aperture center
+    lie on the neighboring segment. Under the 'correct' method none of
+    them can be corrected and the aperture has no valid members.
 
     Returns
     -------
     result : `~photutils.segmentation.SourceCatalog`
         The source catalog.
+
+    apertures : list
+        The reference Kron apertures for the moved centroid.
     """
     yy, xx = np.mgrid[0:41, 0:41]
     data = 0.5 + 20.0 * np.exp(-((xx - 6) ** 2 + (yy - 6) ** 2) / 8.0)
@@ -244,30 +249,38 @@ def _make_uncorrectable_catalog(method):
     cat = SourceCatalog(data, SegmentationImage(segm_data),
                         error=np.full(data.shape, 0.5),
                         aperture_mask_method=method)
-    _ = cat.kron_aperture  # cache before overriding
-    apertures = list(cat._array('kron_aperture'))
-    apertures[0] = CircularAperture((25.0, 25.0), r=3.0)
-    cat.__dict__['kron_aperture'] = apertures
-    return cat
+    _ = cat.kron_radius  # measure the Kron radii before moving
+    xcen = cat.x_centroid.copy()
+    ycen = cat.y_centroid.copy()
+    xcen[0] = 25.0
+    ycen[0] = 25.0
+    cat.__dict__['x_centroid'] = xcen
+    cat.__dict__['y_centroid'] = ycen
+    apertures = cat._make_kron_apertures(cat.kron_params)
+    assert apertures[0].a < 9  # lies within the neighboring segment
+    return cat, apertures
 
 
 def test_uncorrectable_members_give_zero_flux():
-    cat = _make_uncorrectable_catalog('correct')
+    cat, apertures = _make_uncorrectable_catalog('correct')
 
     # Check that the construction gives an aperture whose only members
     # are uncorrectable neighbor pixels
+    aperture = apertures[0]
     arrays = cat._get_batch_arrays()
     fcounts = batch_aperture_sums(
         arrays['data'], arrays['error'], arrays['mask'],
-        np.array([[25.0, 25.0]]), SHAPE_CIRCLE, None, 0.0, 0.0, 0.0,
+        np.array([[25.0, 25.0]]), SHAPE_ELLIPSE, None, 0.0, 0.0, 0.0,
         0.0, 1, 1, arrays['segm'], np.array([1], dtype=np.intp), 3,
-        np.zeros(1), 0, params_per_source=np.array([[3.0]]))[9]
+        np.zeros(1), 0,
+        params_per_source=np.array([[aperture.a, aperture.b,
+                                     aperture.theta.to_value(u.rad)]]))[9]
     assert fcounts[0, FLAG_COL_VALID] == 0
     assert fcounts[0, FLAG_COL_UNCORRECTED] > 0
 
     flux, flux_err, kron_flags = cat._calc_kron_photometry()
     ref_flux, ref_err, ref_flags = _reference_kron_photometry(
-        cat, cat._array('kron_aperture'))
+        cat, apertures)
 
     # Uncorrectable neighbor pixels stay members with a value of zero,
     # so the flux is 0.0 rather than NaN
@@ -281,10 +294,10 @@ def test_uncorrectable_members_give_zero_flux():
 
 
 def test_uncorrectable_members_masked_give_nan_flux():
-    cat = _make_uncorrectable_catalog('mask')
+    cat, apertures = _make_uncorrectable_catalog('mask')
     flux, flux_err, kron_flags = cat._calc_kron_photometry()
     ref_flux, ref_err, ref_flags = _reference_kron_photometry(
-        cat, cat._array('kron_aperture'))
+        cat, apertures)
 
     # The 'mask' method excludes the neighbor pixels outright, leaving
     # the aperture with no members at all

--- a/photutils/segmentation/tests/test_batch_kron_radius.py
+++ b/photutils/segmentation/tests/test_batch_kron_radius.py
@@ -1,0 +1,329 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch Kron radius Cython kernel.
+"""
+
+import math
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from photutils.segmentation import SegmentationImage, SourceCatalog
+from photutils.segmentation._batch_catalog import batch_kron_radius
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+from photutils.segmentation.utils import _mask_to_mirrored_value
+
+
+def _reference_measured_kron_radius(cat):
+    """
+    Compute the unscaled measured Kron radius of each source.
+
+    This is a verbatim port of the per-source Python implementation
+    of ``_measured_kron_radius`` that the batch Cython kernel
+    replaces. It is the numerical reference for the kernel.
+    """
+    scale = 6.0
+
+    xcen_arr = cat._array('x_centroid')
+    ycen_arr = cat._array('y_centroid')
+    a_arr = cat._array('semimajor_axis').value * scale
+    b_arr = cat._array('semiminor_axis').value * scale
+    theta_arr = cat._array('orientation').to_value(u.radian)
+    cxx_arr = cat._array('ellipse_cxx').value
+    cxy_arr = cat._array('ellipse_cxy').value
+    cyy_arr = cat._array('ellipse_cyy').value
+    all_masked = cat._all_masked
+
+    data_full = cat._data
+    data_shape = data_full.shape
+    mask_full = cat._mask
+    segm_data = cat._segmentation_image.data
+    max_size = max(data_full.size, 1_000_000)
+    kron_min = cat.kron_params[1]
+    min_circ_radius = (cat.kron_params[2]
+                       if len(cat.kron_params) == 3 else 0.0)
+    aperture_mask_method = cat.aperture_mask_method
+
+    kron_radius = []
+    for (label, xc, yc, a, b, theta, cxx_, cxy_, cyy_,
+         masked) in zip(cat.labels, xcen_arr, ycen_arr, a_arr, b_arr,
+                        theta_arr, cxx_arr, cxy_arr, cyy_arr,
+                        all_masked, strict=True):
+        if masked or not (math.isfinite(xc) and math.isfinite(yc)
+                          and math.isfinite(a) and math.isfinite(b)
+                          and math.isfinite(theta)):
+            kron_radius.append(np.nan)
+            continue
+
+        use_circular = (a == 0 and b == 0)
+        if use_circular:
+            if min_circ_radius <= 0:
+                kron_radius.append(np.nan)
+                continue
+            half_w = min_circ_radius
+            half_h = min_circ_radius
+        else:
+            cos_theta = math.cos(theta)
+            sin_theta = math.sin(theta)
+            half_w = math.sqrt(a * a * cos_theta * cos_theta
+                               + b * b * sin_theta * sin_theta)
+            half_h = math.sqrt(a * a * sin_theta * sin_theta
+                               + b * b * cos_theta * cos_theta)
+
+        ixmin = math.floor(xc - half_w + 0.5)
+        ixmax = math.floor(xc + half_w + 0.5) + 1
+        iymin = math.floor(yc - half_h + 0.5)
+        iymax = math.floor(yc + half_h + 0.5) + 1
+
+        if (ixmax - ixmin) * (iymax - iymin) > max_size:
+            kron_radius.append(np.nan)
+            continue
+
+        dx_min = max(0, -ixmin)
+        dy_min = max(0, -iymin)
+        dx_max = max(0, ixmax - data_shape[1])
+        dy_max = max(0, iymax - data_shape[0])
+        lg_xmin = ixmin + dx_min
+        lg_xmax = ixmax - dx_max
+        lg_ymin = iymin + dy_min
+        lg_ymax = iymax - dy_max
+        if lg_xmin >= lg_xmax or lg_ymin >= lg_ymax:
+            kron_radius.append(np.nan)
+            continue
+
+        slc_lg = (slice(lg_ymin, lg_ymax), slice(lg_xmin, lg_xmax))
+        data = data_full[slc_lg].astype(float)
+
+        data_mask = ~np.isfinite(data)
+        if mask_full is not None:
+            data_mask |= mask_full[slc_lg]
+
+        if aperture_mask_method != 'none':
+            seg_cut = segm_data[slc_lg]
+            segm_mask = (seg_cut != label) & (seg_cut != 0)
+            if aperture_mask_method == 'mask':
+                mask = data_mask | segm_mask
+            else:
+                mask = data_mask
+            if aperture_mask_method == 'correct':
+                cutout_xycen = (xc - max(0, ixmin), yc - max(0, iymin))
+                data = _mask_to_mirrored_value(data, segm_mask,
+                                               cutout_xycen,
+                                               mask=mask)
+        else:
+            mask = data_mask
+
+        ny, nx = data.shape
+        xval = np.arange(nx) - (xc - lg_xmin)
+        yval = np.arange(ny) - (yc - lg_ymin)
+        yy = yval[:, np.newaxis]
+        xx = xval[np.newaxis, :]
+
+        rr_sq = cxx_ * xx * xx + cxy_ * xx * yy + cyy_ * yy * yy
+        rr = np.sqrt(np.maximum(rr_sq, 0.0))
+
+        if use_circular:
+            dx = xx
+            dy = yy
+            pixel_mask = ((dx * dx + dy * dy)
+                          <= min_circ_radius * min_circ_radius) & ~mask
+        else:
+            pixel_mask = (rr <= scale) & ~mask
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            flux_numer = np.sum(data[pixel_mask] * rr[pixel_mask])
+            flux_denom = np.sum(data[pixel_mask])
+
+        if flux_numer <= 0 or flux_denom <= 0:
+            kron_radius.append(kron_min)
+            continue
+
+        kron_radius.append(flux_numer / flux_denom)
+
+    return np.array(kron_radius)
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('method', ['correct', 'mask', 'none'])
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_matches_reference(scene, method, with_mask):
+    cat = make_catalog(scene, aperture_mask_method=method,
+                       with_mask=with_mask)
+    expected = _reference_measured_kron_radius(cat)
+    assert_allclose(cat._measured_kron_radius, expected, rtol=1e-12,
+                    equal_nan=True)
+    assert np.any(np.isfinite(expected))
+
+
+def test_negative_data_gives_minimum_radius(scene):
+    # A negative background within the measurement ellipse makes the
+    # Kron numerator or denominator non-positive, which gives the
+    # minimum Kron radius
+    data = scene['data'].copy()
+    data[scene['segm'].data == 0] = -20.0
+    cat = SourceCatalog(data, scene['segm'], kron_params=(2.5, 1.7))
+    expected = _reference_measured_kron_radius(cat)
+    assert np.any(expected == 1.7)
+    assert_allclose(cat._measured_kron_radius, expected, rtol=1e-12,
+                    equal_nan=True)
+
+
+def test_nonfinite_and_masked_sources(scene):
+    # A completely masked source or a non-finite centroid is NaN
+    mask = scene['mask'].copy()
+    segm = scene['segm']
+    slc = segm.slices[0]
+    mask[slc] |= segm.data[slc] == segm.labels[0]
+    cat = SourceCatalog(scene['data'], segm, mask=mask)
+    xcen = cat.x_centroid.copy()
+    xcen[1] = np.nan
+    cat.__dict__['x_centroid'] = xcen
+    expected = _reference_measured_kron_radius(cat)
+    assert np.isnan(expected[0])
+    assert np.isnan(expected[1])
+    assert_allclose(cat._measured_kron_radius, expected, rtol=1e-12,
+                    equal_nan=True)
+
+
+@pytest.mark.parametrize('kron_params', [(2.5, 1.4, 5.0), (2.5, 1.4)])
+def test_circular_fallback(scene, kron_params):
+    # Zero semimajor and semiminor axes use the circle of minimum
+    # radius, or give NaN if there is no minimum circular radius
+    cat = make_catalog(scene)
+    cat.kron_params = kron_params
+    n_src = cat.n_labels
+    zero = np.zeros(n_src) << u.pix
+    cxx = np.ones(n_src) / (u.pix * u.pix)
+    cxy = np.zeros(n_src) / (u.pix * u.pix)
+    with (patch.object(type(cat), 'semimajor_axis',
+                       new_callable=lambda: property(lambda _self: zero)),
+          patch.object(type(cat), 'semiminor_axis',
+                       new_callable=lambda: property(lambda _self: zero)),
+          patch.object(type(cat), 'ellipse_cxx',
+                       new_callable=lambda: property(lambda _self: cxx)),
+          patch.object(type(cat), 'ellipse_cyy',
+                       new_callable=lambda: property(lambda _self: cxx)),
+          patch.object(type(cat), 'ellipse_cxy',
+                       new_callable=lambda: property(lambda _self: cxy))):
+        expected = _reference_measured_kron_radius(cat)
+        result = cat._measured_kron_radius
+    if len(kron_params) == 3:
+        assert np.any(np.isfinite(expected))
+    else:
+        assert np.all(np.isnan(expected))
+    assert_allclose(result, expected, rtol=1e-12, equal_nan=True)
+
+
+def test_oom_guard_and_off_image(scene):
+    cat = make_catalog(scene)
+    n_src = cat.n_labels
+    huge = np.full(n_src, 1e6) << u.pix
+    with patch.object(type(cat), 'semimajor_axis',
+                      new_callable=lambda: property(lambda _self: huge)):
+        assert np.all(np.isnan(cat._measured_kron_radius))
+
+    cat = make_catalog(scene)
+    cat.__dict__['x_centroid'] = np.full(n_src, 5000.0)
+    cat.__dict__['y_centroid'] = np.full(n_src, 5000.0)
+    assert np.all(np.isnan(cat._measured_kron_radius))
+
+
+def test_partially_off_image():
+    # An ellipse whose bounding box extends beyond every data edge
+    data = np.zeros((15, 15))
+    yy, xx = np.mgrid[0:15, 0:15]
+    data += 10.0 * np.exp(-((xx - 7) ** 2 + (yy - 7) ** 2) / 32.0)
+    segm = SegmentationImage((data > 0.5).astype(int))
+    cat = SourceCatalog(data, segm)
+    expected = _reference_measured_kron_radius(cat)
+    assert np.isfinite(expected[0])
+    assert_allclose(cat._measured_kron_radius, expected, rtol=1e-12)
+
+
+def _driver_inputs(cat):
+    arrays = cat._get_batch_arrays()
+    n_src = cat.n_labels
+    return {'data': arrays['data'], 'mask': arrays['mask'],
+            'segm': arrays['segm'],
+            'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
+            'xcen': np.ascontiguousarray(cat.x_centroid, dtype=float),
+            'ycen': np.ascontiguousarray(cat.y_centroid, dtype=float),
+            'semimajor': np.ascontiguousarray(cat.semimajor_axis.value),
+            'semiminor': np.ascontiguousarray(cat.semiminor_axis.value),
+            'theta': np.ascontiguousarray(
+                cat.orientation.to_value(u.radian)),
+            'cxx': np.ascontiguousarray(cat.ellipse_cxx.value),
+            'cxy': np.ascontiguousarray(cat.ellipse_cxy.value),
+            'cyy': np.ascontiguousarray(cat.ellipse_cyy.value),
+            'skip': np.zeros(n_src, dtype=np.uint8),
+            'seg_method': 3, 'scale': 6.0, 'min_circ_radius': 0.0,
+            'max_aper_size': 1_000_000}
+
+
+def _call_driver(inp):
+    return batch_kron_radius(inp.pop('data'), **inp)
+
+
+@pytest.mark.parametrize('name', ['xcen', 'ycen', 'semimajor', 'semiminor',
+                                  'theta', 'cxx', 'cxy', 'cyy', 'skip'])
+def test_length_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1]
+    with pytest.raises(ValueError, match='same length as labels'):
+        _call_driver(inp)
+
+
+@pytest.mark.parametrize('name', ['mask', 'segm'])
+def test_shape_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1, :]
+    with pytest.raises(ValueError, match='same shape as data'):
+        _call_driver(inp)
+
+
+def test_skip_rows(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp['skip'][0] = 1
+    result = _call_driver(inp)
+    assert np.all(np.isnan(result[0]))
+    assert np.all(np.isfinite(result[1:]))
+
+
+def test_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    expected = _call_driver(dict(inp))
+
+    def run(_):
+        return _call_driver(dict(inp))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(run, range(8)))
+    for result in results:
+        assert_allclose(result, expected, rtol=0, atol=0)
+
+
+def test_catalog_kron_radius(scene):
+    # The catalog kron_radius applies the minimum radius and the
+    # measurement-scale limit to the measured value
+    cat = make_catalog(scene)
+    measured = _reference_measured_kron_radius(cat)
+    expected = measured.copy()
+    expected[expected > 6.0] = np.nan
+    expected[expected < cat.kron_params[1]] = cat.kron_params[1]
+    assert_allclose(cat.kron_radius.value, expected, rtol=1e-12,
+                    equal_nan=True)

--- a/photutils/segmentation/tests/test_batch_minmax_index.py
+++ b/photutils/segmentation/tests/test_batch_minmax_index.py
@@ -1,0 +1,204 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch minimum and maximum value position kernel.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from photutils.segmentation import SegmentationImage, SourceCatalog
+from photutils.segmentation._batch_catalog import batch_minmax_index
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+
+
+def _reference_cutout_index(cat, argfunc):
+    """
+    The cutout-frame position of an extreme value of each source.
+
+    This is a verbatim port of the per-source ``cutout_min_value_index``
+    and ``cutout_max_value_index`` loops that the batch kernel
+    replaces. It is the reference for the kernel.
+    """
+    idx = []
+    for arr in cat._array('data_cutout_masked'):
+        if np.all(arr.mask):
+            idx.append((np.nan, np.nan))
+        else:
+            idx.append(np.unravel_index(argfunc(arr), arr.shape))
+    return np.array(idx)
+
+
+def _reference_index(cat, cutout_index):
+    """
+    The verbatim port of the previous ``min_value_index`` and
+    ``max_value_index`` loops, adding the bounding-box origin.
+    """
+    out = []
+    for idx, slc in zip(cutout_index, cat._slices_iter, strict=True):
+        out.append((idx[0] + slc[0].start, idx[1] + slc[1].start))
+    return np.array(out)
+
+
+def _assert_index_equal(result, expected):
+    assert result.shape == expected.shape
+    assert result.dtype.kind == expected.dtype.kind
+    assert_array_equal(result, expected)
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_matches_reference(scene, with_mask):
+    cat = make_catalog(scene, with_mask=with_mask)
+    cutout_min = _reference_cutout_index(cat, np.argmin)
+    cutout_max = _reference_cutout_index(cat, np.argmax)
+    _assert_index_equal(cat.cutout_min_value_index, cutout_min)
+    _assert_index_equal(cat.cutout_max_value_index, cutout_max)
+    _assert_index_equal(cat.min_value_index, _reference_index(cat, cutout_min))
+    _assert_index_equal(cat.max_value_index, _reference_index(cat, cutout_max))
+    assert_array_equal(cat.min_value_xindex, cat.min_value_index[:, 1])
+    assert_array_equal(cat.min_value_yindex, cat.min_value_index[:, 0])
+    assert_array_equal(cat.max_value_xindex, cat.max_value_index[:, 1])
+    assert_array_equal(cat.max_value_yindex, cat.max_value_index[:, 0])
+    # Integer positions when no source is completely masked
+    assert cat.min_value_index.dtype.kind == 'i'
+    # The positions hold the extreme values
+    data = scene['data']
+    ymin, xmin = cat.min_value_index.T
+    ymax, xmax = cat.max_value_index.T
+    assert_array_equal(data[ymin, xmin], cat.min_value)
+    assert_array_equal(data[ymax, xmax], cat.max_value)
+
+
+def test_ties_and_all_masked():
+    """
+    Test the first occurrence of a repeated extreme, a completely
+    masked source (NaN positions and a float result), and a source
+    whose extremes lie on the bounding-box edges.
+    """
+    data = np.zeros((30, 30))
+    segm_data = np.zeros(data.shape, dtype=int)
+    mask = np.zeros(data.shape, dtype=bool)
+    # Label 1: constant source, so every pixel ties
+    data[2:6, 2:7] = 4.0
+    segm_data[2:6, 2:7] = 1
+    # Label 2: completely masked
+    data[10:14, 10:14] = 1.0
+    segm_data[10:14, 10:14] = 2
+    mask[10:14, 10:14] = True
+    # Label 3: minimum at the top-left and maximum at the bottom-right
+    # corner of the bounding box, with a masked would-be maximum
+    yy, xx = np.mgrid[0:6, 0:8]
+    data[18:24, 18:26] = xx + yy
+    data[20, 21] = 100.0
+    mask[20, 21] = True
+    segm_data[18:24, 18:26] = 3
+    # Label 4: repeated minimum whose first occurrence is not first in
+    # the (non-rectangular) segment's bounding box
+    data[2:7, 15:22] = 5.0
+    data[3, 16] = -1.0
+    data[5, 20] = -1.0
+    segm_data[2:7, 15:22] = 4
+    segm_data[2, 15:17] = 0
+    cat = SourceCatalog(data, SegmentationImage(segm_data), mask=mask)
+
+    cutout_min = _reference_cutout_index(cat, np.argmin)
+    cutout_max = _reference_cutout_index(cat, np.argmax)
+    _assert_index_equal(cat.cutout_min_value_index, cutout_min)
+    _assert_index_equal(cat.cutout_max_value_index, cutout_max)
+    _assert_index_equal(cat.min_value_index, _reference_index(cat, cutout_min))
+    _assert_index_equal(cat.max_value_index, _reference_index(cat, cutout_max))
+
+    # A completely masked source gives NaN positions and a float array
+    assert cat.min_value_index.dtype.kind == 'f'
+    assert np.all(np.isnan(cat.min_value_index[1]))
+    assert np.all(np.isnan(cat.cutout_max_value_index[1]))
+    # The constant source reports its first pixel
+    assert_array_equal(cat.cutout_min_value_index[0], [0, 0])
+    assert_array_equal(cat.cutout_max_value_index[0], [0, 0])
+    # The masked would-be maximum is skipped
+    assert_array_equal(cat.max_value_index[2], [23, 25])
+    assert_array_equal(cat.min_value_index[2], [18, 18])
+    assert_array_equal(cat.min_value_index[3], [3, 16])
+
+
+def test_sliced_and_scalar_catalog(scene):
+    parent = make_catalog(scene)
+    expected_min = parent.min_value_index
+    expected_cutout_max = parent.cutout_max_value_index
+    child = parent[[4, 1, 6]]
+    assert_array_equal(child.min_value_index, expected_min[[4, 1, 6]])
+    assert_array_equal(child.cutout_max_value_index,
+                       expected_cutout_max[[4, 1, 6]])
+    fresh = make_catalog(scene)[[4, 1, 6]]
+    assert_array_equal(fresh.min_value_index, expected_min[[4, 1, 6]])
+    scalar = make_catalog(scene)[3]
+    assert scalar.isscalar
+    assert_array_equal(scalar.min_value_index, expected_min[3])
+    assert_array_equal(scalar.cutout_max_value_index,
+                       expected_cutout_max[3])
+    assert scalar.min_value_xindex == expected_min[3, 1]
+    assert scalar.max_value_yindex == parent.max_value_index[3, 0]
+
+
+def _driver_inputs(cat):
+    arrays = cat._get_batch_arrays()
+    iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()
+    return {'values': arrays['data'], 'mask': arrays['mask'],
+            'segm': arrays['segm'],
+            'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
+            'bbox_iymin': iymin, 'bbox_iymax': iymax,
+            'bbox_ixmin': ixmin, 'bbox_ixmax': ixmax}
+
+
+def _call_driver(inp):
+    return batch_minmax_index(inp.pop('values'), **inp)
+
+
+def test_driver_outputs(scene):
+    cat = make_catalog(scene)
+    index = _call_driver(_driver_inputs(cat))
+    assert index.shape == (cat.n_labels, 4)
+    assert index.dtype == np.intp
+    assert_array_equal(index[:, :2], cat.cutout_min_value_index)
+    assert_array_equal(index[:, 2:], cat.cutout_max_value_index)
+
+
+@pytest.mark.parametrize('name', ['bbox_iymin', 'bbox_iymax', 'bbox_ixmin',
+                                  'bbox_ixmax'])
+def test_length_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1]
+    with pytest.raises(ValueError, match='same length as labels'):
+        _call_driver(inp)
+
+
+@pytest.mark.parametrize('name', ['mask', 'segm'])
+def test_shape_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1, :]
+    with pytest.raises(ValueError, match='same shape as values'):
+        _call_driver(inp)
+
+
+def test_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    expected = _call_driver(dict(inp))
+
+    def run(_):
+        return _call_driver(dict(inp))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(run, range(8)))
+    for result in results:
+        assert_array_equal(result, expected)

--- a/photutils/segmentation/tests/test_batch_minmax_index.py
+++ b/photutils/segmentation/tests/test_batch_minmax_index.py
@@ -38,7 +38,7 @@ def _reference_index(cat, cutout_index):
     ``max_value_index`` loops, adding the bounding-box origin.
     """
     out = []
-    for idx, slc in zip(cutout_index, cat._slices_iter, strict=True):
+    for idx, slc in zip(cutout_index, cat.slices, strict=True):
         out.append((idx[0] + slc[0].start, idx[1] + slc[1].start))
     return np.array(out)
 

--- a/photutils/segmentation/tests/test_batch_moments.py
+++ b/photutils/segmentation/tests/test_batch_moments.py
@@ -19,7 +19,7 @@ from photutils.segmentation.tests._batch_scene import (make_batch_scene,
 
 def _moment_cutout(cat, i):
     # The _moment_data_cutouts zeroing rules, per source
-    slc = cat._slices_iter[i]
+    slc = cat.slices[i]
     conv = cat._convolved_data[slc]
     segm = cat._segmentation_image.data[slc]
     bad = (~np.isfinite(conv) | (conv < 0)
@@ -61,7 +61,7 @@ def _driver_inputs(cat):
     arrays = cat._get_batch_arrays()
     convdata = np.ascontiguousarray(cat._convolved_data,
                                     dtype=np.float64)
-    slices = cat._slices_iter
+    slices = cat.slices
     return {
         'convdata': convdata,
         'mask': arrays['mask'],
@@ -83,7 +83,7 @@ def _reference_moment_err(cat, xcen, ycen):
     # The _centroid_err_cov accumulation rules, per source
     result = []
     for i in range(cat.n_labels):
-        slc = cat._slices_iter[i]
+        slc = cat.slices[i]
         moment_data = _moment_cutout(cat, i)
         err_sq = cat._error[slc].astype(float) ** 2
         total_mask = ((cat._segmentation_image.data[slc]
@@ -222,7 +222,7 @@ def _reference_err_pixels(cat, i):
     """
     Boolean cutout mask of the pixels included in the error sums.
     """
-    slc = cat._slices_iter[i]
+    slc = cat.slices[i]
     moment_data = _moment_cutout(cat, i)
     included = np.isfinite(cat._data[slc])
     included &= cat._segmentation_image.data[slc] == cat.labels[i]
@@ -243,7 +243,7 @@ def test_edge_case_inclusion_rules():
     # The excluded pixels must actually change the result, otherwise
     # this test would not discriminate the inclusion rules
     for i in range(cat.n_labels):
-        slc = cat._slices_iter[i]
+        slc = cat.slices[i]
         in_segment = (cat._segmentation_image.data[slc]
                       == cat.labels[i])
         assert (np.count_nonzero(_moment_cutout(cat, i))
@@ -313,7 +313,7 @@ def test_catalog_centroid_err(scene):
         if not np.isfinite(m00[i]) or m00[i] <= 0:
             assert np.all(np.isnan(cov[i]))
             continue
-        slc = cat._slices_iter[i]
+        slc = cat.slices[i]
         moment_data = _moment_cutout(cat, i)
         err_sq = scene['error'][slc].astype(float) ** 2
         total_mask = ((cat._segmentation_image.data[slc]

--- a/photutils/segmentation/tests/test_batch_moments.py
+++ b/photutils/segmentation/tests/test_batch_moments.py
@@ -1,0 +1,293 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch moments Cython kernels.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from photutils.segmentation import SegmentationImage, SourceCatalog
+from photutils.segmentation._batch_catalog import (batch_central_moments,
+                                                   batch_moment_err,
+                                                   batch_raw_moments)
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+
+
+def _moment_cutout(cat, i):
+    # The _moment_data_cutouts zeroing rules, per source
+    slc = cat._slices_iter[i]
+    conv = cat._convolved_data[slc]
+    segm = cat._segmentation_image.data[slc]
+    bad = (~np.isfinite(conv) | (conv < 0)
+           | (segm != cat.labels[i]))
+    if cat._mask is not None:
+        bad |= cat._mask[slc]
+    cutout = conv.astype(float).copy()
+    cutout[bad] = 0.0
+    return cutout
+
+
+def _reference_raw(cat):
+    result = []
+    for i in range(cat.n_labels):
+        arr = _moment_cutout(cat, i)
+        ny, nx = arr.shape
+        y = np.arange(ny, dtype=float)
+        x = np.arange(nx, dtype=float)
+        yp = np.column_stack([np.ones(ny), y, y * y, y ** 3])
+        xp = np.column_stack([np.ones(nx), x, x * x, x ** 3])
+        result.append(yp.T @ arr @ xp)
+    return np.array(result)
+
+
+def _reference_central(cat, xcen, ycen):
+    result = []
+    for i in range(cat.n_labels):
+        arr = _moment_cutout(cat, i)
+        ny, nx = arr.shape
+        yc = np.arange(ny, dtype=float) - ycen[i]
+        xc = np.arange(nx, dtype=float) - xcen[i]
+        yp = np.column_stack([np.ones(ny), yc, yc * yc, yc ** 3])
+        xp = np.column_stack([np.ones(nx), xc, xc * xc, xc ** 3])
+        result.append(yp.T @ arr @ xp)
+    return np.array(result)
+
+
+def _driver_inputs(cat):
+    arrays = cat._get_batch_arrays()
+    convdata = np.ascontiguousarray(cat._convolved_data,
+                                    dtype=np.float64)
+    slices = cat._slices_iter
+    return {
+        'convdata': convdata,
+        'mask': arrays['mask'],
+        'segm': arrays['segm'],
+        'labels': np.ascontiguousarray(np.atleast_1d(cat.labels),
+                                       dtype=np.intp),
+        'bbox_iymin': np.array([s[0].start for s in slices],
+                               dtype=np.intp),
+        'bbox_iymax': np.array([s[0].stop for s in slices],
+                               dtype=np.intp),
+        'bbox_ixmin': np.array([s[1].start for s in slices],
+                               dtype=np.intp),
+        'bbox_ixmax': np.array([s[1].stop for s in slices],
+                               dtype=np.intp),
+    }
+
+
+def _reference_moment_err(cat, xcen, ycen):
+    # The _centroid_err_cov accumulation rules, per source
+    result = []
+    for i in range(cat.n_labels):
+        slc = cat._slices_iter[i]
+        moment_data = _moment_cutout(cat, i)
+        err_sq = cat._error[slc].astype(float) ** 2
+        total_mask = ((cat._segmentation_image.data[slc]
+                       != cat.labels[i])
+                      | ~np.isfinite(cat._data[slc]))
+        if cat._mask is not None:
+            total_mask |= cat._mask[slc]
+        err_sq[total_mask | (moment_data == 0)] = 0.0
+        yy, xx = np.mgrid[0:err_sq.shape[0], 0:err_sq.shape[1]]
+        dx = xx - xcen[i]
+        dy = yy - ycen[i]
+        result.append((np.sum(err_sq), np.sum(err_sq * dx ** 2),
+                       np.sum(err_sq * dy ** 2),
+                       np.sum(err_sq * dx * dy)))
+    return np.array(result)
+
+
+def _cutout_centroids(raw):
+    with np.errstate(invalid='ignore', divide='ignore'):
+        xcen = raw[:, 0, 1] / raw[:, 0, 0]
+        ycen = raw[:, 1, 0] / raw[:, 0, 0]
+    return xcen, ycen
+
+
+def _call_raw(inp):
+    return batch_raw_moments(inp['convdata'], mask=inp['mask'],
+                             segm=inp['segm'], labels=inp['labels'],
+                             bbox_iymin=inp['bbox_iymin'],
+                             bbox_iymax=inp['bbox_iymax'],
+                             bbox_ixmin=inp['bbox_ixmin'],
+                             bbox_ixmax=inp['bbox_ixmax'])
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_raw_moments(scene, with_mask):
+    cat = make_catalog(scene, with_mask=with_mask)
+    inp = _driver_inputs(cat)
+    result = _call_raw(inp)
+    assert result.shape == (cat.n_labels, 4, 4)
+    assert_allclose(result, _reference_raw(cat), rtol=1e-12,
+                    atol=1e-10, equal_nan=True)
+
+
+def test_central_moments(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    raw = _reference_raw(cat)
+    xcen, ycen = _cutout_centroids(raw)
+    assert np.all(np.isfinite(xcen))
+    assert np.all(np.isfinite(ycen))
+    result = batch_central_moments(
+        inp['convdata'], mask=inp['mask'], segm=inp['segm'],
+        labels=inp['labels'], bbox_iymin=inp['bbox_iymin'],
+        bbox_iymax=inp['bbox_iymax'], bbox_ixmin=inp['bbox_ixmin'],
+        bbox_ixmax=inp['bbox_ixmax'], xcen=xcen, ycen=ycen)
+    assert_allclose(result, _reference_central(cat, xcen, ycen),
+                    rtol=1e-12, atol=1e-10, equal_nan=True)
+
+
+def test_central_moments_nan_centroid(scene):
+    # A fully-masked source has zero total flux -> NaN centroid; the
+    # previous implementation then produced NaN everywhere except
+    # [0, 0], which holds the (zero) flux sum
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    n = cat.n_labels
+    xcen = np.full(n, np.nan)
+    ycen = np.full(n, np.nan)
+    result = batch_central_moments(
+        inp['convdata'], mask=inp['mask'], segm=inp['segm'],
+        labels=inp['labels'], bbox_iymin=inp['bbox_iymin'],
+        bbox_iymax=inp['bbox_iymax'], bbox_ixmin=inp['bbox_ixmin'],
+        bbox_ixmax=inp['bbox_ixmax'], xcen=xcen, ycen=ycen)
+    expected = _reference_central(cat, xcen, ycen)
+    assert_allclose(result, expected, rtol=1e-12, atol=1e-10,
+                    equal_nan=True)
+    # The reference is NaN everywhere except the plain flux sum
+    assert np.all(np.isfinite(result[:, 0, 0]))
+    assert np.all(np.isnan(result[:, 1:, :]))
+    assert np.all(np.isnan(result[:, :, 1:]))
+
+
+def test_moment_err(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    error = np.ascontiguousarray(scene['error'], dtype=np.float64)
+    raw = _reference_raw(cat)
+    xcen, ycen = _cutout_centroids(raw)
+    result = batch_moment_err(
+        error, convdata=inp['convdata'], mask=inp['mask'],
+        segm=inp['segm'], labels=inp['labels'],
+        bbox_iymin=inp['bbox_iymin'], bbox_iymax=inp['bbox_iymax'],
+        bbox_ixmin=inp['bbox_ixmin'], bbox_ixmax=inp['bbox_ixmax'],
+        xcen=xcen, ycen=ycen)
+    assert result.shape == (cat.n_labels, 4)
+    assert_allclose(result, _reference_moment_err(cat, xcen, ycen),
+                    rtol=1e-12, atol=1e-10, equal_nan=True)
+
+
+def _edge_catalog():
+    """
+    Make a small catalog whose sources exercise every pixel-inclusion
+    rule of the moment kernels.
+    """
+    rng = np.random.default_rng(42)
+    ny = nx = 12
+    data = np.abs(rng.normal(2.0, 0.5, (ny, nx)))
+    segmdata = np.zeros((ny, nx), dtype=int)
+    segmdata[2:6, 2:6] = 1
+    segmdata[7:11, 6:11] = 2
+    convdata = data.copy()
+    convdata[3, 3] = -1.5  # negative convolved value in a segment
+    convdata[4, 4] = np.nan  # non-finite convolved value
+    convdata[8, 8] = np.inf
+    convdata[9, 9] = 0.0  # zero flux weight, excluded from the errors
+    # Non-finite data with a finite convolved value: included in the
+    # moments, excluded from the errors
+    data[5, 5] = np.nan
+    data[9, 7] = np.nan
+    mask = np.zeros((ny, nx), dtype=bool)
+    mask[2, 2] = True  # input-masked pixel in a segment
+    mask[8, 9] = True
+    error = np.full((ny, nx), 0.2)
+    error[::3, ::2] = 0.5
+    return SourceCatalog(data, SegmentationImage(segmdata),
+                         convolved_data=convdata, error=error,
+                         mask=mask)
+
+
+def _reference_err_pixels(cat, i):
+    """
+    Boolean cutout mask of the pixels included in the error sums.
+    """
+    slc = cat._slices_iter[i]
+    moment_data = _moment_cutout(cat, i)
+    included = np.isfinite(cat._data[slc])
+    included &= cat._segmentation_image.data[slc] == cat.labels[i]
+    if cat._mask is not None:
+        included &= ~cat._mask[slc]
+    return included & (moment_data != 0)
+
+
+def test_edge_case_inclusion_rules():
+    cat = _edge_catalog()
+    inp = _driver_inputs(cat)
+    raw = batch_raw_moments(
+        inp['convdata'], mask=inp['mask'], segm=inp['segm'],
+        labels=inp['labels'], bbox_iymin=inp['bbox_iymin'],
+        bbox_iymax=inp['bbox_iymax'], bbox_ixmin=inp['bbox_ixmin'],
+        bbox_ixmax=inp['bbox_ixmax'])
+    reference_raw = _reference_raw(cat)
+    # The excluded pixels must actually change the result, otherwise
+    # this test would not discriminate the inclusion rules
+    for i in range(cat.n_labels):
+        slc = cat._slices_iter[i]
+        in_segment = (cat._segmentation_image.data[slc]
+                      == cat.labels[i])
+        assert (np.count_nonzero(_moment_cutout(cat, i))
+                < np.count_nonzero(in_segment))
+
+    assert_allclose(raw, reference_raw, rtol=1e-12, atol=1e-10,
+                    equal_nan=True)
+
+    xcen, ycen = _cutout_centroids(reference_raw)
+    central = batch_central_moments(
+        inp['convdata'], mask=inp['mask'], segm=inp['segm'],
+        labels=inp['labels'], bbox_iymin=inp['bbox_iymin'],
+        bbox_iymax=inp['bbox_iymax'], bbox_ixmin=inp['bbox_ixmin'],
+        bbox_ixmax=inp['bbox_ixmax'], xcen=xcen, ycen=ycen)
+    assert_allclose(central, _reference_central(cat, xcen, ycen),
+                    rtol=1e-12, atol=1e-10, equal_nan=True)
+
+    error = np.ascontiguousarray(cat._error, dtype=np.float64)
+    err = batch_moment_err(
+        error, convdata=inp['convdata'], mask=inp['mask'],
+        segm=inp['segm'], labels=inp['labels'],
+        bbox_iymin=inp['bbox_iymin'], bbox_iymax=inp['bbox_iymax'],
+        bbox_ixmin=inp['bbox_ixmin'], bbox_ixmax=inp['bbox_ixmax'],
+        xcen=xcen, ycen=ycen)
+    reference_err = _reference_moment_err(cat, xcen, ycen)
+    # The non-finite data pixel is excluded from the errors but not
+    # from the moments, so the error sums use fewer pixels
+    n_moment = np.array([np.count_nonzero(_moment_cutout(cat, i))
+                         for i in range(cat.n_labels)])
+    n_err = np.array([np.count_nonzero(_reference_err_pixels(cat, i))
+                      for i in range(cat.n_labels)])
+    assert np.all(n_err < n_moment)
+
+    assert_allclose(err, reference_err, rtol=1e-12, atol=1e-10,
+                    equal_nan=True)
+
+
+def test_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+
+    expected = _call_raw(inp)
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: _call_raw(inp),
+                                    range(16)))
+    for res in results:
+        assert_allclose(res, expected, rtol=0, atol=0, equal_nan=True)

--- a/photutils/segmentation/tests/test_batch_moments.py
+++ b/photutils/segmentation/tests/test_batch_moments.py
@@ -337,6 +337,96 @@ def test_catalog_centroid_err(scene):
                         rtol=1e-12, atol=1e-10)
 
 
+BBOX_NAMES = ['bbox_iymin', 'bbox_iymax', 'bbox_ixmin', 'bbox_ixmax']
+
+
+def _guard_inputs(scene):
+    """
+    Build the driver inputs for the input-validation tests, including
+    the centroid and error arrays.
+    """
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    xcen, ycen = _cutout_centroids(_reference_raw(cat))
+    inp['xcen'] = xcen
+    inp['ycen'] = ycen
+    inp['error'] = np.ascontiguousarray(scene['error'],
+                                        dtype=np.float64)
+    return inp
+
+
+def _call_central(inp):
+    return batch_central_moments(
+        inp['convdata'], mask=inp['mask'], segm=inp['segm'],
+        labels=inp['labels'], bbox_iymin=inp['bbox_iymin'],
+        bbox_iymax=inp['bbox_iymax'], bbox_ixmin=inp['bbox_ixmin'],
+        bbox_ixmax=inp['bbox_ixmax'], xcen=inp['xcen'],
+        ycen=inp['ycen'])
+
+
+def _call_err(inp):
+    return batch_moment_err(
+        inp['error'], convdata=inp['convdata'], mask=inp['mask'],
+        segm=inp['segm'], labels=inp['labels'],
+        bbox_iymin=inp['bbox_iymin'], bbox_iymax=inp['bbox_iymax'],
+        bbox_ixmin=inp['bbox_ixmin'], bbox_ixmax=inp['bbox_ixmax'],
+        xcen=inp['xcen'], ycen=inp['ycen'])
+
+
+@pytest.mark.parametrize('name', BBOX_NAMES)
+def test_raw_moments_length_guard(scene, name):
+    inp = _guard_inputs(scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same length as labels'
+    with pytest.raises(ValueError, match=match):
+        _call_raw(inp)
+
+
+@pytest.mark.parametrize('name', ['mask', 'segm'])
+def test_raw_moments_shape_guard(scene, name):
+    inp = _guard_inputs(scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same shape as convdata'
+    with pytest.raises(ValueError, match=match):
+        _call_raw(inp)
+
+
+@pytest.mark.parametrize('name', [*BBOX_NAMES, 'xcen', 'ycen'])
+def test_central_moments_length_guard(scene, name):
+    inp = _guard_inputs(scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same length as labels'
+    with pytest.raises(ValueError, match=match):
+        _call_central(inp)
+
+
+@pytest.mark.parametrize('name', ['mask', 'segm'])
+def test_central_moments_shape_guard(scene, name):
+    inp = _guard_inputs(scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same shape as convdata'
+    with pytest.raises(ValueError, match=match):
+        _call_central(inp)
+
+
+@pytest.mark.parametrize('name', [*BBOX_NAMES, 'xcen', 'ycen'])
+def test_moment_err_length_guard(scene, name):
+    inp = _guard_inputs(scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same length as labels'
+    with pytest.raises(ValueError, match=match):
+        _call_err(inp)
+
+
+@pytest.mark.parametrize('name', ['convdata', 'mask', 'segm'])
+def test_moment_err_shape_guard(scene, name):
+    inp = _guard_inputs(scene)
+    inp[name] = np.ascontiguousarray(inp[name][:-1])
+    match = f'{name} must have the same shape as error'
+    with pytest.raises(ValueError, match=match):
+        _call_err(inp)
+
+
 def test_thread_safety(scene):
     cat = make_catalog(scene)
     inp = _driver_inputs(cat)

--- a/photutils/segmentation/tests/test_batch_moments.py
+++ b/photutils/segmentation/tests/test_batch_moments.py
@@ -281,6 +281,62 @@ def test_edge_case_inclusion_rules():
                     equal_nan=True)
 
 
+def test_catalog_moments(scene):
+    cat = make_catalog(scene)
+    assert_allclose(cat.moments, _reference_raw(cat), rtol=1e-12,
+                    atol=1e-10)
+    raw = cat._array('moments')
+    with np.errstate(invalid='ignore'):
+        xcen = raw[:, 0, 1] / raw[:, 0, 0]
+        ycen = raw[:, 1, 0] / raw[:, 0, 0]
+    assert_allclose(cat.moments_central,
+                    _reference_central(cat, xcen, ycen), rtol=1e-12,
+                    atol=1e-10, equal_nan=True)
+    # Downstream shape properties still finite where expected
+    assert np.all(np.isfinite(np.atleast_1d(
+        cat.semimajor_axis.value)[~np.isnan(
+            np.atleast_1d(cat.semimajor_axis.value))]))
+
+
+def test_catalog_centroid_err(scene):
+    # _centroid_err_cov = normalized batch_moment_err accumulators;
+    # rebuild it from the reference accumulation of test_moment_err
+    cat = make_catalog(scene)
+    cov = cat._centroid_err_cov
+    assert cov.shape == (cat.n_labels, 2, 2)
+    raw = _reference_raw(cat)
+    m00 = raw[:, 0, 0]
+    with np.errstate(invalid='ignore'):
+        xcen = raw[:, 0, 1] / m00
+        ycen = raw[:, 1, 0] / m00
+    for i in range(cat.n_labels):
+        if not np.isfinite(m00[i]) or m00[i] <= 0:
+            assert np.all(np.isnan(cov[i]))
+            continue
+        slc = cat._slices_iter[i]
+        moment_data = _moment_cutout(cat, i)
+        err_sq = scene['error'][slc].astype(float) ** 2
+        total_mask = ((cat._segmentation_image.data[slc]
+                       != cat.labels[i])
+                      | ~np.isfinite(scene['data'][slc])
+                      | scene['mask'][slc])
+        err_sq[total_mask | (moment_data == 0)] = 0.0
+        yy, xx = np.mgrid[0:err_sq.shape[0], 0:err_sq.shape[1]]
+        dx = xx - xcen[i]
+        dy = yy - ycen[i]
+        norm = 1.0 / m00[i] ** 2
+        var_x = np.sum(err_sq * dx ** 2) * norm
+        var_y = np.sum(err_sq * dy ** 2) * norm
+        cov_xy = np.sum(err_sq * dx * dy) * norm
+        if np.atleast_1d(cat._singular_covariance_mask)[i]:
+            corr = np.sum(err_sq) * (1.0 / 12.0) * norm
+            if var_x * var_y - cov_xy ** 2 < corr ** 2:
+                var_x += corr
+                var_y += corr
+        assert_allclose(cov[i], [[var_x, cov_xy], [cov_xy, var_y]],
+                        rtol=1e-12, atol=1e-10)
+
+
 def test_thread_safety(scene):
     cat = make_catalog(scene)
     inp = _driver_inputs(cat)

--- a/photutils/segmentation/tests/test_batch_perimeter.py
+++ b/photutils/segmentation/tests/test_batch_perimeter.py
@@ -118,6 +118,33 @@ def test_scalar_and_sliced_catalog(scene):
     assert scalar.perimeter == parent.perimeter[3]
 
 
+def test_batch_bboxes_cached_and_sliced(scene):
+    """
+    Test that the cached bounding-box array is sliced along the source
+    axis, including for scalar catalogs, and matches a fresh catalog.
+    """
+    cat = make_catalog(scene)
+    bboxes = cat._batch_bboxes
+    assert bboxes.shape == (cat.n_labels, 4)
+    assert bboxes.dtype == np.intp
+    iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()
+    for col in (iymin, iymax, ixmin, ixmax):
+        assert col.flags.c_contiguous
+    assert_array_equal(np.column_stack((iymin, iymax, ixmin, ixmax)),
+                       bboxes)
+    slices = cat._slices_iter
+    assert_array_equal(iymin, [slc[0].start for slc in slices])
+    assert_array_equal(ixmax, [slc[1].stop for slc in slices])
+
+    child = cat[[1, 4, 6]]
+    assert_array_equal(child._batch_bboxes, bboxes[[1, 4, 6]])
+    scalar = cat[3]
+    assert scalar._batch_bboxes.shape == (1, 4)
+    assert_array_equal(scalar._batch_bboxes[0], bboxes[3])
+    fresh = make_catalog(scene)[3]
+    assert_array_equal(fresh._batch_bboxes, scalar._batch_bboxes)
+
+
 def _driver_inputs(cat):
     arrays = cat._get_batch_arrays()
     iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()

--- a/photutils/segmentation/tests/test_batch_perimeter.py
+++ b/photutils/segmentation/tests/test_batch_perimeter.py
@@ -1,0 +1,173 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch perimeter kernel.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from photutils.segmentation import SegmentationImage, SourceCatalog
+from photutils.segmentation._batch_catalog import batch_perimeter
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+
+
+def _reference_perimeter(cat):
+    """
+    Compute the perimeter of each source segment.
+
+    This is a verbatim port of the per-source Python implementation
+    of ``perimeter`` that the batch Cython kernel replaces. It is the
+    numerical reference for the kernel.
+    """
+    size = 34
+    weights = np.zeros(size, dtype=float)
+    weights[[5, 7, 15, 17, 25, 27]] = 1.0
+    weights[[21, 33]] = np.sqrt(2.0)
+    weights[[13, 23]] = (1 + np.sqrt(2.0)) / 2.0
+
+    perimeter = []
+    for mask in cat._cutout_total_masks:
+        if np.all(mask):
+            perimeter.append(np.nan)
+            continue
+
+        ny, nx = mask.shape
+
+        padded = np.zeros((ny + 2, nx + 2), dtype=np.int8)
+        padded[1:-1, 1:-1] = ~mask
+
+        p = padded
+        eroded = (p[1:-1, 1:-1] & p[:-2, 1:-1] & p[2:, 1:-1]
+                  & p[1:-1, :-2] & p[1:-1, 2:])
+
+        border = np.zeros((ny + 2, nx + 2), dtype=np.int8)
+        border[1:-1, 1:-1] = padded[1:-1, 1:-1] & ~eroded
+
+        b = border
+        conv = (10 * b[:-2, :-2] + 2 * b[:-2, 1:-1]
+                + 10 * b[:-2, 2:] + 2 * b[1:-1, :-2]
+                + b[1:-1, 1:-1] + 2 * b[1:-1, 2:]
+                + 10 * b[2:, :-2] + 2 * b[2:, 1:-1]
+                + 10 * b[2:, 2:])
+
+        hist = np.bincount(conv.ravel(), minlength=size)
+        perimeter.append(hist[:size] @ weights)
+
+    return np.array(perimeter) * u.pix
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_matches_reference(scene, with_mask):
+    cat = make_catalog(scene, with_mask=with_mask)
+    expected = _reference_perimeter(cat)
+    assert np.all(np.isfinite(expected))
+    assert_allclose(cat.perimeter, expected, rtol=1e-12)
+
+
+def test_shapes():
+    # Hand-checkable shapes: a single pixel, a 2x2 square, a 5x5
+    # square, a diagonal line, an annulus with a masked hole, a fully
+    # masked source, and an edge-touching source
+    data = np.ones((40, 40))
+    segm_data = np.zeros(data.shape, dtype=int)
+    mask = np.zeros(data.shape, dtype=bool)
+    segm_data[2, 2] = 1
+    segm_data[5:7, 5:7] = 2
+    segm_data[10:15, 10:15] = 3
+    for k in range(5):
+        segm_data[20 + k, 20 + k] = 4
+    segm_data[25:32, 2:9] = 5
+    mask[27:30, 4:7] = True
+    segm_data[33:36, 33:36] = 6
+    mask[33:36, 33:36] = True
+    segm_data[37:40, 0:3] = 7
+    segm = SegmentationImage(segm_data)
+    cat = SourceCatalog(data, segm, mask=mask)
+    expected = _reference_perimeter(cat)
+    assert_allclose(cat.perimeter, expected, rtol=1e-12, equal_nan=True)
+    # A single pixel has a zero perimeter and the fully masked source
+    # has none
+    assert cat.perimeter[0] == 0 * u.pix
+    assert np.isnan(cat.perimeter[5])
+    # The annulus perimeter includes the inner hole
+    square = SourceCatalog(data, SegmentationImage(
+        np.where(segm_data == 5, 5, 0))).perimeter[0]
+    assert cat.perimeter[4] > square
+
+
+def test_scalar_and_sliced_catalog(scene):
+    parent = make_catalog(scene)
+    expected = _reference_perimeter(parent)
+    child = parent[[1, 4, 6]]
+    assert_array_equal(child.perimeter.value,
+                       parent.perimeter.value[[1, 4, 6]])
+    assert_allclose(child.perimeter, expected[[1, 4, 6]], rtol=1e-12)
+    scalar = make_catalog(scene)[3]
+    assert scalar.isscalar
+    assert_allclose(scalar.perimeter, expected[3], rtol=1e-12)
+    assert scalar.perimeter == parent.perimeter[3]
+
+
+def _driver_inputs(cat):
+    arrays = cat._get_batch_arrays()
+    iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()
+    return {'mask': arrays['mask'], 'segm': arrays['segm'],
+            'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
+            'bbox_iymin': iymin, 'bbox_iymax': iymax,
+            'bbox_ixmin': ixmin, 'bbox_ixmax': ixmax}
+
+
+def _call_driver(inp):
+    return batch_perimeter(inp.pop('mask'), **inp)
+
+
+def test_histogram(scene):
+    # Every bounding-box pixel is counted in the histogram (values of
+    # 34 and above are dropped)
+    cat = make_catalog(scene)
+    hist = _call_driver(_driver_inputs(cat))
+    assert hist.shape == (cat.n_labels, 34)
+    iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()
+    assert np.all(hist.sum(axis=1) <= (iymax - iymin) * (ixmax - ixmin))
+
+
+@pytest.mark.parametrize('name', ['bbox_iymin', 'bbox_iymax', 'bbox_ixmin',
+                                  'bbox_ixmax'])
+def test_length_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1]
+    with pytest.raises(ValueError, match='same length as labels'):
+        _call_driver(inp)
+
+
+def test_shape_guard(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp['segm'] = inp['segm'][:-1, :]
+    with pytest.raises(ValueError, match='same shape as mask'):
+        _call_driver(inp)
+
+
+def test_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    expected = _call_driver(dict(inp))
+
+    def run(_):
+        return _call_driver(dict(inp))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(run, range(8)))
+    for result in results:
+        assert_array_equal(result, expected)

--- a/photutils/segmentation/tests/test_batch_perimeter.py
+++ b/photutils/segmentation/tests/test_batch_perimeter.py
@@ -132,7 +132,7 @@ def test_batch_bboxes_cached_and_sliced(scene):
         assert col.flags.c_contiguous
     assert_array_equal(np.column_stack((iymin, iymax, ixmin, ixmax)),
                        bboxes)
-    slices = cat._slices_iter
+    slices = cat.slices
     assert_array_equal(iymin, [slc[0].start for slc in slices])
     assert_array_equal(ixmax, [slc[1].stop for slc in slices])
 

--- a/photutils/segmentation/tests/test_batch_segment_gather.py
+++ b/photutils/segmentation/tests/test_batch_segment_gather.py
@@ -167,7 +167,7 @@ def _reference_gini(cat):
 def _reference_segment_area(cat):
     # The previous per-source segment_area implementation
     areas = []
-    for label, slices in zip(cat.labels, cat._slices_iter, strict=True):
+    for label, slices in zip(cat.labels, cat.slices, strict=True):
         areas.append(np.count_nonzero(
             cat._segmentation_image[slices] == label))
     return np.array(areas)

--- a/photutils/segmentation/tests/test_batch_segment_gather.py
+++ b/photutils/segmentation/tests/test_batch_segment_gather.py
@@ -13,6 +13,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from photutils.morphology import gini as gini_func
 from photutils.segmentation import SegmentationImage, SourceCatalog
 from photutils.segmentation._batch_catalog import batch_segment_gather
+from photutils.segmentation.catalog import _SegmentValues
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
 
@@ -37,7 +38,9 @@ def _reference_values(masked_cutouts):
 
 def _assert_values_equal(values, expected):
     assert len(values) == len(expected)
-    for got, want in zip(values, expected, strict=True):
+    assert values.offsets[-1] == values.packed.size
+    assert_array_equal(values.sizes, np.maximum(values.counts, 1))
+    for got, want in zip(values.values, expected, strict=True):
         assert got.dtype == np.float64
         assert_array_equal(got, want)
 
@@ -65,13 +68,13 @@ def test_matches_reference(scene, with_error, with_mask, with_background):
         _assert_values_equal(cat._error_values,
                              _reference_values(cat.error_cutout_masked))
     else:
-        assert all(value is None for value in cat._error_values)
+        assert cat._error_values is None
     if with_background:
         _assert_values_equal(
             cat._background_values,
             _reference_values(cat.background_cutout_masked))
     else:
-        assert all(value is None for value in cat._background_values)
+        assert cat._background_values is None
     assert_array_equal(cat._all_masked,
                        [np.all(mask) for mask in cat._cutout_total_masks])
 
@@ -150,7 +153,7 @@ def test_sliced_catalog_equals_parent(scene):
     _ = parent._all_masked
     child = parent[[0, 3, 5]]
     _assert_values_equal(child._data_values,
-                         [parent._data_values[i] for i in (0, 3, 5)])
+                         [parent._data_values.values[i] for i in (0, 3, 5)])
     assert_array_equal(child._all_masked, parent._all_masked[[0, 3, 5]])
     fresh = make_catalog(scene)[[0, 3, 5]]
     _assert_values_equal(fresh._data_values, child._data_values)
@@ -158,7 +161,7 @@ def test_sliced_catalog_equals_parent(scene):
 
 def _reference_gini(cat):
     # The previous per-source gini implementation
-    return np.array([gini_func(arr) for arr in cat._data_values])
+    return np.array([gini_func(arr) for arr in cat._data_values.values])
 
 
 def _reference_segment_area(cat):
@@ -218,6 +221,69 @@ def test_segment_area_matches_reference(scene):
     assert_array_equal(child.segment_area.value, expected[[2, 0, 5]])
     scalar = make_catalog(scene)[4]
     assert scalar.segment_area.value == expected[4]
+
+
+def _sample_values():
+    """
+    A container of four sources with 3, 0 (masked placeholder), 1, and
+    2 values.
+    """
+    packed = np.array([1.0, -2.0, 3.0, np.nan, 5.0, 6.0, 7.0])
+    offsets = np.array([0, 3, 4, 5, 7], dtype=np.intp)
+    counts = np.array([3, 0, 1, 2], dtype=np.intp)
+    return _SegmentValues(packed, offsets, counts)
+
+
+class TestSegmentValues:
+    """
+    Tests for the packed per-source value container.
+    """
+
+    def test_attributes(self):
+        values = _sample_values()
+        assert len(values) == 4
+        assert_array_equal(values.sizes, [3, 1, 1, 2])
+        arrays = values.values
+        assert len(arrays) == 4
+        assert_array_equal(arrays[0], [1.0, -2.0, 3.0])
+        assert np.isnan(arrays[1][0])
+        assert_array_equal(arrays[3], [6.0, 7.0])
+        # Iteration yields the per-source arrays
+        for got, want in zip(values, arrays, strict=True):
+            assert_array_equal(got, want)
+
+    def test_reduce(self):
+        values = _sample_values()
+        assert_allclose(values.reduce(np.add), [2.0, np.nan, 5.0, 13.0])
+        assert_allclose(values.reduce(np.add, transform=np.square),
+                        [14.0, np.nan, 25.0, 85.0])
+        assert_allclose(values.reduce(np.minimum),
+                        [-2.0, np.nan, 5.0, 6.0])
+
+    @pytest.mark.parametrize('index', [1, slice(1, 3), [3, 0],
+                                       np.array([2, 2]),
+                                       np.array([True, False, False,
+                                                 True])])
+    def test_getitem(self, index):
+        values = _sample_values()
+        expected = values.values
+        idx = np.atleast_1d(np.arange(4)[index])
+        result = values[index]
+        assert isinstance(result, _SegmentValues)
+        assert len(result) == len(idx)
+        assert_array_equal(result.counts, values.counts[idx])
+        assert result.offsets[0] == 0
+        assert result.offsets[-1] == result.packed.size
+        for got, i in zip(result.values, idx, strict=True):
+            assert_array_equal(got, expected[i])
+
+    def test_getitem_scalar_index_keeps_container(self):
+        values = _sample_values()
+        result = values[1]
+        assert len(result) == 1
+        assert result.counts[0] == 0
+        assert np.isnan(result.packed[0])
+        assert_allclose(result.reduce(np.add), [np.nan])
 
 
 def _driver_inputs(cat):

--- a/photutils/segmentation/tests/test_batch_segment_gather.py
+++ b/photutils/segmentation/tests/test_batch_segment_gather.py
@@ -1,0 +1,213 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch segment pixel gather.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from photutils.segmentation import SourceCatalog
+from photutils.segmentation._batch_catalog import batch_segment_gather
+from photutils.segmentation.tests._batch_scene import (make_batch_scene,
+                                                       make_catalog)
+
+
+def _reference_values(masked_cutouts):
+    """
+    Get a list of 1D arrays of the unmasked values of each masked
+    cutout.
+
+    This is a verbatim port of the previous ``_get_values`` method,
+    applied to the public masked cutouts, that the batch segment
+    gather replaces. It is the reference for the gather.
+    """
+    values = []
+    for arr in masked_cutouts:
+        compressed = arr.compressed()
+        if len(compressed) == 0:
+            compressed = np.array([np.nan])
+        values.append(compressed)
+    return values
+
+
+def _assert_values_equal(values, expected):
+    assert len(values) == len(expected)
+    for got, want in zip(values, expected, strict=True):
+        assert got.dtype == np.float64
+        assert_array_equal(got, want)
+
+
+@pytest.fixture(scope='module')
+def scene():
+    return make_batch_scene()
+
+
+@pytest.mark.parametrize('with_error', [True, False])
+@pytest.mark.parametrize('with_mask', [True, False])
+@pytest.mark.parametrize('with_background', [True, False])
+def test_matches_reference(scene, with_error, with_mask, with_background):
+    background = None
+    if with_background:
+        rng = np.random.default_rng(1)
+        background = rng.normal(0.5, 0.1, scene['data'].shape)
+    cat = SourceCatalog(scene['data'], scene['segm'],
+                        error=scene['error'] if with_error else None,
+                        mask=scene['mask'] if with_mask else None,
+                        background=background)
+    _assert_values_equal(cat._data_values,
+                         _reference_values(cat.data_cutout_masked))
+    if with_error:
+        _assert_values_equal(cat._error_values,
+                             _reference_values(cat.error_cutout_masked))
+    else:
+        assert all(value is None for value in cat._error_values)
+    if with_background:
+        _assert_values_equal(
+            cat._background_values,
+            _reference_values(cat.background_cutout_masked))
+    else:
+        assert all(value is None for value in cat._background_values)
+    assert_array_equal(cat._all_masked,
+                       [np.all(mask) for mask in cat._cutout_total_masks])
+
+
+def test_all_masked_source(scene):
+    # A completely masked source gathers a single NaN and is flagged as
+    # all masked; a source with a single unmasked pixel is not
+    mask = scene['mask'].copy()
+    segm = scene['segm']
+    slc = segm.slices[0]
+    mask[slc] |= segm.data[slc] == segm.labels[0]
+    slc = segm.slices[1]
+    single = segm.data[slc] == segm.labels[1]
+    single[np.flatnonzero(single.ravel())[0] // single.shape[1],
+           np.flatnonzero(single.ravel())[0] % single.shape[1]] = False
+    mask[slc] |= single
+    cat = SourceCatalog(scene['data'], segm, mask=mask,
+                        error=scene['error'])
+    expected = _reference_values(cat.data_cutout_masked)
+    assert expected[0].size == 1
+    assert np.isnan(expected[0][0])
+    assert expected[1].size == 1
+    assert np.isfinite(expected[1][0])
+    _assert_values_equal(cat._data_values, expected)
+    _assert_values_equal(cat._error_values,
+                         _reference_values(cat.error_cutout_masked))
+    assert cat._all_masked[0]
+    assert not cat._all_masked[1]
+    assert_array_equal(cat._all_masked,
+                       [np.all(mask) for mask in cat._cutout_total_masks])
+    assert np.isnan(cat.segment_flux[0])
+    assert np.isnan(cat.area.value[0])
+    assert cat.area.value[1] == 1
+
+
+def test_properties(scene):
+    # The pixel-statistics properties computed from the gathered values
+    # match the same reductions of the reference values
+    rng = np.random.default_rng(2)
+    background = rng.normal(0.5, 0.1, scene['data'].shape)
+    cat = SourceCatalog(scene['data'], scene['segm'], error=scene['error'],
+                        mask=scene['mask'], background=background)
+    ref = _reference_values(cat.data_cutout_masked)
+    ref_err = _reference_values(cat.error_cutout_masked)
+    ref_bkg = _reference_values(cat.background_cutout_masked)
+    # The catalog sums with ufunc.reduceat (sequential) rather than
+    # np.sum (pairwise), so the sums agree to rounding only
+    assert_allclose(cat.segment_flux,
+                    np.array([np.sum(arr) for arr in ref]), rtol=1e-14)
+    assert_array_equal(cat.min_value, np.array([np.min(arr) for arr in ref]))
+    assert_array_equal(cat.max_value, np.array([np.max(arr) for arr in ref]))
+    assert_array_equal(cat.area.value,
+                       np.array([arr.size for arr in ref], dtype=float))
+    assert_allclose(cat.segment_flux_err,
+                    np.sqrt([np.sum(arr**2) for arr in ref_err]),
+                    rtol=1e-15)
+    assert_allclose(cat.background_sum,
+                    np.array([np.sum(arr) for arr in ref_bkg]), rtol=1e-14)
+    assert_allclose(cat.background_mean,
+                    np.array([np.mean(arr) for arr in ref_bkg]),
+                    rtol=1e-15)
+
+
+def test_scalar_catalog(scene):
+    cat = make_catalog(scene)[2]
+    assert cat.isscalar
+    _assert_values_equal(cat._data_values,
+                         _reference_values([cat.data_cutout_masked]))
+    assert cat._all_masked.shape == (1,)
+    assert not cat._all_masked[0]
+
+
+def test_sliced_catalog_equals_parent(scene):
+    parent = make_catalog(scene)
+    _ = parent._data_values
+    _ = parent._all_masked
+    child = parent[[0, 3, 5]]
+    _assert_values_equal(child._data_values,
+                         [parent._data_values[i] for i in (0, 3, 5)])
+    assert_array_equal(child._all_masked, parent._all_masked[[0, 3, 5]])
+    fresh = make_catalog(scene)[[0, 3, 5]]
+    _assert_values_equal(fresh._data_values, child._data_values)
+
+
+def _driver_inputs(cat):
+    arrays = cat._get_batch_arrays()
+    iymin, iymax, ixmin, ixmax = cat._get_batch_bboxes()
+    return {'values': arrays['data'], 'mask': arrays['mask'],
+            'segm': arrays['segm'],
+            'labels': np.ascontiguousarray(cat.labels, dtype=np.intp),
+            'bbox_iymin': iymin, 'bbox_iymax': iymax,
+            'bbox_ixmin': ixmin, 'bbox_ixmax': ixmax}
+
+
+def _call_driver(inp):
+    return batch_segment_gather(inp.pop('values'), **inp)
+
+
+def test_driver_outputs(scene):
+    cat = make_catalog(scene)
+    packed, offsets, counts = _call_driver(_driver_inputs(cat))
+    assert offsets[0] == 0
+    assert offsets[-1] == packed.size
+    assert_array_equal(np.diff(offsets), np.maximum(counts, 1))
+    assert_array_equal(counts,
+                       [np.count_nonzero(~mask)
+                        for mask in cat._cutout_total_masks])
+
+
+@pytest.mark.parametrize('name', ['bbox_iymin', 'bbox_iymax', 'bbox_ixmin',
+                                  'bbox_ixmax'])
+def test_length_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1]
+    with pytest.raises(ValueError, match='same length as labels'):
+        _call_driver(inp)
+
+
+@pytest.mark.parametrize('name', ['mask', 'segm'])
+def test_shape_guard(scene, name):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    inp[name] = inp[name][:-1, :]
+    with pytest.raises(ValueError, match='same shape as values'):
+        _call_driver(inp)
+
+
+def test_thread_safety(scene):
+    cat = make_catalog(scene)
+    inp = _driver_inputs(cat)
+    expected = _call_driver(dict(inp))
+
+    def run(_):
+        return _call_driver(dict(inp))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(run, range(8)))
+    for result in results:
+        for got, want in zip(result, expected, strict=True):
+            assert_array_equal(got, want)

--- a/photutils/segmentation/tests/test_batch_segment_gather.py
+++ b/photutils/segmentation/tests/test_batch_segment_gather.py
@@ -5,11 +5,13 @@ Tests for the batch segment pixel gather.
 
 from concurrent.futures import ThreadPoolExecutor
 
+import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
-from photutils.segmentation import SourceCatalog
+from photutils.morphology import gini as gini_func
+from photutils.segmentation import SegmentationImage, SourceCatalog
 from photutils.segmentation._batch_catalog import batch_segment_gather
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
@@ -152,6 +154,70 @@ def test_sliced_catalog_equals_parent(scene):
     assert_array_equal(child._all_masked, parent._all_masked[[0, 3, 5]])
     fresh = make_catalog(scene)[[0, 3, 5]]
     _assert_values_equal(fresh._data_values, child._data_values)
+
+
+def _reference_gini(cat):
+    # The previous per-source gini implementation
+    return np.array([gini_func(arr) for arr in cat._data_values])
+
+
+def _reference_segment_area(cat):
+    # The previous per-source segment_area implementation
+    areas = []
+    for label, slices in zip(cat.labels, cat._slices_iter, strict=True):
+        areas.append(np.count_nonzero(
+            cat._segmentation_image[slices] == label))
+    return np.array(areas)
+
+
+@pytest.mark.parametrize('with_mask', [True, False])
+def test_gini_matches_reference(scene, with_mask):
+    cat = make_catalog(scene, with_mask=with_mask)
+    expected = _reference_gini(cat)
+    assert np.all(np.isfinite(expected))
+    assert_allclose(cat.gini, expected, rtol=1e-12)
+
+
+def test_gini_edge_cases():
+    # A completely masked source (NaN), a single-pixel source (0), a
+    # zero-valued source (0), a source with negative values (absolute
+    # values are used), and a normal source
+    data = np.zeros((30, 30))
+    yy, xx = np.mgrid[0:30, 0:30]
+    segm_data = np.zeros(data.shape, dtype=int)
+    mask = np.zeros(data.shape, dtype=bool)
+    data[2:5, 2:5] = 3.0
+    segm_data[2:5, 2:5] = 1
+    mask[2:5, 2:5] = True
+    data[8, 8] = 5.0
+    segm_data[8, 8] = 2
+    segm_data[12:15, 12:15] = 3
+    data[18:24, 18:24] = -np.exp(-((xx[18:24, 18:24] - 20.5) ** 2
+                                   + (yy[18:24, 18:24] - 20.5) ** 2) / 3.0)
+    segm_data[18:24, 18:24] = 4
+    data[2:9, 20:27] = np.exp(-((xx[2:9, 20:27] - 23) ** 2
+                                + (yy[2:9, 20:27] - 5) ** 2) / 4.0)
+    segm_data[2:9, 20:27] = 5
+    cat = SourceCatalog(data, SegmentationImage(segm_data), mask=mask)
+    expected = _reference_gini(cat)
+    assert np.isnan(expected[0])
+    assert expected[1] == 0.0
+    assert expected[2] == 0.0
+    assert 0 < expected[3] < 1
+    assert_allclose(cat.gini, expected, rtol=1e-12, equal_nan=True)
+
+
+def test_segment_area_matches_reference(scene):
+    cat = make_catalog(scene)
+    expected = _reference_segment_area(cat)
+    assert_array_equal(cat.segment_area.value, expected)
+    assert cat.segment_area.unit == u.pix**2
+    # Unaffected by the mask, unlike area
+    assert np.all(cat.segment_area.value >= cat.area.value)
+    child = cat[[2, 0, 5]]
+    assert_array_equal(child.segment_area.value, expected[[2, 0, 5]])
+    scalar = make_catalog(scene)[4]
+    assert scalar.segment_area.value == expected[4]
 
 
 def _driver_inputs(cat):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -929,12 +929,19 @@ class TestSourceCatalog:
         assert 0.5 in cat._flux_radius_cache
         assert 0.3 in cat._flux_radius_cache
 
-        # Scalar slice preserves the cache
+        # Scalar slice preserves the cache, with the cached values kept
+        # as length-1 arrays (the same shape a scalar catalog stores
+        # when it computes flux_radius itself).
         obj = cat[1]
         assert 0.5 in obj._flux_radius_cache
         assert 0.3 in obj._flux_radius_cache
+        assert obj._flux_radius_cache[0.5].shape == (1,)
         r_sliced = obj.flux_radius(0.5)
+        assert r_sliced.isscalar
         assert_allclose(r_sliced.value, r_parent_05[1].value)
+        obj.flux_radius(0.5, name='r_hl')
+        assert obj.r_hl.isscalar
+        assert_allclose(obj.r_hl.value, r_parent_05[1].value)
         r_sliced_03 = obj.flux_radius(0.3)
         assert_allclose(r_sliced_03.value, r_parent_03[1].value)
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -705,11 +705,12 @@ class TestSourceCatalog:
                                  detection_catalog=det_cat)
 
         # The detection-catalog area includes the masked pixels
-        n_pixels = len(meas_cat._data_values[0])
+        values = meas_cat._data_values.values[0]
+        n_pixels = len(values)
         assert meas_cat.area.value[0] > n_pixels
 
         localbkg = meas_cat._local_background[0]
-        expected = np.sum(meas_cat._data_values[0]) - n_pixels * localbkg
+        expected = np.sum(values) - n_pixels * localbkg
         assert_allclose(meas_cat.segment_flux[0], expected)
 
     def test_kron_minradius(self):
@@ -2173,19 +2174,9 @@ def test_flux_radius_nan_fallback():
     assert np.isnan(radius.value)
 
 
-def test_reduceat_empty_input():
+def test_reduce_negative_data():
     """
-    Test that _reduceat returns empty arrays when given an empty list.
-    """
-    result, sizes = SourceCatalog._reduceat([], np.add)
-    assert len(result) == 0
-    assert len(sizes) == 0
-    assert sizes.dtype == int
-
-
-def test_reduceat_negative_data():
-    """
-    Test that the _reduceat optimization gives correct results for
+    Test that the packed per-source reductions give correct results for
     min_value, max_value, and segment_flux when data contains negative
     pixel values.
     """
@@ -2198,7 +2189,7 @@ def test_reduceat_negative_data():
     cat = SourceCatalog(data, segm)
     for i in range(cat.n_labels):
         obj = cat[i]
-        vals = obj._data_values[0]
+        vals = obj._data_values.values[0]
         expected_min = np.min(vals) - obj._local_background
         expected_max = np.max(vals) - obj._local_background
         expected_flux = np.sum(vals) - obj._local_background * len(vals)
@@ -2314,23 +2305,20 @@ def test_validate_kron_params_wrong_element_count():
         SourceCatalog._validate_kron_params([2.5])
 
 
-def test_error_values_with_error(single_source_catalog):
+def test_error_values_without_error(single_source_catalog):
     """
-    Test that _error_values returns null objects when error is None.
-    """
-    _data, _segm, cat = single_source_catalog
-    err_vals = cat._error_values
-    assert err_vals is cat._null_objects
-
-
-def test_background_values_with_background(single_source_catalog):
-    """
-    Test that _background_values returns null objects when background is
-    None.
+    Test that _error_values is None when error is None.
     """
     _data, _segm, cat = single_source_catalog
-    bkg_vals = cat._background_values
-    assert bkg_vals is cat._null_objects
+    assert cat._error_values is None
+
+
+def test_background_values_without_background(single_source_catalog):
+    """
+    Test that _background_values is None when background is None.
+    """
+    _data, _segm, cat = single_source_catalog
+    assert cat._background_values is None
 
 
 def test_sky_centroid_quad_with_wcs(single_source_catalog):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2606,24 +2606,18 @@ def test_kron_photometry_oom_guard(gauss_101_catalog):
     cat3.__dict__['kron_aperture'] = off_aper
     assert np.all(np.isnan(cat3.kron_flux))
 
-    # All pixels masked in aperture overlap triggers empty values with
-    # error branch
+    # An aperture whose pixels are all masked has no contributing
+    # pixels, giving NaN flux and flux error
     error = np.ones_like(data)
-    cat4 = SourceCatalog(data, segm, error=error)
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[:20, :20] = True
+    cat4 = SourceCatalog(data, segm, error=error, mask=mask)
     _ = cat4.kron_aperture  # cache
-    original_make = type(cat4)._make_aperture_data
-
-    def _make_all_masked(self, label, xcen, ycen, bbox, bkg, **kwargs):
-        result = original_make(self, label, xcen, ycen, bbox, bkg, **kwargs)
-        if result[0] is not None:
-            # Set mask to all True (all pixels masked)
-            return (result[0], result[1], np.ones_like(result[2]),
-                    result[3], result[4], result[5])
-        return result
-
-    with patch.object(type(cat4), '_make_aperture_data', _make_all_masked):
-        assert np.all(np.isnan(cat4.kron_flux))
-        assert np.all(np.isnan(cat4.kron_flux_err))
+    masked_aper = [CircularAperture((10, 10), r=3)
+                   for _ in range(cat4.n_labels)]
+    cat4.__dict__['kron_aperture'] = masked_aper
+    assert np.all(np.isnan(cat4.kron_flux))
+    assert np.all(np.isnan(cat4.kron_flux_err))
 
 
 def test_flux_radius_cache_not_mutated_by_centroid_win(gauss_101_data):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -38,19 +38,6 @@ from photutils.utils.cutouts import CutoutImage
 
 
 @pytest.fixture
-def progress_bar_catalog():
-    """
-    A two-source SourceCatalog on a 101x101 grid with progress_bar=True.
-    """
-    yy, xx = np.mgrid[0:101, 0:101]
-    g1 = Gaussian2D(100, 50, 50, 5, 5)
-    g2 = Gaussian2D(80, 30, 30, 4, 4)
-    data = g1(xx, yy) + g2(xx, yy)
-    segm = detect_sources(data, 10.0, n_pixels=5)
-    return SourceCatalog(data, segm, progress_bar=True)
-
-
-@pytest.fixture
 def single_source_catalog():
     """
     A single-source SourceCatalog from a Gaussian on a 51x51 grid.
@@ -2254,61 +2241,21 @@ def test_make_cutouts_trim_mode():
     assert any(s == shape for s in shapes)
 
 
-def test_progress_bar_centroid_win(progress_bar_catalog):
+def test_progress_bar_deprecated():
     """
-    Test that centroid_win works with progress_bar=True.
+    Test that the progress_bar keyword is deprecated and has no effect.
     """
-    cat = progress_bar_catalog
-    cwin = cat.centroid_win
-    assert cwin.shape == (cat.n_labels, 2)
-    assert np.all(np.isfinite(cwin))
-
-
-def test_progress_bar_centroid_quad(progress_bar_catalog):
-    """
-    Test that centroid_quad works with progress_bar=True.
-    """
-    cat = progress_bar_catalog
-    cquad = cat.centroid_quad
-    assert cquad.shape == (cat.n_labels, 2)
-    assert np.all(np.isfinite(cquad))
-
-
-def test_progress_bar_kron_radius(progress_bar_catalog):
-    """
-    Test that kron_radius works with progress_bar=True.
-    """
-    cat = progress_bar_catalog
-    kr = cat.kron_radius
-    assert len(kr) == cat.n_labels
-
-
-def test_progress_bar_kron_photometry(progress_bar_catalog):
-    """
-    Test that kron_photometry (aperture photometry) works with
-    progress_bar=True.
-    """
-    cat = progress_bar_catalog
-    flux, _flux_err = cat.kron_photometry((2.5, 1.4))
-    assert len(flux) == cat.n_labels
-
-
-def test_progress_bar_flux_radius(progress_bar_catalog):
-    """
-    Test that flux_radius and its prep work with progress_bar=True.
-    """
-    cat = progress_bar_catalog
-    r = cat.flux_radius(0.5)
-    assert len(r) == cat.n_labels
-
-
-def test_progress_bar_circular_photometry(progress_bar_catalog):
-    """
-    Test that circular_photometry works with progress_bar=True.
-    """
-    cat = progress_bar_catalog
-    flux, _fluxerr = cat.circular_photometry(5.0)
-    assert len(flux) == cat.n_labels
+    yy, xx = np.mgrid[0:101, 0:101]
+    data = Gaussian2D(100, 50, 50, 5, 5)(xx, yy)
+    segm = detect_sources(data, 10.0, n_pixels=5)
+    match = "'progress_bar' was deprecated"
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        cat = SourceCatalog(data, segm, progress_bar=True)
+    assert cat.progress_bar
+    cat2 = SourceCatalog(data, segm)
+    assert not cat2.progress_bar
+    assert_allclose(cat.centroid_win, cat2.centroid_win)
+    assert_allclose(cat.flux_radius(0.5), cat2.flux_radius(0.5))
 
 
 def test_negative_covariance_eigvals(single_source_catalog):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2467,59 +2467,6 @@ def test_kron_radius_max(gauss_101_catalog):
         assert np.isnan(cat2.flux_radius(0.5).value[0])
 
 
-def test_aperture_to_mask_size_check():
-    """
-    Test that _aperture_to_mask returns None when the aperture bounding
-    box exceeds the allowed size, preventing out-of-memory errors from
-    pathologically large apertures (e.g., from huge Kron radii).
-
-    The check happens before to_mask() allocates the mask array.
-    """
-    data = np.zeros((11, 11))
-    data[4:7, 4:7] = 100.0
-    segm_data = np.zeros((11, 11), dtype=int)
-    segm_data[4:7, 4:7] = 1
-    segm = SegmentationImage(segm_data)
-    cat = SourceCatalog(data, segm)
-
-    # A small aperture is fine
-    small_aper = CircularAperture((5, 5), r=3)
-    result = cat._aperture_to_mask(small_aper, method='center')
-    assert result is not None
-
-    # An aperture larger than data.size but within the 1M floor is fine
-    big_aper = CircularAperture((5, 5), r=100)
-    assert big_aper.bbox.shape[0] * big_aper.bbox.shape[1] > data.size
-    result = cat._aperture_to_mask(big_aper, method='center')
-    assert result is not None
-
-    # An aperture whose bbox exceeds 1_000_000 pixels returns None
-    huge_aper = CircularAperture((5, 5), r=600)
-    bbox_size = huge_aper.bbox.shape[0] * huge_aper.bbox.shape[1]
-    assert bbox_size > 1_000_000
-    result = cat._aperture_to_mask(huge_aper, method='center')
-    assert result is None
-
-
-def test_aperture_to_mask_none_branches(gauss_101_catalog):
-    """
-    Test that _aperture_photometry gracefully returns NaN when
-    _aperture_to_mask returns None (i.e., aperture too large to
-    allocate).
-
-    This covers the None-guard branch in _aperture_photometry (used by
-    the general circle photometry path).
-    """
-    _, _, cat = gauss_101_catalog
-
-    # _aperture_photometry (general path) with _aperture_to_mask
-    # returning None
-    with patch.object(type(cat), '_aperture_to_mask', return_value=None):
-        circ_aper = [CircularAperture((50, 50), r=10)] * cat.n_labels
-        flux, _ = cat._aperture_photometry(circ_aper, method='exact')
-        assert np.all(np.isnan(flux))
-
-
 def test_kron_photometry_oom_guard(gauss_101_catalog):
     """
     Test that _calc_kron_photometry returns NaN when the Kron aperture
@@ -2617,34 +2564,6 @@ def test_centroid_win_nan_when_flux_radius_nan(gauss_101_data):
         assert np.all(np.isnan(cwin))
 
 
-def test_centroid_win_aperture_mask_none_in_loop(gauss_101_catalog):
-    """
-    Test that centroid_win falls back to the isophotal centroid when
-    _aperture_to_mask returns None during the iteration loop (e.g.,
-    because the circular aperture exceeds the size threshold).
-    """
-    _data, _segm, cat = gauss_101_catalog
-
-    # Pre-compute flux_radius before mocking, since it also uses
-    # CircularAperture internally
-    hl_val = cat.flux_radius(0.5)
-    original_method = cat._aperture_to_mask
-
-    def mock_aperture_to_mask(aperture, **kwargs):
-        if isinstance(aperture, CircularAperture):
-            return None
-        return original_method(aperture, **kwargs)
-
-    with (patch.object(cat, '_aperture_to_mask',
-                       side_effect=mock_aperture_to_mask),
-          patch.object(type(cat), 'flux_radius', return_value=hl_val)):
-        cwin = cat.centroid_win
-        # NaN from the loop resets to isophotal centroid
-        # because nan_hl is False (flux_radius was valid)
-        assert_allclose(cwin[:, 0], cat.x_centroid)
-        assert_allclose(cwin[:, 1], cat.y_centroid)
-
-
 def test_centroid_win_oom_guard(gauss_101_catalog):
     """
     Test that centroid_win returns NaN for sources whose half-light
@@ -2678,20 +2597,6 @@ def test_centroid_win_aperture_mask_mask(centroid_win_data):
     cwin = cat.centroid_win
     assert cwin.shape == (len(cat), 2)
     assert np.isfinite(cwin[0, 0])
-
-
-def test_make_aperture_data_outside_image(gauss_101_catalog):
-    """
-    Test that _make_aperture_data returns (None,) * 6 when the aperture
-    bbox does not overlap the data.
-    """
-    _data, _segm, cat = gauss_101_catalog
-
-    # BoundingBox completely outside the 101x101 data
-    offimage_bbox = BoundingBox(ixmin=200, ixmax=210,
-                                iymin=200, iymax=210)
-    result = cat._make_aperture_data(1, 205.0, 205.0, offimage_bbox, 0.0)
-    assert result == (None,) * 6
 
 
 def test_flux_radius_optimizer_args_oom_guard(gauss_101_catalog):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1438,6 +1438,30 @@ class TestSourceCatalogFlags:
         assert not (cat.flags[other]
                     & SEGMENTATION_FLAGS.NON_FINITE_ERROR)
 
+    def test_masked_non_finite_pixel(self):
+        """
+        Test that a pixel that is both input-masked and non-finite
+        sets the masked_pixels, non_finite_data, and non_finite_error
+        flags together.
+        """
+        data = self.data.copy()
+        data[25, 25] = np.nan
+        error = np.ones(self.data.shape)
+        error[25, 25] = np.nan
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[25, 25] = True
+        cat = SourceCatalog(data, self.segm, error=error, mask=mask)
+        idx = np.argmax(cat.bbox_xmin > 0)
+        expected = (SEGMENTATION_FLAGS.MASKED_PIXELS
+                    | SEGMENTATION_FLAGS.NON_FINITE_DATA
+                    | SEGMENTATION_FLAGS.NON_FINITE_ERROR)
+        assert cat.flags[idx] & expected == expected
+        other = 1 - idx
+        assert not (cat.flags[other] & expected)
+
+        # The flags are sliced with the catalog
+        assert cat[idx].flags & expected == expected
+
     def test_all_masked(self):
         """
         Test the all_masked flag when every segment pixel is masked.

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -18,7 +18,6 @@ from astropy.table import QTable
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose, assert_equal
-from scipy.optimize import root_scalar
 
 from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture)
@@ -974,43 +973,6 @@ class TestSourceCatalog:
         # Modifying the parent cache does not affect the sliced cache
         cat.flux_radius(0.7)
         assert 0.7 not in obj._flux_radius_cache
-
-    def test_flux_radius_max_radius_delta(self):
-        """
-        Test that the max_radius_delta fallback loop reduces max_radius
-        by 10 percent on each failed bracketing attempt and still
-        returns a valid result when the second (reduced) bracket
-        succeeds.
-        """
-        # Use a single-source scalar catalog to keep the mock simple
-        cat = SourceCatalog(self.data, self.segm)[1]
-        assert cat.isscalar
-
-        brackets_seen = []
-        call_count = [0]
-
-        def mock_root_scalar(fcn, args, bracket, method):
-            call_count[0] += 1
-            brackets_seen.append(list(bracket))
-            if call_count[0] == 1:
-                # Simulate a bracket with no sign change
-                msg = 'no sign change in bracket'
-                raise ValueError(msg)
-            return root_scalar(fcn, args=args, bracket=bracket, method=method)
-
-        with patch('photutils.segmentation.catalog.root_scalar',
-                   mock_root_scalar):
-            r = cat.flux_radius(0.5)
-
-        # Fallback triggered once then succeeded
-        assert call_count[0] == 2
-
-        # Second bracket max_radius must be 10% smaller than the first
-        assert_allclose(brackets_seen[1][1], 0.9 * brackets_seen[0][1],
-                        rtol=1e-10)
-
-        # Result is a valid radius (not NaN)
-        assert np.isfinite(r.value)
 
     def test_flux_radius(self):
         """
@@ -2475,24 +2437,6 @@ def test_centroid_quad_edge_cases():
     cat4 = SourceCatalog(data4, segm4)
     cquad4 = cat4.cutout_centroid_quad
     assert np.all(np.isfinite(cquad4))
-
-
-def test_flux_radius_no_solution(single_source_catalog):
-    """
-    Test that flux_radius returns NaN when no solution is found
-    (root_scalar always raises ValueError).
-    """
-    _data, _segm, cat = single_source_catalog
-
-    # Make root_scalar always raise ValueError so no solution is found
-    def mock_root_scalar(*_args, **_kwargs):
-        msg = 'bracket signs'
-        raise ValueError(msg)
-
-    with patch('photutils.segmentation.catalog.root_scalar',
-               mock_root_scalar):
-        result = cat.flux_radius(0.5)
-    assert np.isnan(result.value[0])
 
 
 def test_kron_radius_max(gauss_101_catalog):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1673,15 +1673,30 @@ class TestSourceCatalogFlags:
         Test the kron_undefined flag when the Kron photometry is skipped
         because the aperture is too large.
         """
-        cat = SourceCatalog(self.data, self.segm)
-        _ = cat.kron_aperture  # cache the apertures
         if circular:
-            aperture = CircularAperture((25, 25), r=2000)
+            # A huge minimum circular radius makes every Kron aperture
+            # the circle of that radius
+            cat = SourceCatalog(self.data, self.segm,
+                                kron_params=(2.5, 1.4, 2000.0))
+            assert np.all(cat.kron_radius.value == 0)
+            assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_UNDEFINED)
         else:
-            aperture = EllipticalAperture((25, 25), 2000, 2000,
-                                          theta=0.0)
-        cat.__dict__['kron_aperture'] = [aperture] * cat.n_labels
-        assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_UNDEFINED)
+            # A huge semimajor axis with a normal Kron radius makes a
+            # huge Kron ellipse
+            cat = SourceCatalog(self.data, self.segm)
+            huge = np.full(cat.n_labels, 2000.0) << u.pix
+            kron_radius = np.full(cat.n_labels, 1.5)
+            with (patch.object(type(cat), 'semimajor_axis',
+                               new_callable=lambda: property(
+                                   lambda _self: huge)),
+                  patch.object(type(cat), 'semiminor_axis',
+                               new_callable=lambda: property(
+                                   lambda _self: huge)),
+                  patch.object(type(cat), '_measured_kron_radius',
+                               new_callable=lambda: property(
+                                   lambda _self: kron_radius))):
+                assert np.all(cat.flags
+                              & SEGMENTATION_FLAGS.KRON_UNDEFINED)
 
     def test_kron_no_overlap(self):
         """
@@ -1689,9 +1704,9 @@ class TestSourceCatalogFlags:
         completely outside the data array.
         """
         cat = SourceCatalog(self.data, self.segm)
-        _ = cat.kron_aperture  # cache the apertures
-        aperture = EllipticalAperture((-1000, -1000), 5, 3, theta=0.0)
-        cat.__dict__['kron_aperture'] = [aperture] * cat.n_labels
+        _ = cat.kron_radius  # measure the Kron radii before moving
+        cat.__dict__['x_centroid'] = np.full(cat.n_labels, -1000.0)
+        cat.__dict__['y_centroid'] = np.full(cat.n_labels, -1000.0)
         assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
 
     def test_kron_no_overlap_zero_weights(self):
@@ -1700,10 +1715,15 @@ class TestSourceCatalogFlags:
         box overlaps the data, but no pixel within the data has a
         nonzero aperture weight.
         """
-        cat = SourceCatalog(self.data, self.segm)
-        _ = cat.kron_aperture  # cache the apertures
-        aperture = CircularAperture((-10.5, -10.5), r=10)
-        cat.__dict__['kron_aperture'] = [aperture] * cat.n_labels
+        # A minimum circular radius of 11 makes every Kron aperture a
+        # circle of that radius, then centered at (-11.5, -11.5) its
+        # bounding box reaches the first data column, but no pixel
+        # center lies within the circle
+        cat = SourceCatalog(self.data, self.segm,
+                            kron_params=(2.5, 1.4, 11.0))
+        assert np.all(cat.kron_radius.value == 0)
+        cat.__dict__['x_centroid'] = np.full(cat.n_labels, -11.5)
+        cat.__dict__['y_centroid'] = np.full(cat.n_labels, -11.5)
         assert np.all(np.isnan(cat.kron_flux))
         assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
         assert not np.any(cat.flags
@@ -2470,43 +2490,46 @@ def test_kron_radius_max(gauss_101_catalog):
 def test_kron_photometry_oom_guard(gauss_101_catalog):
     """
     Test that _calc_kron_photometry returns NaN when the Kron aperture
-    is too large (OOM guard).
+    is too large (OOM guard), does not overlap the data, or has no
+    contributing pixels.
     """
     data, segm, cat = gauss_101_catalog
-    _ = cat.kron_aperture  # cache
 
-    # Create huge elliptical apertures that exceed the max_size check
-    huge_aper = [EllipticalAperture((50, 50), 2000, 2000, theta=0.0)
-                 for _ in range(cat.n_labels)]
-    cat.__dict__['kron_aperture'] = huge_aper
-    assert np.all(np.isnan(cat.kron_flux))
+    # A huge semimajor axis with a normal Kron radius makes a huge
+    # Kron ellipse that exceeds the max_size check
+    huge = np.array([2000.0]) << u.pix
+    kron_radius = np.array([1.5])
+    with (patch.object(type(cat), 'semimajor_axis',
+                       new_callable=lambda: property(lambda _self: huge)),
+          patch.object(type(cat), 'semiminor_axis',
+                       new_callable=lambda: property(lambda _self: huge)),
+          patch.object(type(cat), '_measured_kron_radius',
+                       new_callable=lambda: property(
+                           lambda _self: kron_radius))):
+        assert np.all(np.isnan(cat.kron_flux))
 
-    # Create huge circular apertures that exceed the max_size check
-    cat2 = SourceCatalog(data, segm)
-    _ = cat2.kron_aperture
-    huge_circ = [CircularAperture((50, 50), r=2000)
-                 for _ in range(cat2.n_labels)]
-    cat2.__dict__['kron_aperture'] = huge_circ
+    # A huge minimum circular radius makes a huge circular aperture
+    # that exceeds the max_size check
+    cat2 = SourceCatalog(data, segm, kron_params=(2.5, 1.4, 2000.0))
+    assert np.all(cat2.kron_radius.value == 0)
     assert np.all(np.isnan(cat2.kron_flux))
 
-    # Aperture completely off-image triggers data=None guard
+    # An aperture completely off-image has no overlap
     cat3 = SourceCatalog(data, segm)
-    _ = cat3.kron_aperture
-    off_aper = [EllipticalAperture((-1000, -1000), 5, 3, theta=0.0)
-                for _ in range(cat3.n_labels)]
-    cat3.__dict__['kron_aperture'] = off_aper
+    _ = cat3.kron_radius  # measure the Kron radius before moving
+    cat3.__dict__['x_centroid'] = np.array([-1000.0])
+    cat3.__dict__['y_centroid'] = np.array([-1000.0])
     assert np.all(np.isnan(cat3.kron_flux))
 
     # An aperture whose pixels are all masked has no contributing
     # pixels, giving NaN flux and flux error
     error = np.ones_like(data)
     mask = np.zeros(data.shape, dtype=bool)
-    mask[:20, :20] = True
+    mask[:40, :40] = True
     cat4 = SourceCatalog(data, segm, error=error, mask=mask)
-    _ = cat4.kron_aperture  # cache
-    masked_aper = [CircularAperture((10, 10), r=3)
-                   for _ in range(cat4.n_labels)]
-    cat4.__dict__['kron_aperture'] = masked_aper
+    _ = cat4.kron_radius  # measure the Kron radius before moving
+    cat4.__dict__['x_centroid'] = np.array([10.0])
+    cat4.__dict__['y_centroid'] = np.array([10.0])
     assert np.all(np.isnan(cat4.kron_flux))
     assert np.all(np.isnan(cat4.kron_flux_err))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ requires = [
     'cython >= 3.1.2, < 4',
     'extension-helpers >= 1.3, < 2',
     'numpy >= 2.0',
+    'scipy >= 1.15.0',
     'setuptools >= 77.0.1',
     'setuptools_scm >= 8.2',
 ]


### PR DESCRIPTION
This PR significantly improves the performance of the ``SourceCatalog`` properties, especially windowed centroids, quadratic centroids, and Kron radii and photometry, typically by factors of ~3-20 depending on the property, by computing all sources in a single call into compiled code. 

No property displays a progress bar any more, but the ``progress_bar`` keyword is retained for backwards compatibility.
    
SciPy is now also a build-time dependency. Its Cython interface to the Brent root finder is used by the compiled code that computes the ``SourceCatalog`` `flux_radus` property.