### PR TITLE
Add SourceCatalog n_threads keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -285,12 +285,13 @@ New Features
     bar any more (see the ``progress_bar`` deprecation under API
     Changes). [#2406]
 
-  - Added an ``n_threads`` keyword to ``SourceCatalog`` to compute the
-    Kron radii, Kron photometry, and flux radii (``kron_radius``,
-    ``kron_flux``, ``kron_flux_err``, ``kron_photometry``, and
-    ``flux_radius``), and thus the measurements that depend on them
-    (e.g., ``centroid_win``), using multiple threads. The sources are
-    divided into chunks that are processed concurrently, producing
+  - Added an ``n_threads`` keyword to ``SourceCatalog`` to compute
+    the compiled per-source measurements (the isophotal moments and
+    their errors, the segment pixel statistics, the windowed and
+    quadratic centroids, ``perimeter``, the Kron radii and photometry,
+    ``circular_photometry``, and ``flux_radius``), and thus every
+    property derived from them, using multiple threads. The sources
+    are divided into chunks that are processed concurrently, producing
     results identical to the single-threaded computation. [#2407]
 
 - ``photutils.utils``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -286,12 +286,12 @@ New Features
     Changes). [#2406]
 
   - Added an ``n_threads`` keyword to ``SourceCatalog`` to compute the
-    Kron radii and Kron photometry (``kron_radius``, ``kron_flux``,
-    ``kron_flux_err``, and ``kron_photometry``), and thus the
-    measurements that depend on them (e.g., ``flux_radius`` and
-    ``centroid_win``), using multiple threads. The sources are divided
-    into chunks that are processed concurrently, producing results
-    identical to the single-threaded computation. [#2407]
+    Kron radii, Kron photometry, and flux radii (``kron_radius``,
+    ``kron_flux``, ``kron_flux_err``, ``kron_photometry``, and
+    ``flux_radius``), and thus the measurements that depend on them
+    (e.g., ``centroid_win``), using multiple threads. The sources are
+    divided into chunks that are processed concurrently, producing
+    results identical to the single-threaded computation. [#2407]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -285,6 +285,14 @@ New Features
     bar any more (see the ``progress_bar`` deprecation under API
     Changes). [#2406]
 
+  - Added an ``n_threads`` keyword to ``SourceCatalog`` to compute the
+    Kron radii and Kron photometry (``kron_radius``, ``kron_flux``,
+    ``kron_flux_err``, and ``kron_photometry``), and thus the
+    measurements that depend on them (e.g., ``flux_radius`` and
+    ``centroid_win``), using multiple threads. The sources are divided
+    into chunks that are processed concurrently, producing results
+    identical to the single-threaded computation. [#2407]
+
 - ``photutils.utils``
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -292,11 +292,12 @@ do:
   a fresh catalog (times include dependent properties, e.g.,
   `centroid_win` includes the Kron flux and `flux_radius` it depends
   on)
-- the `SourceCatalog` `n_threads` keyword for the Kron and flux
-  radius measurements (`kron_radius`, `kron_flux`, `kron_photometry`,
-  and `flux_radius`) across thread counts, with the isophotal
-  prerequisites precomputed (with speedups relative to the first
-  thread count)
+- the `SourceCatalog` `n_threads` keyword across thread counts for
+  each compiled per-source measurement (moments, segment statistics,
+  centroids, perimeter, Kron and circular photometry, and flux
+  radius), with the prerequisites of each measurement precomputed,
+  plus the cold default `to_table` (with speedups relative to the
+  first thread count)
 - concurrent `SourceCatalog` measurement jobs across thread counts
   (with speedups relative to the first thread count)
 
@@ -310,8 +311,8 @@ python benchmarks/bench_segmentation.py
 python benchmarks/bench_segmentation.py --which deblend \
     --n-sources 4000 --n-processes 1,4,8
 
-# Only the SourceCatalog n_threads benchmark for the Kron measurements
-python benchmarks/bench_segmentation.py --which kron-threads \
+# Only the SourceCatalog n_threads benchmark
+python benchmarks/bench_segmentation.py --which n-threads \
     --n-sources 4000 --threads 1,4,8
 ```
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -292,6 +292,11 @@ do:
   a fresh catalog (times include dependent properties, e.g.,
   `centroid_win` includes the Kron flux and `flux_radius` it depends
   on)
+- the `SourceCatalog` `n_threads` keyword for the Kron measurements
+  (`kron_radius`, `kron_flux`, `kron_photometry`, and the dependent
+  `flux_radius`) across thread counts, with the isophotal
+  prerequisites precomputed (with speedups relative to the first
+  thread count)
 - concurrent `SourceCatalog` measurement jobs across thread counts
   (with speedups relative to the first thread count)
 
@@ -304,6 +309,10 @@ python benchmarks/bench_segmentation.py
 # Only the deblending benchmark with a larger image
 python benchmarks/bench_segmentation.py --which deblend \
     --n-sources 4000 --n-processes 1,4,8
+
+# Only the SourceCatalog n_threads benchmark for the Kron measurements
+python benchmarks/bench_segmentation.py --which kron-threads \
+    --n-sources 4000 --threads 1,4,8
 ```
 
 ## Background (`bench_background.py`)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -292,9 +292,9 @@ do:
   a fresh catalog (times include dependent properties, e.g.,
   `centroid_win` includes the Kron flux and `flux_radius` it depends
   on)
-- the `SourceCatalog` `n_threads` keyword for the Kron measurements
-  (`kron_radius`, `kron_flux`, `kron_photometry`, and the dependent
-  `flux_radius`) across thread counts, with the isophotal
+- the `SourceCatalog` `n_threads` keyword for the Kron and flux
+  radius measurements (`kron_radius`, `kron_flux`, `kron_photometry`,
+  and `flux_radius`) across thread counts, with the isophotal
   prerequisites precomputed (with speedups relative to the first
   thread count)
 - concurrent `SourceCatalog` measurement jobs across thread counts

--- a/benchmarks/bench_segmentation.py
+++ b/benchmarks/bench_segmentation.py
@@ -471,8 +471,8 @@ def bench_catalog_kron_threads(*, n_sources=1000,
     coefficients) that every Kron measurement depends on. The Kron
     radius, the Kron flux (which includes the Kron radius), the Kron
     photometry with alternate parameters (on a catalog whose Kron
-    radius is already computed), and the flux radius (which runs
-    serial kernels on the threaded Kron flux) are then timed.
+    radius is already computed), and the flux radius (on a catalog
+    whose Kron flux is already computed) are then timed.
 
     Parameters
     ----------

--- a/benchmarks/bench_segmentation.py
+++ b/benchmarks/bench_segmentation.py
@@ -8,8 +8,8 @@ detect_sources), source deblending (deblend_sources) across the
 threshold modes and process counts, the combined SourceFinder class,
 SegmentationImage operations (relabeling, border-label removal,
 source masks, and polygons), SourceCatalog property calculations, the
-SourceCatalog n_threads keyword for the Kron measurements, and
-concurrent SourceCatalog runs across thread counts.
+SourceCatalog n_threads keyword, and concurrent SourceCatalog runs
+across thread counts.
 
 Run ``python benchmarks/bench_segmentation.py --help`` to see the
 available options.
@@ -458,21 +458,18 @@ def bench_catalog_threads(*, n_sources=1000, n_calls=8,
     print(''.join(f'{cell:>18}' for cell in format_sweep_cells(times)))
 
 
-def bench_catalog_kron_threads(*, n_sources=1000,
-                               thread_counts=(1, 2, 4, 8), repeats=3,
-                               seed=0):
+def bench_catalog_n_threads(*, n_sources=1000, thread_counts=(1, 2, 4, 8),
+                            repeats=3, seed=0):
     """
-    Benchmark the SourceCatalog n_threads keyword for the Kron
-    measurements.
+    Benchmark the SourceCatalog n_threads keyword.
 
     Each timing constructs a fresh SourceCatalog with the given
     ``n_threads`` and, outside the timed region, computes the
-    isophotal prerequisites (centroid, shape parameters, and ellipse
-    coefficients) that every Kron measurement depends on. The Kron
-    radius, the Kron flux (which includes the Kron radius), the Kron
-    photometry with alternate parameters (on a catalog whose Kron
-    radius is already computed), and the flux radius (on a catalog
-    whose Kron flux is already computed) are then timed.
+    prerequisites of the measurement (e.g., the isophotal centroid
+    and shape parameters for the Kron radius, or the Kron flux for
+    the flux radius), so that only the measurement itself is timed.
+    The default ``to_table`` columns are timed from a cold catalog,
+    so that row shows the end-to-end effect.
 
     Parameters
     ----------
@@ -492,40 +489,54 @@ def bench_catalog_kron_threads(*, n_sources=1000,
     error = np.ones_like(data)
 
     def _make_catalog(n_threads):
-        cat = SourceCatalog(data, segm, convolved_data=convolved_data,
-                            error=error, n_threads=n_threads)
-        # Warm the isophotal prerequisites of the Kron measurements
-        for name in ('centroid', 'semimajor_axis', 'semiminor_axis',
-                     'orientation', 'ellipse_cxx', 'ellipse_cxy',
-                     'ellipse_cyy'):
-            getattr(cat, name)
-        return cat
+        return SourceCatalog(data, segm, convolved_data=convolved_data,
+                             error=error, n_threads=n_threads)
 
     def _time_measurement(func, n_threads, *, warm=()):
         best = np.inf
         for _ in range(repeats):
             cat = _make_catalog(n_threads)
-            for name in warm:
-                getattr(cat, name)
+            for item in warm:
+                if isinstance(item, str):
+                    getattr(cat, item)
+                else:
+                    item(cat)
             t0 = time.perf_counter()
             func(cat)
             best = min(best, time.perf_counter() - t0)
         return best
 
-    attrgetter('kron_flux')(_make_catalog(1))  # warm up
+    _make_catalog(1).to_table()  # warm up
 
+    shape = ('centroid', 'semimajor_axis', 'semiminor_axis',
+             'orientation', 'ellipse_cxx', 'ellipse_cxy', 'ellipse_cyy')
+    half_light = [lambda cat: cat.flux_radius(0.5)]
     benchmarks = [
-        ('kron_radius', attrgetter('kron_radius'), ()),
-        ('kron_flux (incl. kron_radius)', attrgetter('kron_flux'), ()),
+        ('moments', attrgetter('moments'), ('bbox_xmin',)),
+        ('moments_central', attrgetter('moments_central'),
+         ('cutout_centroid',)),
+        ('centroid_err', attrgetter('centroid_err'), ('covariance',)),
+        ('segment_flux (+ error)', attrgetter('segment_flux'),
+         ('bbox_xmin',)),
+        ('min_value_xindex', attrgetter('min_value_xindex'),
+         ('bbox_xmin',)),
+        ('perimeter', attrgetter('perimeter'), ('bbox_xmin',)),
+        ('centroid_quad', attrgetter('centroid_quad'), ('bbox_xmin',)),
+        ('circular_photometry(5)',
+         lambda cat: cat.circular_photometry(5.0), ('centroid',)),
+        ('kron_radius', attrgetter('kron_radius'), shape),
+        ('kron_flux (incl. kron_radius)', attrgetter('kron_flux'), shape),
         ('kron_photometry((2.5, 1.4))',
          lambda cat: cat.kron_photometry((2.5, 1.4)), ('kron_radius',)),
         ('flux_radius(0.5)', lambda cat: cat.flux_radius(0.5),
          ('kron_flux',)),
+        ('centroid_win', attrgetter('centroid_win'), half_light),
+        ('to_table (default columns)', lambda cat: cat.to_table(), ()),
     ]
 
     print(f'\n== SourceCatalog n_threads scaling ({segm.n_labels} '
-          f'segments, {data.shape[0]}x{data.shape[1]} image; isophotal '
-          'prerequisites precomputed) ==')
+          f'segments, {data.shape[0]}x{data.shape[1]} image; '
+          'prerequisites precomputed except for to_table) ==')
     header = f'{"measurement":>32}'
     header += ''.join(f'{f"n={n}":>18}' for n in thread_counts)
     print(header)
@@ -586,7 +597,7 @@ def main():
                              '(default: %(default)s)')
     parser.add_argument('--which', default='all',
                         choices=['all', 'detect', 'deblend', 'finder',
-                                 'segmimage', 'catalog', 'kron-threads',
+                                 'segmimage', 'catalog', 'n-threads',
                                  'threads'],
                         help='which benchmark to run '
                              '(default: %(default)s)')
@@ -610,10 +621,10 @@ def main():
     if args.which in ('all', 'catalog'):
         bench_catalog(n_sources=args.n_sources, repeats=args.repeats,
                       seed=args.seed)
-    if args.which in ('all', 'kron-threads'):
-        bench_catalog_kron_threads(n_sources=args.n_sources,
-                                   thread_counts=args.threads,
-                                   repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'n-threads'):
+        bench_catalog_n_threads(n_sources=args.n_sources,
+                                thread_counts=args.threads,
+                                repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'threads'):
         bench_catalog_threads(n_sources=args.n_sources,
                               n_calls=args.n_calls,

--- a/benchmarks/bench_segmentation.py
+++ b/benchmarks/bench_segmentation.py
@@ -7,7 +7,8 @@ The benchmarks cover source detection (detect_threshold and
 detect_sources), source deblending (deblend_sources) across the
 threshold modes and process counts, the combined SourceFinder class,
 SegmentationImage operations (relabeling, border-label removal,
-source masks, and polygons), SourceCatalog property calculations, and
+source masks, and polygons), SourceCatalog property calculations, the
+SourceCatalog n_threads keyword for the Kron measurements, and
 concurrent SourceCatalog runs across thread counts.
 
 Run ``python benchmarks/bench_segmentation.py --help`` to see the
@@ -15,6 +16,7 @@ available options.
 """
 
 import argparse
+import time
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from operator import attrgetter
@@ -456,6 +458,84 @@ def bench_catalog_threads(*, n_sources=1000, n_calls=8,
     print(''.join(f'{cell:>18}' for cell in format_sweep_cells(times)))
 
 
+def bench_catalog_kron_threads(*, n_sources=1000,
+                               thread_counts=(1, 2, 4, 8), repeats=3,
+                               seed=0):
+    """
+    Benchmark the SourceCatalog n_threads keyword for the Kron
+    measurements.
+
+    Each timing constructs a fresh SourceCatalog with the given
+    ``n_threads`` and, outside the timed region, computes the
+    isophotal prerequisites (centroid, shape parameters, and ellipse
+    coefficients) that every Kron measurement depends on. The Kron
+    radius, the Kron flux (which includes the Kron radius), the Kron
+    photometry with alternate parameters (on a catalog whose Kron
+    radius is already computed), and the flux radius (which runs
+    serial kernels on the threaded Kron flux) are then timed.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources in the image.
+
+    thread_counts : tuple of int, optional
+        The ``n_threads`` values.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, convolved_data, segm = make_inputs(n_sources, seed=seed)
+    error = np.ones_like(data)
+
+    def _make_catalog(n_threads):
+        cat = SourceCatalog(data, segm, convolved_data=convolved_data,
+                            error=error, n_threads=n_threads)
+        # Warm the isophotal prerequisites of the Kron measurements
+        for name in ('centroid', 'semimajor_axis', 'semiminor_axis',
+                     'orientation', 'ellipse_cxx', 'ellipse_cxy',
+                     'ellipse_cyy'):
+            getattr(cat, name)
+        return cat
+
+    def _time_measurement(func, n_threads, *, warm=()):
+        best = np.inf
+        for _ in range(repeats):
+            cat = _make_catalog(n_threads)
+            for name in warm:
+                getattr(cat, name)
+            t0 = time.perf_counter()
+            func(cat)
+            best = min(best, time.perf_counter() - t0)
+        return best
+
+    attrgetter('kron_flux')(_make_catalog(1))  # warm up
+
+    benchmarks = [
+        ('kron_radius', attrgetter('kron_radius'), ()),
+        ('kron_flux (incl. kron_radius)', attrgetter('kron_flux'), ()),
+        ('kron_photometry((2.5, 1.4))',
+         lambda cat: cat.kron_photometry((2.5, 1.4)), ('kron_radius',)),
+        ('flux_radius(0.5)', lambda cat: cat.flux_radius(0.5),
+         ('kron_flux',)),
+    ]
+
+    print(f'\n== SourceCatalog n_threads scaling ({segm.n_labels} '
+          f'segments, {data.shape[0]}x{data.shape[1]} image; isophotal '
+          'prerequisites precomputed) ==')
+    header = f'{"measurement":>32}'
+    header += ''.join(f'{f"n={n}":>18}' for n in thread_counts)
+    print(header)
+    for name, func, warm in benchmarks:
+        times = [_time_measurement(func, n_threads, warm=warm)
+                 for n_threads in thread_counts]
+        cells = ''.join(f'{cell:>18}' for cell in format_sweep_cells(times))
+        print(f'{name:>32}{cells}')
+
+
 def parse_int_list(text):
     """
     Parse a comma-separated list of positive integers.
@@ -496,7 +576,8 @@ def main():
     parser.add_argument('--threads', type=parse_thread_counts,
                         default=[1, 2, 4, 8],
                         help='comma-separated thread counts for the '
-                             'thread-scaling benchmark (default: 1,2,4,8)')
+                             'thread-scaling and n_threads benchmarks '
+                             '(default: 1,2,4,8)')
     parser.add_argument('--repeats', type=int, default=3,
                         help='number of repeats per timing; the best '
                              'time is reported (default: %(default)s)')
@@ -505,7 +586,8 @@ def main():
                              '(default: %(default)s)')
     parser.add_argument('--which', default='all',
                         choices=['all', 'detect', 'deblend', 'finder',
-                                 'segmimage', 'catalog', 'threads'],
+                                 'segmimage', 'catalog', 'kron-threads',
+                                 'threads'],
                         help='which benchmark to run '
                              '(default: %(default)s)')
     args = parser.parse_args()
@@ -528,6 +610,10 @@ def main():
     if args.which in ('all', 'catalog'):
         bench_catalog(n_sources=args.n_sources, repeats=args.repeats,
                       seed=args.seed)
+    if args.which in ('all', 'kron-threads'):
+        bench_catalog_kron_threads(n_sources=args.n_sources,
+                                   thread_counts=args.threads,
+                                   repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'threads'):
         bench_catalog_threads(n_sources=args.n_sources,
                               n_calls=args.n_calls,

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -285,17 +285,19 @@ for the aperture fluxes and sums as well as for statistics such as the
 median, MAD standard deviation, and the biweight estimators.
 
 `~photutils.segmentation.SourceCatalog` also accepts an ``n_threads``
-keyword. The Kron radii, Kron photometry, and flux radii, and thus the
-measurements that depend on them such as ``centroid_win``, are computed
-in chunks of sources processed concurrently, with results identical to
-the single-threaded computation::
+keyword. Its compiled per-source measurements (the isophotal moments,
+segment pixel statistics, windowed and quadratic centroids, perimeter,
+Kron and circular photometry, and flux radii) are computed in chunks
+of sources processed concurrently, with results identical to the
+single-threaded computation, so the default ``to_table`` output of a
+large catalog is several times faster with several threads::
 
     >>> from photutils.datasets import make_100gaussians_image
     >>> from photutils.segmentation import SourceCatalog, detect_sources
     >>> image = make_100gaussians_image() - 5.0  # subtract background
     >>> segm = detect_sources(image, 9.0, n_pixels=5)
     >>> cat = SourceCatalog(image, segm, n_threads=8)
-    >>> kron_flux = cat.kron_flux
+    >>> table = cat.to_table()
 
 For more advanced workflows, independent images can also be processed
 concurrently with a thread pool, one instance per frame::

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -285,10 +285,10 @@ for the aperture fluxes and sums as well as for statistics such as the
 median, MAD standard deviation, and the biweight estimators.
 
 `~photutils.segmentation.SourceCatalog` also accepts an ``n_threads``
-keyword. The Kron radii and Kron photometry, and thus the measurements
-that depend on them such as ``flux_radius`` and ``centroid_win``, are
-computed in chunks of sources processed concurrently, with results
-identical to the single-threaded computation::
+keyword. The Kron radii, Kron photometry, and flux radii, and thus the
+measurements that depend on them such as ``centroid_win``, are computed
+in chunks of sources processed concurrently, with results identical to
+the single-threaded computation::
 
     >>> from photutils.datasets import make_100gaussians_image
     >>> from photutils.segmentation import SourceCatalog, detect_sources

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -284,6 +284,19 @@ measured speedups are ~2x with 2 threads and ~8-10x with 12 threads,
 for the aperture fluxes and sums as well as for statistics such as the
 median, MAD standard deviation, and the biweight estimators.
 
+`~photutils.segmentation.SourceCatalog` also accepts an ``n_threads``
+keyword. The Kron radii and Kron photometry, and thus the measurements
+that depend on them such as ``flux_radius`` and ``centroid_win``, are
+computed in chunks of sources processed concurrently, with results
+identical to the single-threaded computation::
+
+    >>> from photutils.datasets import make_100gaussians_image
+    >>> from photutils.segmentation import SourceCatalog, detect_sources
+    >>> image = make_100gaussians_image() - 5.0  # subtract background
+    >>> segm = detect_sources(image, 9.0, n_pixels=5)
+    >>> cat = SourceCatalog(image, segm, n_threads=8)
+    >>> kron_flux = cat.kron_flux
+
 For more advanced workflows, independent images can also be processed
 concurrently with a thread pool, one instance per frame::
 

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -225,7 +225,9 @@ class AperturePhotometry:
         self.subpixels = subpixels
         self.mask_method = mask_method
 
-        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+        if (isinstance(n_threads, bool)
+                or not isinstance(n_threads, (int, np.integer))
+                or n_threads < 1):
             msg = 'n_threads must be a positive integer'
             raise ValueError(msg)
         self.n_threads = int(n_threads)

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -401,7 +401,9 @@ class ApertureStats:
             raise ValueError(msg)
         self.ddof = ddof
 
-        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+        if (isinstance(n_threads, bool)
+                or not isinstance(n_threads, (int, np.integer))
+                or n_threads < 1):
             msg = 'n_threads must be a positive integer'
             raise ValueError(msg)
         self.n_threads = int(n_threads)

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -1145,7 +1145,7 @@ class TestNThreads:
         data = np.ones((40, 40))
         aper = CircularAperture((20, 20), r=5.0)
         match = 'n_threads must be a positive integer'
-        for n_threads in (0, -1, 2.5):
+        for n_threads in (0, -1, 2.5, True):
             with pytest.raises(ValueError, match=match):
                 AperturePhotometry(data, aper, n_threads=n_threads)
 

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -1516,7 +1516,7 @@ class TestNThreads:
         data = np.ones((40, 40))
         aper = CircularAperture((20, 20), r=5.0)
         match = 'n_threads must be a positive integer'
-        for n_threads in (0, -1, 2.5):
+        for n_threads in (0, -1, 2.5, True):
             with pytest.raises(ValueError, match=match):
                 ApertureStats(data, aper, n_threads=n_threads)
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -301,7 +301,9 @@ class Background2D:
                                    lower_bound=(0, 0), check_odd=True)
         self.filter_threshold = filter_threshold
 
-        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+        if (isinstance(n_threads, bool)
+                or not isinstance(n_threads, (int, np.integer))
+                or n_threads < 1):
             msg = 'n_threads must be a positive integer'
             raise ValueError(msg)
         self.n_threads = int(n_threads)

--- a/photutils/background/local_background.py
+++ b/photutils/background/local_background.py
@@ -89,7 +89,9 @@ class LocalBackground:
             bkg_estimator = MedianBackground()
         self.bkg_estimator = bkg_estimator
 
-        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+        if (isinstance(n_threads, bool)
+                or not isinstance(n_threads, (int, np.integer))
+                or n_threads < 1):
             msg = 'n_threads must be a positive integer'
             raise ValueError(msg)
         self.n_threads = int(n_threads)

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -317,7 +317,7 @@ class TestBackground2D:
         integer.
         """
         match = 'n_threads must be a positive integer'
-        for n_threads in (0, -1, 2.5):
+        for n_threads in (0, -1, 2.5, True):
             with pytest.raises(ValueError, match=match):
                 Background2D(test_data, (25, 25), n_threads=n_threads)
 

--- a/photutils/background/tests/test_local_background.py
+++ b/photutils/background/tests/test_local_background.py
@@ -311,6 +311,6 @@ class TestFastLocalBackground:
         integer.
         """
         match = 'n_threads must be a positive integer'
-        for n_threads in (0, -1, 2.5):
+        for n_threads in (0, -1, 2.5, True):
             with pytest.raises(ValueError, match=match):
                 LocalBackground(5, 10, n_threads=n_threads)

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -1223,7 +1223,9 @@ def batch_flux_radius_solve(const double[::1] values, *,
     ------
     ValueError
         If a per-source array does not have the same length as
-        ``counts``.
+        ``counts``, if ``grid_edges`` does not have 4 columns, or if a
+        source's ``starts`` and ``counts`` region extends beyond the
+        ``values`` buffer.
     """
     cdef Py_ssize_t n_src = counts.shape[0]
     for name, length in (('starts', starts.shape[0]), ('nx', nx.shape[0]),
@@ -1234,6 +1236,19 @@ def batch_flux_radius_solve(const double[::1] values, *,
         if length != n_src:
             msg = f'{name} must have the same length as counts'
             raise ValueError(msg)
+    if grid_edges.shape[1] != 4:
+        msg = 'grid_edges must have 4 columns'
+        raise ValueError(msg)
+
+    # The source loops below index the packed buffer without bounds
+    # checks, so reject a region that does not fit in it.
+    cdef Py_ssize_t n_values = values.shape[0]
+    cdef Py_ssize_t i
+    for i in range(n_src):
+        if counts[i] < 0 or starts[i] < 0 or starts[i] + counts[i] > n_values:
+            msg = ('the starts and counts regions must lie within the '
+                   'values buffer')
+            raise ValueError(msg)
 
     radius_arr = np.full(n_src, np.nan)
     cdef double[::1] radius = radius_arr
@@ -1242,7 +1257,7 @@ def batch_flux_radius_solve(const double[::1] values, *,
     cdef double xmin_e, xmax_e, ymin_e, ymax_e, max_extent
     cdef double dx, dy, pixel_radius, bin_width, rmax, delta, result
     cdef bint found
-    cdef Py_ssize_t i, n_bins, max_pix = 0, max_bins = 0
+    cdef Py_ssize_t n_bins, max_pix = 0, max_bins = 0
 
     # Size the scratch buffers of the radial binning for the largest
     # cutout and bin count (local to this call, so the function is

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -761,10 +761,6 @@ cdef void _flux_radius_cutout(const double *data,
             out[(iy - y0) * nx + (ix - x0)] = value
 
 
-cdef inline double _dmax(double a, double b) noexcept nogil:
-    return a if a > b else b
-
-
 def batch_flux_radius_prepare(const double[:, ::1] data, *,
                               const unsigned char[:, ::1] mask,
                               const Py_ssize_t[:, ::1] segm,
@@ -1277,8 +1273,8 @@ def batch_flux_radius_solve(const double[::1] values, *,
             dy = (ymax_e - ymin_e) / ny[i]
             pixel_radius = 0.5 * sqrt(dx * dx + dy * dy)
             bin_width = 0.5 * pixel_radius
-            max_extent = sqrt(_dmax(xmin_e * xmin_e, xmax_e * xmax_e)
-                              + _dmax(ymin_e * ymin_e, ymax_e * ymax_e))
+            max_extent = sqrt(fmax(xmin_e * xmin_e, xmax_e * xmax_e)
+                              + fmax(ymin_e * ymin_e, ymax_e * ymax_e))
             n_bins = <Py_ssize_t>(max_extent / bin_width) + 1
             if n_bins > max_bins:
                 max_bins = n_bins
@@ -1320,9 +1316,8 @@ def batch_flux_radius_solve(const double[::1] values, *,
             # farthest cutout corner; the boundary band of a circle
             # then spans the pixel diagonal plus two bins
             p.bin_width = 0.5 * p.pixel_radius
-            max_extent = sqrt(_dmax(p.xmin_e * p.xmin_e, xmax_e * xmax_e)
-                              + _dmax(p.ymin_e * p.ymin_e,
-                                      ymax_e * ymax_e))
+            max_extent = sqrt(fmax(p.xmin_e * p.xmin_e, xmax_e * xmax_e)
+                              + fmax(p.ymin_e * p.ymin_e, ymax_e * ymax_e))
             p.n_bins = <Py_ssize_t>(max_extent / p.bin_width) + 1
             _bin_flux_radius_pixels(&p, &order[0], &bin_of[0],
                                     &bin_starts[0], &bin_cumsum[0],

--- a/photutils/segmentation/_batch_catalog.pyx
+++ b/photutils/segmentation/_batch_catalog.pyx
@@ -21,7 +21,9 @@ the pixel-statistics properties (e.g., ``segment_flux``).
 The fractional-flux radius solver additionally runs its bracketed
 root-find entirely in C, using the ``brentq`` implementation exported
 by ``scipy.optimize.cython_optimize``, so that no Python call is made
-per root-finder iteration.
+per root-finder iteration. Its prepared per-source inputs (the cleaned
+cutouts) are packed into one buffer, so the preparation and the solve
+each run as a single GIL-free loop over the sources.
 
 The source loops run without the GIL and use no global mutable state,
 so this module is safe to use from multiple threads, including on
@@ -31,6 +33,8 @@ free-threaded Python builds.
 import numpy as np
 
 from scipy.optimize.cython_optimize cimport brentq, zeros_full_output
+
+from photutils.segmentation._batch_results import BatchFluxRadiusArgs
 
 from photutils.aperture._batch_overlap cimport (_circle_pixel_frac,
                                                 _seg_pixel_contributes)
@@ -757,6 +761,10 @@ cdef void _flux_radius_cutout(const double *data,
             out[(iy - y0) * nx + (ix - x0)] = value
 
 
+cdef inline double _dmax(double a, double b) noexcept nogil:
+    return a if a > b else b
+
+
 def batch_flux_radius_prepare(const double[:, ::1] data, *,
                               const unsigned char[:, ::1] mask,
                               const Py_ssize_t[:, ::1] segm,
@@ -780,7 +788,8 @@ def batch_flux_radius_prepare(const double[:, ::1] data, *,
     parameters of that cutout, relative to the source centroid, are
     computed. The bounding-box arithmetic, the per-pixel masking, and
     the neighbor handling replicate the previous per-source Python
-    implementation exactly.
+    implementation exactly. The cutouts of all sources are packed
+    into one buffer, and the source loops run without the GIL.
 
     Parameters
     ----------
@@ -849,17 +858,16 @@ def batch_flux_radius_prepare(const double[:, ::1] data, *,
 
     Returns
     -------
-    args : list
-        The prepared per-source arguments consumed by
-        ``batch_flux_radius_solve``, with one entry per source. Each
-        entry is either `None`, for a skipped source (including those
+    args : `~photutils.segmentation._batch_results.BatchFluxRadiusArgs`
+        The prepared per-source inputs consumed by
+        ``batch_flux_radius_solve``. The cleaned cutouts are packed
+        into the ``values`` buffer, located by the per-source
+        ``starts`` and ``counts``. A skipped source (including those
         rejected by ``max_aper_size`` and those whose bounding box
-        does not overlap the data), or the list ``[clean_data,
-        grid_params, kronflux, max_radius]``, where ``clean_data`` is
-        the cleaned C-contiguous float64 cutout and ``grid_params`` is
-        the tuple ``(xmin_e, xmax_e, ymin_e, ymax_e, nx, ny,
-        use_exact, subpixels)`` of grid parameters whose edges are
-        relative to the source centroid.
+        does not overlap the data) has a zero count. The
+        ``grid_edges`` are the ``(xmin, xmax, ymin, ymax)`` cutout
+        grid edges relative to the source centroid, and ``kronflux``
+        and ``max_radius`` are copies of the inputs.
 
     Raises
     ------
@@ -871,7 +879,6 @@ def batch_flux_radius_prepare(const double[:, ::1] data, *,
     cdef Py_ssize_t n_src = labels.shape[0]
     cdef Py_ssize_t ny_data = data.shape[0]
     cdef Py_ssize_t nx_data = data.shape[1]
-
     _check_length(xcen.shape[0], n_src, 'xcen')
     _check_length(ycen.shape[0], n_src, 'ycen')
     _check_length(local_bkg.shape[0], n_src, 'local_bkg')
@@ -883,68 +890,98 @@ def batch_flux_radius_prepare(const double[:, ::1] data, *,
     _check_shape(segm.shape[0], segm.shape[1], ny_data, nx_data,
                  'segm', 'data')
 
-    cdef Py_ssize_t i, x0, x1, y0, y1, nx, ny, ccx, ccy
+    # The clipped cutout bounding box (x0, x1, y0, y1) and the mirror
+    # center (ccx, ccy) of each source
+    bbox_arr = np.zeros((n_src, 6), dtype=np.intp)
+    counts_arr = np.zeros(n_src, dtype=np.intp)
+    starts_arr = np.zeros(n_src, dtype=np.intp)
+    nx_arr = np.zeros(n_src, dtype=np.intp)
+    ny_arr = np.zeros(n_src, dtype=np.intp)
+    grid_edges_arr = np.zeros((n_src, 4))
+    cdef Py_ssize_t[:, ::1] bbox = bbox_arr
+    cdef Py_ssize_t[::1] counts = counts_arr
+    cdef Py_ssize_t[::1] starts = starts_arr
+    cdef Py_ssize_t[::1] nx_out = nx_arr
+    cdef Py_ssize_t[::1] ny_out = ny_arr
+    cdef double[:, ::1] grid_edges = grid_edges_arr
+
+    cdef Py_ssize_t i, x0, x1, y0, y1, nx, ny, total = 0
     cdef double xc, yc, rmax, ixmin_d, ixmax_d, iymin_d, iymax_d
     cdef double x0_d, x1_d, y0_d, y1_d, cutout_xcen, cutout_ycen
-    cdef double[:, ::1] cutout
-    args = []
-    for i in range(n_src):
-        if skip[i]:
-            args.append(None)
-            continue
-        xc = xcen[i]
-        yc = ycen[i]
-        rmax = max_radius[i]
+    with nogil:
+        for i in range(n_src):
+            if skip[i]:
+                continue
+            xc = xcen[i]
+            yc = ycen[i]
+            rmax = max_radius[i]
 
-        # The bounding box of the maximum-radius circle, kept as
-        # integral doubles until it is clipped to avoid integer
-        # overflow for sources far outside the image
-        ixmin_d = floor(xc - rmax + 0.5)
-        ixmax_d = ceil(xc + rmax + 0.5)
-        iymin_d = floor(yc - rmax + 0.5)
-        iymax_d = ceil(yc + rmax + 0.5)
-        if (iymax_d - iymin_d) * (ixmax_d - ixmin_d) > max_aper_size:
-            args.append(None)
-            continue
+            # The bounding box of the maximum-radius circle, kept as
+            # integral doubles until it is clipped to avoid integer
+            # overflow for sources far outside the image
+            ixmin_d = floor(xc - rmax + 0.5)
+            ixmax_d = ceil(xc + rmax + 0.5)
+            iymin_d = floor(yc - rmax + 0.5)
+            iymax_d = ceil(yc + rmax + 0.5)
+            if (iymax_d - iymin_d) * (ixmax_d - ixmin_d) > max_aper_size:
+                continue
 
-        # Clip to the data
-        x0_d = ixmin_d if ixmin_d > 0.0 else 0.0
-        x1_d = ixmax_d if ixmax_d < nx_data else nx_data
-        y0_d = iymin_d if iymin_d > 0.0 else 0.0
-        y1_d = iymax_d if iymax_d < ny_data else ny_data
-        if y0_d >= y1_d or x0_d >= x1_d:
-            args.append(None)
-            continue
-        x0 = <Py_ssize_t>x0_d
-        x1 = <Py_ssize_t>x1_d
-        y0 = <Py_ssize_t>y0_d
-        y1 = <Py_ssize_t>y1_d
-        nx = x1 - x0
-        ny = y1 - y0
+            # Clip to the data
+            x0_d = ixmin_d if ixmin_d > 0.0 else 0.0
+            x1_d = ixmax_d if ixmax_d < nx_data else nx_data
+            y0_d = iymin_d if iymin_d > 0.0 else 0.0
+            y1_d = iymax_d if iymax_d < ny_data else ny_data
+            if y0_d >= y1_d or x0_d >= x1_d:
+                continue
 
-        # The cutout-frame centroid and the mirror center of the
-        # 'correct' method (truncation of the cutout centroid + 0.5
-        # replicates the Python int() call)
-        cutout_xcen = xc - <double>x0
-        cutout_ycen = yc - <double>y0
-        ccx = <Py_ssize_t>(cutout_xcen + 0.5) + x0
-        ccy = <Py_ssize_t>(cutout_ycen + 0.5) + y0
+            x0 = <Py_ssize_t>x0_d
+            x1 = <Py_ssize_t>x1_d
+            y0 = <Py_ssize_t>y0_d
+            y1 = <Py_ssize_t>y1_d
+            nx = x1 - x0
+            ny = y1 - y0
 
-        clean_data = np.empty((ny, nx))
-        cutout = clean_data
-        with nogil:
+            # The cutout-frame centroid and the mirror center of the
+            # 'correct' method (truncation of the cutout centroid + 0.5
+            # replicates the Python int() call)
+            cutout_xcen = xc - <double>x0
+            cutout_ycen = yc - <double>y0
+            bbox[i, 0] = x0
+            bbox[i, 1] = x1
+            bbox[i, 2] = y0
+            bbox[i, 3] = y1
+            bbox[i, 4] = <Py_ssize_t>(cutout_xcen + 0.5) + x0
+            bbox[i, 5] = <Py_ssize_t>(cutout_ycen + 0.5) + y0
+            nx_out[i] = nx
+            ny_out[i] = ny
+            counts[i] = nx * ny
+            grid_edges[i, 0] = -0.5 - cutout_xcen
+            grid_edges[i, 1] = (<double>nx - 0.5) - cutout_xcen
+            grid_edges[i, 2] = -0.5 - cutout_ycen
+            grid_edges[i, 3] = (<double>ny - 0.5) - cutout_ycen
+
+        for i in range(n_src):
+            starts[i] = total
+            total += counts[i]
+
+    values_arr = np.empty(total)
+    cdef double[::1] values = values_arr
+    with nogil:
+        for i in range(n_src):
+            if counts[i] == 0:
+                continue
             _flux_radius_cutout(&data[0, 0], &mask[0, 0], &segm[0, 0],
-                                nx_data, labels[i], x0, x1, y0, y1,
-                                ccx, ccy, local_bkg[i], seg_method,
-                                &cutout[0, 0])
+                                nx_data, labels[i], bbox[i, 0], bbox[i, 1],
+                                bbox[i, 2], bbox[i, 3], bbox[i, 4],
+                                bbox[i, 5], local_bkg[i], seg_method,
+                                &values[starts[i]])
 
-        grid_params = (-0.5 - cutout_xcen,
-                       (<double>nx - 0.5) - cutout_xcen,
-                       -0.5 - cutout_ycen,
-                       (<double>ny - 0.5) - cutout_ycen,
-                       nx, ny, use_exact, subpixels)
-        args.append([clean_data, grid_params, kronflux[i], rmax])
-    return args
+    return BatchFluxRadiusArgs(
+        values=values_arr, starts=starts_arr, counts=counts_arr,
+        nx=nx_arr, ny=ny_arr, grid_edges=grid_edges_arr,
+        kronflux=np.array(kronflux, dtype=np.float64),
+        max_radius=np.array(max_radius, dtype=np.float64),
+        use_exact=use_exact, subpixels=subpixels)
 
 
 ctypedef struct _FluxRadiusArgs:
@@ -1096,7 +1133,15 @@ cdef double _flux_radius_objective(double r,
     return 1.0 - flux / p.normflux
 
 
-def batch_flux_radius_solve(args_list, *, double fraction):
+def batch_flux_radius_solve(const double[::1] values, *,
+                            const Py_ssize_t[::1] starts,
+                            const Py_ssize_t[::1] counts,
+                            const Py_ssize_t[::1] nx,
+                            const Py_ssize_t[::1] ny,
+                            const double[:, ::1] grid_edges,
+                            const double[::1] kronflux,
+                            const double[::1] max_radius,
+                            double fraction, int use_exact, int subpixels):
     """
     Solve the fractional-flux radius for many prepared sources in one
     call.
@@ -1123,123 +1168,167 @@ def batch_flux_radius_solve(args_list, *, double fraction):
     retried, until either a root is found or the maximum radius drops
     to the minimum radius (0.1), in which case NaN is returned.
 
+    The source loop runs without the GIL, and the scratch buffers are
+    local to the call, so disjoint source ranges can be solved
+    concurrently.
+
     Parameters
     ----------
-    args_list : list
-        The prepared per-source arguments, as built by
-        ``SourceCatalog._flux_radius_optimizer_args``. Each entry is
-        either `None`, for a source that cannot have a solution (NaN
-        is returned), or the list ``[clean_data, grid_params,
-        kronflux, max_radius]``. ``clean_data`` is the C-contiguous
-        float64 source cutout with masked pixels zeroed,
-        ``grid_params`` is the tuple ``(xmin_e, xmax_e, ymin_e,
-        ymax_e, nx, ny, use_exact, subpixels)`` of
-        `~photutils.geometry.circular_overlap_grid` parameters whose
-        grid edges are relative to the source centroid, ``kronflux``
-        is the source Kron flux, and ``max_radius`` is the initial
-        upper bracket radius.
+    values : 1D ndarray of float64 (C-contiguous)
+        The packed cleaned cutout values of all sources, each in
+        row-major order (see ``batch_flux_radius_prepare``).
+
+    starts, counts : 1D ndarray of intp (C-contiguous)
+        The start offset of each source in ``values`` and its number
+        of cutout pixels, with shape ``(n_sources,)``. A source with a
+        zero count has no solution (NaN is returned).
+
+    nx, ny : 1D ndarray of intp (C-contiguous)
+        The cutout width and height of each source, with shape
+        ``(n_sources,)``.
+
+    grid_edges : 2D ndarray of float64 (C-contiguous)
+        The ``(n_sources, 4)`` cutout grid edges ``(xmin, xmax, ymin,
+        ymax)`` of `~photutils.geometry.circular_overlap_grid`,
+        relative to the source centroid.
+
+    kronflux : 1D ndarray of float64 (C-contiguous)
+        The Kron flux of each source, with shape ``(n_sources,)``.
+
+    max_radius : 1D ndarray of float64 (C-contiguous)
+        The initial upper bracket radius of each source, with shape
+        ``(n_sources,)``.
 
     fraction : float
         The fraction of the Kron flux at which to find the circular
         radius.
+
+    use_exact : int
+        Whether to compute exact overlap fractions (1) or use subpixel
+        sampling (0).
+
+    subpixels : int
+        The number of subpixels in each dimension when ``use_exact``
+        is 0.
 
     Returns
     -------
     radius : 1D `~numpy.ndarray`
         The circular radius enclosing the specified fraction of the
         Kron flux for each source, with shape ``(n_sources,)``. NaN is
-        returned for `None` entries and where no solution was found.
+        returned for sources with a zero count and where no solution
+        was found.
+
+    Raises
+    ------
+    ValueError
+        If a per-source array does not have the same length as
+        ``counts``.
     """
-    cdef Py_ssize_t n_src = len(args_list)
+    cdef Py_ssize_t n_src = counts.shape[0]
+    for name, length in (('starts', starts.shape[0]), ('nx', nx.shape[0]),
+                         ('ny', ny.shape[0]),
+                         ('grid_edges', grid_edges.shape[0]),
+                         ('kronflux', kronflux.shape[0]),
+                         ('max_radius', max_radius.shape[0])):
+        if length != n_src:
+            msg = f'{name} must have the same length as counts'
+            raise ValueError(msg)
+
     radius_arr = np.full(n_src, np.nan)
     cdef double[::1] radius = radius_arr
-    cdef const double[:, ::1] cdata
     cdef _FluxRadiusArgs p
     cdef zeros_full_output full_output
-    cdef double xmax_e, ymax_e, max_extent
-    cdef double max_radius, delta, result
+    cdef double xmin_e, xmax_e, ymin_e, ymax_e, max_extent
+    cdef double dx, dy, pixel_radius, bin_width, rmax, delta, result
     cdef bint found
-    cdef Py_ssize_t i, n_pix, n_bins, max_pix = 0, max_bins = 0
+    cdef Py_ssize_t i, n_bins, max_pix = 0, max_bins = 0
 
-    # Scratch buffers for the radial binning, sized for the largest
-    # cutout (local to this call, so the function is thread safe)
-    for entry in args_list:
-        if entry is None:
-            continue
-        n_pix = entry[1][4] * entry[1][5]
-        if n_pix > max_pix:
-            max_pix = n_pix
+    # Size the scratch buffers of the radial binning for the largest
+    # cutout and bin count (local to this call, so the function is
+    # thread safe). The bin count uses the same arithmetic as the
+    # source loop below.
+    with nogil:
+        for i in range(n_src):
+            if counts[i] == 0:
+                continue
+            if counts[i] > max_pix:
+                max_pix = counts[i]
+            xmin_e = grid_edges[i, 0]
+            xmax_e = grid_edges[i, 1]
+            ymin_e = grid_edges[i, 2]
+            ymax_e = grid_edges[i, 3]
+            dx = (xmax_e - xmin_e) / nx[i]
+            dy = (ymax_e - ymin_e) / ny[i]
+            pixel_radius = 0.5 * sqrt(dx * dx + dy * dy)
+            bin_width = 0.5 * pixel_radius
+            max_extent = sqrt(_dmax(xmin_e * xmin_e, xmax_e * xmax_e)
+                              + _dmax(ymin_e * ymin_e, ymax_e * ymax_e))
+            n_bins = <Py_ssize_t>(max_extent / bin_width) + 1
+            if n_bins > max_bins:
+                max_bins = n_bins
+
     order_arr = np.empty(max(max_pix, 1), dtype=np.intp)
     bin_of_arr = np.empty(max(max_pix, 1), dtype=np.intp)
+    bin_starts_arr = np.empty(max_bins + 1, dtype=np.intp)
+    bin_cumsum_arr = np.empty(max_bins + 1, dtype=np.float64)
+    work_arr = np.empty(max(max_bins, 1), dtype=np.intp)
     cdef Py_ssize_t[::1] order = order_arr
     cdef Py_ssize_t[::1] bin_of = bin_of_arr
-    bin_starts_arr = np.empty(1, dtype=np.intp)
-    bin_cumsum_arr = np.empty(1, dtype=np.float64)
-    work_arr = np.empty(1, dtype=np.intp)
     cdef Py_ssize_t[::1] bin_starts = bin_starts_arr
     cdef double[::1] bin_cumsum = bin_cumsum_arr
     cdef Py_ssize_t[::1] work = work_arr
 
-    for i, entry in enumerate(args_list):
-        if entry is None:
-            continue
-        clean_data, grid_params, kronflux, max_radius_py = entry
-        cdata = clean_data
-        p.data = &cdata[0, 0]
-        p.xmin_e = grid_params[0]
-        xmax_e = grid_params[1]
-        p.ymin_e = grid_params[2]
-        ymax_e = grid_params[3]
-        p.nx = grid_params[4]
-        p.ny = grid_params[5]
-        # The pixel size and pixel radius are derived from the grid
-        # extent exactly as in ``circular_overlap_grid``
-        p.dx = (xmax_e - p.xmin_e) / p.nx
-        p.dy = (ymax_e - p.ymin_e) / p.ny
-        p.pixel_radius = 0.5 * sqrt(p.dx * p.dx + p.dy * p.dy)
-        p.use_exact = grid_params[6]
-        p.subpixels = grid_params[7]
-        p.normflux = kronflux * fraction
-        max_radius = max_radius_py
+    p.use_exact = use_exact
+    p.subpixels = subpixels
+    with nogil:
+        for i in range(n_src):
+            if counts[i] == 0:
+                continue
+            p.data = &values[starts[i]]
+            p.xmin_e = grid_edges[i, 0]
+            xmax_e = grid_edges[i, 1]
+            p.ymin_e = grid_edges[i, 2]
+            ymax_e = grid_edges[i, 3]
+            p.nx = nx[i]
+            p.ny = ny[i]
 
-        # Radial bins of a quarter pixel diagonal out to the farthest
-        # cutout corner; the boundary band of a circle then spans the
-        # pixel diagonal plus two bins
-        p.bin_width = 0.5 * p.pixel_radius
-        max_extent = sqrt(max(p.xmin_e * p.xmin_e, xmax_e * xmax_e)
-                          + max(p.ymin_e * p.ymin_e, ymax_e * ymax_e))
-        n_bins = <Py_ssize_t>(max_extent / p.bin_width) + 1
-        p.n_bins = n_bins
-        if n_bins > max_bins:
-            max_bins = n_bins
-            bin_starts_arr = np.empty(max_bins + 1, dtype=np.intp)
-            bin_cumsum_arr = np.empty(max_bins + 1, dtype=np.float64)
-            work_arr = np.empty(max_bins, dtype=np.intp)
-            bin_starts = bin_starts_arr
-            bin_cumsum = bin_cumsum_arr
-            work = work_arr
+            # The pixel size and pixel radius are derived from the grid
+            # extent exactly as in ``circular_overlap_grid``
+            p.dx = (xmax_e - p.xmin_e) / p.nx
+            p.dy = (ymax_e - p.ymin_e) / p.ny
+            p.pixel_radius = 0.5 * sqrt(p.dx * p.dx + p.dy * p.dy)
+            p.normflux = kronflux[i] * fraction
+            rmax = max_radius[i]
 
-        with nogil:
+            # Radial bins of a quarter pixel diagonal out to the
+            # farthest cutout corner; the boundary band of a circle
+            # then spans the pixel diagonal plus two bins
+            p.bin_width = 0.5 * p.pixel_radius
+            max_extent = sqrt(_dmax(p.xmin_e * p.xmin_e, xmax_e * xmax_e)
+                              + _dmax(p.ymin_e * p.ymin_e,
+                                      ymax_e * ymax_e))
+            p.n_bins = <Py_ssize_t>(max_extent / p.bin_width) + 1
             _bin_flux_radius_pixels(&p, &order[0], &bin_of[0],
                                     &bin_starts[0], &bin_cumsum[0],
                                     &work[0])
+
             found = False
             result = NAN
-            delta = 0.1 * max_radius
-            while max_radius > 0.1 and not found:
+            delta = 0.1 * rmax
+            while rmax > 0.1 and not found:
                 # xtol, rtol (4 * float64 eps), and maxiter are the
                 # root_scalar(method='brentq') defaults, so the same
                 # underlying C algorithm follows the identical
                 # iteration sequence
-                result = brentq(_flux_radius_objective, 0.1,
-                                max_radius, &p, 2e-12,
-                                8.881784197001252e-16, 100,
+                result = brentq(_flux_radius_objective, 0.1, rmax, &p,
+                                2e-12, 8.881784197001252e-16, 100,
                                 &full_output)
                 if full_output.error_num == -1:
                     # Sign error (same-sign bracket): shrink and
                     # retry, matching the ValueError path of
                     # root_scalar
-                    max_radius -= delta
+                    rmax -= delta
                 else:
                     # Success or non-convergence: root_scalar does
                     # not raise on non-convergence, so accept the
@@ -1247,7 +1336,7 @@ def batch_flux_radius_solve(args_list, *, double fraction):
                     found = True
             if not found:
                 result = NAN
-        radius[i] = result
+            radius[i] = result
     return radius_arr
 
 

--- a/photutils/segmentation/_batch_results.py
+++ b/photutils/segmentation/_batch_results.py
@@ -1,0 +1,56 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Result containers of the batch segmentation Cython drivers.
+"""
+
+from typing import NamedTuple
+
+import numpy as np
+
+__all__ = []
+
+
+class BatchFluxRadiusArgs(NamedTuple):
+    """
+    The prepared per-source inputs of the flux-radius root-find, as
+    returned by ``batch_flux_radius_prepare`` and consumed by
+    ``batch_flux_radius_solve`` (see their docstrings).
+
+    The cleaned cutouts of all sources are packed into one buffer.
+    A source that cannot have a solution has a zero pixel count.
+    """
+
+    values: np.ndarray
+    """The packed cleaned, background-subtracted cutout values of all
+    sources, each in row-major order."""
+
+    starts: np.ndarray
+    """The start offset of each source in ``values``."""
+
+    counts: np.ndarray
+    """The number of cutout pixels of each source (zero for a source
+    without a solution)."""
+
+    nx: np.ndarray
+    """The cutout width of each source."""
+
+    ny: np.ndarray
+    """The cutout height of each source."""
+
+    grid_edges: np.ndarray
+    """The ``(n_sources, 4)`` grid edges ``(xmin, xmax, ymin, ymax)``
+    of each cutout, relative to the source centroid."""
+
+    kronflux: np.ndarray
+    """The Kron flux of each source."""
+
+    max_radius: np.ndarray
+    """The initial upper bracket radius of each source."""
+
+    use_exact: int
+    """Whether the root-find uses exact overlap fractions (1) or
+    subpixel sampling (0)."""
+
+    subpixels: int
+    """The number of subpixels in each dimension when ``use_exact`` is
+    0."""

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -7,6 +7,7 @@ segmentation image.
 import functools
 import inspect
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from functools import cached_property
 
@@ -29,6 +30,7 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_VALID, SHAPE_CIRCLE,
                                                   SHAPE_ELLIPSE,
                                                   batch_aperture_sums)
+from photutils.aperture._batch_results import BatchApertureSums
 from photutils.aperture._segmentation import SEG_METHOD_CODES
 from photutils.background import SExtractorBackground
 from photutils.segmentation._batch_catalog import (batch_central_moments,
@@ -150,6 +152,34 @@ class _SegmentValues:
         if transform is not None:
             packed = transform(packed)
         return ufunc.reduceat(packed, self.offsets[:-1])
+
+
+def _concatenate_aperture_sums(results):
+    """
+    Concatenate per-chunk ``batch_aperture_sums`` results along the
+    source axis.
+
+    Only the per-source fields are combined. The packed per-pixel
+    fields, which are empty unless the driver is called with
+    ``emit_sum``, are not merged and are returned as `None`.
+
+    Parameters
+    ----------
+    results : list of `~photutils.aperture._batch_results.BatchApertureSums`
+        The per-chunk driver results, in source order.
+
+    Returns
+    -------
+    result : `~photutils.aperture._batch_results.BatchApertureSums`
+        The combined per-source results.
+    """
+    fields = {name: np.concatenate([getattr(result, name)
+                                    for result in results])
+              for name in ('sums', 'sum_vars', 'areas', 'overlap',
+                           'flag_counts', 'weights_out')}
+    return BatchApertureSums(**fields, starts=None, sum_values=None,
+                             sum_fracs=None, sum_errsq=None,
+                             sum_counts=None)
 
 
 def _batch_gini(values):
@@ -450,6 +480,18 @@ class SourceCatalog:
         custom `kron_photometry`), and `flux_radius` (which is based on
         the Kron flux).
 
+    n_threads : int, optional
+        The number of threads to use to compute the Kron radii and
+        Kron photometry (`kron_radius`, `kron_flux`, `kron_flux_err`,
+        and `kron_photometry`), and thus the measurements that depend
+        on them (e.g., `flux_radius` and `centroid_win`). The default
+        is 1 (no multithreading). When ``n_threads`` > 1, the sources
+        are divided into chunks that are processed concurrently. The
+        per-source results are independent, so they are identical to
+        the single-threaded computation. The underlying kernels release
+        the Python global interpreter lock (GIL), so multithreading can
+        significantly speed up these measurements for many sources.
+
     progress_bar : bool, optional
         Whether to display a progress bar when calculating properties.
 
@@ -563,7 +605,7 @@ class SourceCatalog:
                  error=None, mask=None, background=None, wcs=None,
                  local_bkg_width=0, aperture_mask_method='correct',
                  kron_params=(2.5, 1.4, 0.0), detection_catalog=None,
-                 progress_bar=False):
+                 n_threads=1, progress_bar=False):
 
         inputs = (data, convolved_data, error, background)
         names = ('data', 'convolved_data', 'error', 'background')
@@ -586,6 +628,11 @@ class SourceCatalog:
             aperture_mask_method)
         self.kron_params = self._validate_kron_params(kron_params)
         self.progress_bar = progress_bar
+
+        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+            msg = 'n_threads must be a positive integer'
+            raise ValueError(msg)
+        self.n_threads = int(n_threads)
 
         # Needed for ordering and isscalar
         # NOTE: calculate slices before labels for performance.
@@ -812,7 +859,8 @@ class SourceCatalog:
         init_attr = ('_data', '_segmentation_image', '_error', '_mask',
                      '_background', 'wcs', '_data_unit', '_convolved_data',
                      'local_bkg_width', 'aperture_mask_method',
-                     'kron_params', 'progress_bar', '_batch_arrays_cache')
+                     'kron_params', 'n_threads', 'progress_bar',
+                     '_batch_arrays_cache')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
@@ -1067,6 +1115,61 @@ class SourceCatalog:
         """
         return tuple(np.ascontiguousarray(col)
                      for col in self._batch_bboxes.T)
+
+    def _threaded_batch(self, func, per_source, *, merge=np.concatenate,
+                        **fixed):
+        """
+        Call a per-source batch kernel over contiguous chunks of
+        sources, concurrently when ``n_threads`` > 1.
+
+        The kernel is called as ``func(**per_source, **fixed)``. When
+        ``n_threads`` > 1, the sources are divided into ``min(n_threads,
+        n_sources)`` contiguous ranges. Each worker receives the
+        corresponding row slices of the ``per_source`` arrays (row
+        slices of C-contiguous arrays are themselves C-contiguous) and
+        the ``fixed`` arguments (e.g., the full-image arrays and scalar
+        options) unchanged, so the kernels run concurrently on disjoint
+        sources. The per-chunk outputs are combined with ``merge``, so
+        the result is identical to the single-chunk call.
+
+        Parameters
+        ----------
+        func : callable
+            The batch kernel. It must release the GIL.
+
+        per_source : dict
+            The per-source arrays (one row per source), keyed by the
+            kernel keyword name. A `None` value is passed unchanged.
+
+        merge : callable, optional
+            The function that combines the list of per-chunk outputs.
+            The default concatenates arrays along the source axis.
+
+        **fixed
+            The remaining kernel keyword arguments, passed unchanged to
+            every chunk.
+
+        Returns
+        -------
+        result : object
+            The (merged) kernel output.
+        """
+        n_src = next(len(arr) for arr in per_source.values()
+                     if arr is not None)
+        n_chunks = min(self.n_threads, n_src)
+        if n_chunks <= 1:  # 0 for no sources
+            return func(**per_source, **fixed)
+
+        edges = np.arange(n_chunks + 1) * n_src // n_chunks
+
+        def run_chunk(i0, i1):
+            chunk = {key: None if arr is None else arr[i0:i1]
+                     for key, arr in per_source.items()}
+            return func(**chunk, **fixed)
+
+        with ThreadPoolExecutor(max_workers=n_chunks) as executor:
+            results = list(executor.map(run_chunk, edges[:-1], edges[1:]))
+        return merge(results)
 
     @cached_property
     def isscalar(self):
@@ -4406,12 +4509,13 @@ class SourceCatalog:
                            if len(self.kron_params) == 3 else 0.0)
 
         arrays = self._get_batch_arrays()
-        sums = batch_kron_radius(
-            arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
-            labels=self._batch_labels(),
-            xcen=xcen, ycen=ycen, semimajor=semimajor,
-            semiminor=semiminor, theta=theta, cxx=cxx, cxy=cxy, cyy=cyy,
-            skip=skip,
+        sums = self._threaded_batch(
+            batch_kron_radius,
+            {'labels': self._batch_labels(), 'xcen': xcen, 'ycen': ycen,
+             'semimajor': semimajor, 'semiminor': semiminor,
+             'theta': theta, 'cxx': cxx, 'cxy': cxy, 'cyy': cyy,
+             'skip': skip},
+            data=arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
             seg_method=SEG_METHOD_CODES[self.aperture_mask_method],
             scale=scale, min_circ_radius=min_circ_radius,
             max_aper_size=max(self._data.size, 1_000_000))
@@ -4927,11 +5031,16 @@ class SourceCatalog:
             psrc = np.ascontiguousarray(psrc, dtype=np.float64)
             pos = np.ascontiguousarray(positions[idx])
             seg_labels = labels_arr[idx] if seg_code != 0 else None
-            result = batch_aperture_sums(
-                arrays['data'], arrays['error'], arrays['mask'], pos,
-                shape_code, None, 0.0, 0.0, 0.0, 0.0, 1, 1, seg_arr,
-                seg_labels, seg_code, local_bkg[idx], 0,
-                params_per_source=psrc)
+            result = self._threaded_batch(
+                batch_aperture_sums,
+                {'positions': pos, 'labels': seg_labels,
+                 'local_bkg': local_bkg[idx], 'params_per_source': psrc},
+                merge=_concatenate_aperture_sums,
+                data=arrays['data'], error=arrays['error'],
+                mask=arrays['mask'], shape_code=shape_code, params=None,
+                ext_x=0.0, ext_y=0.0, off_x=0.0, off_y=0.0, use_exact=1,
+                subpixels=1, segmentation=seg_arr, seg_method=seg_code,
+                emit_sum=0)
             sums = result.sums
             sum_vars = result.sum_vars
             overlap = result.overlap

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -715,7 +715,9 @@ class SourceCatalog:
         self.kron_params = self._validate_kron_params(kron_params)
         self.progress_bar = progress_bar
 
-        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+        if (isinstance(n_threads, bool)
+                or not isinstance(n_threads, (int, np.integer))
+                or n_threads < 1):
             msg = 'n_threads must be a positive integer'
             raise ValueError(msg)
         self.n_threads = int(n_threads)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -678,6 +678,11 @@ class SourceCatalog:
     .. _SourceExtractor: https://sextractor.readthedocs.io/en/latest/
     """
 
+    # Cached properties whose values are packed across sources and thus
+    # cannot be sliced per source. __getitem__ drops them from the
+    # sliced catalog, which recomputes them on demand.
+    _recompute_on_slice = ('_flux_radius_optimizer_args',)
+
     @deprecated_renamed_argument('segment_img', 'segmentation_image', '3.0',
                                  until='4.0')
     @deprecated_renamed_argument('localbkg_width', 'local_bkg_width',
@@ -994,10 +999,9 @@ class SourceCatalog:
         keys = (set(self.__dict__.keys())
                 & (set(self._cached_properties)
                    | set(self._custom_properties)))
-        # The packed flux-radius inputs cannot be sliced per source.
-        # The sliced catalog recomputes them on demand (its flux_radius
-        # cache is sliced above).
-        keys.discard('_flux_radius_optimizer_args')
+        # The packed caches are recomputed by the sliced catalog on
+        # demand (its flux_radius cache is sliced above).
+        keys.difference_update(self._recompute_on_slice)
         for key in keys:
             value = self.__dict__[key]
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -174,13 +174,12 @@ def _concatenate_aperture_sums(results):
     result : `~photutils.aperture._batch_results.BatchApertureSums`
         The combined per-source results.
     """
+    packed = ('starts', 'sum_values', 'sum_fracs', 'sum_errsq',
+              'sum_counts')
     fields = {name: np.concatenate([getattr(result, name)
                                     for result in results])
-              for name in ('sums', 'sum_vars', 'areas', 'overlap',
-                           'flag_counts', 'weights_out')}
-    return BatchApertureSums(**fields, starts=None, sum_values=None,
-                             sum_fracs=None, sum_errsq=None,
-                             sum_counts=None)
+              for name in BatchApertureSums._fields if name not in packed}
+    return BatchApertureSums(**fields, **dict.fromkeys(packed))
 
 
 def _concatenate_arrays(results):
@@ -256,14 +255,15 @@ def _concatenate_flux_radius_args(results):
     """
     offsets = np.cumsum([0] + [len(result.values) for result in results])
     starts = np.concatenate([result.starts + offset for result, offset
-                             in zip(results, offsets, strict=False)])
+                             in zip(results, offsets[:-1], strict=True)])
+    scalars = ('use_exact', 'subpixels')
     fields = {name: np.concatenate([getattr(result, name)
                                     for result in results])
-              for name in ('values', 'counts', 'nx', 'ny', 'grid_edges',
-                           'kronflux', 'max_radius')}
+              for name in BatchFluxRadiusArgs._fields
+              if name not in ('starts', *scalars)}
     return BatchFluxRadiusArgs(**fields, starts=starts,
-                               use_exact=results[0].use_exact,
-                               subpixels=results[0].subpixels)
+                               **{name: getattr(results[0], name)
+                                  for name in scalars})
 
 
 def _batch_gini(values):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -183,6 +183,59 @@ def _concatenate_aperture_sums(results):
                              sum_counts=None)
 
 
+def _concatenate_arrays(results):
+    """
+    Concatenate per-chunk tuples of per-source arrays, element by
+    element, along the source axis.
+
+    Parameters
+    ----------
+    results : list of tuple of `~numpy.ndarray`
+        The per-chunk kernel outputs, in source order.
+
+    Returns
+    -------
+    result : tuple of `~numpy.ndarray`
+        The combined per-source arrays.
+    """
+    return tuple(np.concatenate(parts)
+                 for parts in zip(*results, strict=True))
+
+
+def _concatenate_segment_gathers(results):
+    """
+    Concatenate per-chunk ``batch_segment_gather`` results along the
+    source axis.
+
+    The packed buffers are concatenated and the per-source offsets
+    (which have one more entry than the sources of a chunk) are
+    rebased to the combined buffer.
+
+    Parameters
+    ----------
+    results : list of tuple
+        The per-chunk ``(packed, offsets, counts)`` outputs, in
+        source order.
+
+    Returns
+    -------
+    packed, offsets, counts : tuple of `~numpy.ndarray`
+        The combined outputs.
+    """
+    packed = np.concatenate([result[0] for result in results])
+    counts = np.concatenate([result[2] for result in results])
+    offsets = np.empty(len(counts) + 1, dtype=np.intp)
+    start = 0
+    total = 0
+    for _packed, chunk_offsets, chunk_counts in results:
+        n_chunk = len(chunk_counts)
+        offsets[start:start + n_chunk] = chunk_offsets[:-1] + total
+        start += n_chunk
+        total += chunk_offsets[-1]
+    offsets[-1] = total
+    return packed, offsets, counts
+
+
 def _concatenate_flux_radius_args(results):
     """
     Concatenate per-chunk ``batch_flux_radius_prepare`` results along
@@ -512,13 +565,15 @@ class SourceCatalog:
         the Kron flux).
 
     n_threads : int, optional
-        The number of threads to use to compute the Kron radii, Kron
-        photometry, and flux radii (`kron_radius`, `kron_flux`,
-        `kron_flux_err`, `kron_photometry`, and `flux_radius`), and thus
-        the measurements that depend on them (e.g., `centroid_win`). The
-        default is 1 (no multithreading). When ``n_threads`` > 1, the
-        sources are divided into chunks that are processed concurrently.
-        The per-source results are independent, so they are identical to
+        The number of threads to use for the compiled per-source
+        measurements: the isophotal moments and their errors, the
+        segment pixel statistics (e.g., `segment_flux`), the windowed
+        and quadratic centroids, `perimeter`, the Kron radii and
+        photometry, `circular_photometry`, and `flux_radius`, and
+        thus every property derived from them. The default is 1 (no
+        multithreading). When ``n_threads`` > 1, the sources are
+        divided into chunks that are processed concurrently. The
+        per-source results are independent, so they are identical to
         the single-threaded computation. The underlying kernels release
         the Python global interpreter lock (GIL), so multithreading can
         significantly speed up these measurements for many sources.
@@ -1022,13 +1077,11 @@ class SourceCatalog:
         length-1 sequence, otherwise return ``value`` unchanged.
 
         This is the method-call analog of the scalar collapse performed
-        for attribute access by `__getattribute__`.
+        for attribute access by `__getattribute__`. Every caller passes
+        a sequence with one entry per source.
         """
-        try:
-            if self.isscalar and len(value) == 1:
-                return value[0]
-        except TypeError:  # value has no len
-            pass
+        if self.isscalar and len(value) == 1:
+            return value[0]
         return value
 
     def _array(self, name):
@@ -1150,6 +1203,17 @@ class SourceCatalog:
         """
         return tuple(np.ascontiguousarray(col)
                      for col in self._batch_bboxes.T)
+
+    def _batch_bbox_args(self):
+        """
+        The per-source labels and segment bounding boxes as the
+        ``per_source`` dict of `_threaded_batch` for the kernels that
+        walk each source's bounding box.
+        """
+        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
+        return {'labels': self._batch_labels(), 'bbox_iymin': iymin,
+                'bbox_iymax': iymax, 'bbox_ixmin': ixmin,
+                'bbox_ixmax': ixmax}
 
     def _threaded_batch(self, func, per_source, *, packed=None,
                         merge=np.concatenate, **fixed):
@@ -1869,13 +1933,12 @@ class SourceCatalog:
 
         # Gather the pixel flags of every segment pixel (the all-zero
         # mask excludes nothing) and reduce them per source
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
-        packed, offsets, counts = batch_segment_gather(
-            pixel_flags.astype(np.float64),
+        packed, offsets, counts = self._threaded_batch(
+            batch_segment_gather, self._batch_bbox_args(),
+            merge=_concatenate_segment_gathers,
+            values=pixel_flags.astype(np.float64),
             mask=np.zeros(pixel_flags.shape, dtype=np.uint8),
-            segm=arrays['segm'], labels=self._batch_labels(),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax)
+            segm=arrays['segm'])
 
         # A source without segment pixels holds a single NaN
         # placeholder, whose integer cast is undefined
@@ -2071,12 +2134,10 @@ class SourceCatalog:
             The number of unmasked segment pixels of each source.
         """
         arrays = self._get_batch_arrays()
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
-        return batch_segment_gather(
-            array, mask=arrays['mask'], segm=arrays['segm'],
-            labels=self._batch_labels(),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax)
+        return self._threaded_batch(
+            batch_segment_gather, self._batch_bbox_args(),
+            merge=_concatenate_segment_gathers,
+            values=array, mask=arrays['mask'], segm=arrays['segm'])
 
     def _segment_values(self, array):
         """
@@ -2140,13 +2201,10 @@ class SourceCatalog:
         Spatial moments up to 3rd order of the source.
         """
         arrays = self._get_batch_arrays()
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
-        return batch_raw_moments(
-            self._get_batch_convdata(), mask=arrays['mask'],
-            segm=arrays['segm'],
-            labels=self._batch_labels(),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax)
+        return self._threaded_batch(
+            batch_raw_moments, self._batch_bbox_args(),
+            convdata=self._get_batch_convdata(), mask=arrays['mask'],
+            segm=arrays['segm'])
 
     @cached_property
     @use_detcat
@@ -2156,16 +2214,14 @@ class SourceCatalog:
         order.
         """
         arrays = self._get_batch_arrays()
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         cutout_centroid = self._array('cutout_centroid')
-        return batch_central_moments(
-            self._get_batch_convdata(), mask=arrays['mask'],
-            segm=arrays['segm'],
-            labels=self._batch_labels(),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax,
-            xcen=np.ascontiguousarray(cutout_centroid[:, 0]),
-            ycen=np.ascontiguousarray(cutout_centroid[:, 1]))
+        per_source = self._batch_bbox_args()
+        per_source['xcen'] = np.ascontiguousarray(cutout_centroid[:, 0])
+        per_source['ycen'] = np.ascontiguousarray(cutout_centroid[:, 1])
+        return self._threaded_batch(
+            batch_central_moments, per_source,
+            convdata=self._get_batch_convdata(), mask=arrays['mask'],
+            segm=arrays['segm'])
 
     @cached_property
     @use_detcat
@@ -2238,8 +2294,10 @@ class SourceCatalog:
             return np.full((self.n_labels, 2, 2), np.nan)
 
         arrays = self._get_batch_arrays()
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
         cutout_centroid = self._array('cutout_centroid')
+        per_source = self._batch_bbox_args()
+        per_source['xcen'] = np.ascontiguousarray(cutout_centroid[:, 0])
+        per_source['ycen'] = np.ascontiguousarray(cutout_centroid[:, 1])
 
         # The accumulators are the summed pixel variance and its
         # dx**2, dy**2, and dx*dy weighted sums. The variance is zeroed
@@ -2247,14 +2305,10 @@ class SourceCatalog:
         # moment data (e.g., non-finite or negative convolved values),
         # so that pixels that do not contribute flux weight also do not
         # contribute error variance.
-        acc = batch_moment_err(
-            arrays['error'], convdata=self._get_batch_convdata(),
-            mask=arrays['mask'], segm=arrays['segm'],
-            labels=self._batch_labels(),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax,
-            xcen=np.ascontiguousarray(cutout_centroid[:, 0]),
-            ycen=np.ascontiguousarray(cutout_centroid[:, 1]))
+        acc = self._threaded_batch(
+            batch_moment_err, per_source,
+            error=arrays['error'], convdata=self._get_batch_convdata(),
+            mask=arrays['mask'], segm=arrays['segm'])
 
         # The total flux is the zeroth raw moment of the moment data.
         total_flux = self._array('moments')[:, 0, 0]
@@ -2601,12 +2655,12 @@ class SourceCatalog:
         skip = (nan_hl | ~np.isfinite(x_centroid)
                 | ~np.isfinite(y_centroid)).astype(np.uint8)
         arrays = self._get_batch_arrays()
-        results = batch_centroid_win(
-            arrays['data'], error=arrays['error'],
+        results = self._threaded_batch(
+            batch_centroid_win,
+            {'labels': self._batch_labels(), 'xcen0': x_centroid,
+             'ycen0': y_centroid, 'sigma': sigma, 'skip': skip},
+            data=arrays['data'], error=arrays['error'],
             mask=arrays['mask'], segm=arrays['segm'],
-            labels=self._batch_labels(),
-            xcen0=x_centroid, ycen0=y_centroid, sigma=sigma,
-            skip=skip,
             seg_method=SEG_METHOD_CODES[self.aperture_mask_method],
             compute_err=int(compute_err),
             max_aper_size=max(self._data.size, 1_000_000))
@@ -2809,12 +2863,12 @@ class SourceCatalog:
         # (zero-filled) cutout.
         arrays = self._get_batch_arrays()
         iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
-        status, peak, boxes, box_var = batch_quad_boxes(
-            arrays['data'], error=arrays['error'], mask=arrays['mask'],
-            segm=arrays['segm'],
-            labels=self._batch_labels(),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax, compute_err=int(compute_err))
+        status, peak, boxes, box_var = self._threaded_batch(
+            batch_quad_boxes, self._batch_bbox_args(),
+            merge=_concatenate_arrays,
+            data=arrays['data'], error=arrays['error'],
+            mask=arrays['mask'], segm=arrays['segm'],
+            compute_err=int(compute_err))
         nx = ixmax - ixmin
         ny = iymax - iymin
         n_src = len(status)
@@ -3462,11 +3516,10 @@ class SourceCatalog:
         completely masked source (see ``batch_minmax_index``).
         """
         arrays = self._get_batch_arrays()
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
-        return batch_minmax_index(
-            arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
-            labels=self._batch_labels(), bbox_iymin=iymin,
-            bbox_iymax=iymax, bbox_ixmin=ixmin, bbox_ixmax=ixmax)
+        return self._threaded_batch(
+            batch_minmax_index, self._batch_bbox_args(),
+            values=arrays['data'], mask=arrays['mask'],
+            segm=arrays['segm'])
 
     def _extreme_value_index(self, columns, *, origin):
         """
@@ -3783,12 +3836,9 @@ class SourceCatalog:
         # einsum so the per-source arithmetic is independent of the
         # number of sources.
         arrays = self._get_batch_arrays()
-        iymin, iymax, ixmin, ixmax = self._get_batch_bboxes()
-        hist = batch_perimeter(
-            arrays['mask'], segm=arrays['segm'],
-            labels=self._batch_labels(),
-            bbox_iymin=iymin, bbox_iymax=iymax, bbox_ixmin=ixmin,
-            bbox_ixmax=ixmax)
+        hist = self._threaded_batch(
+            batch_perimeter, self._batch_bbox_args(),
+            mask=arrays['mask'], segm=arrays['segm'])
         perimeter = np.einsum('nk,k->n', hist.astype(float), weights)
         perimeter[self._all_masked] = np.nan
         return np.array(perimeter) * u.pix
@@ -4925,11 +4975,17 @@ class SourceCatalog:
         use_exact, subpixels = self._overlap_params(
             self._aperture_mask_kwargs['circ'])
 
-        result = batch_aperture_sums(
-            arrays['data'], arrays['error'], arrays['mask'], positions,
-            SHAPE_CIRCLE, np.array([radius], dtype=np.float64), radius,
-            radius, 0.0, 0.0, use_exact, subpixels, seg_arr, seg_labels,
-            seg_code, local_bkg, 0)
+        result = self._threaded_batch(
+            batch_aperture_sums,
+            {'positions': positions, 'labels': seg_labels,
+             'local_bkg': local_bkg},
+            merge=_concatenate_aperture_sums,
+            data=arrays['data'], error=arrays['error'],
+            mask=arrays['mask'], shape_code=SHAPE_CIRCLE,
+            params=np.array([radius], dtype=np.float64), ext_x=radius,
+            ext_y=radius, off_x=0.0, off_y=0.0, use_exact=use_exact,
+            subpixels=subpixels, segmentation=seg_arr,
+            seg_method=seg_code, emit_sum=0)
         sums = result.sums
         sum_vars = result.sum_vars
         overlap = result.overlap

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -44,6 +44,7 @@ from photutils.segmentation._batch_catalog import (batch_central_moments,
                                                    batch_quad_boxes,
                                                    batch_raw_moments,
                                                    batch_segment_gather)
+from photutils.segmentation._batch_results import BatchFluxRadiusArgs
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
                                           decode_segmentation_flags)
@@ -180,6 +181,36 @@ def _concatenate_aperture_sums(results):
     return BatchApertureSums(**fields, starts=None, sum_values=None,
                              sum_fracs=None, sum_errsq=None,
                              sum_counts=None)
+
+
+def _concatenate_flux_radius_args(results):
+    """
+    Concatenate per-chunk ``batch_flux_radius_prepare`` results along
+    the source axis.
+
+    The packed ``values`` buffers are concatenated and the per-source
+    ``starts`` are rebased to the combined buffer.
+
+    Parameters
+    ----------
+    results : list of `BatchFluxRadiusArgs`
+        The per-chunk driver results, in source order.
+
+    Returns
+    -------
+    result : `~photutils.segmentation._batch_results.BatchFluxRadiusArgs`
+        The combined per-source inputs.
+    """
+    offsets = np.cumsum([0] + [len(result.values) for result in results])
+    starts = np.concatenate([result.starts + offset for result, offset
+                             in zip(results, offsets, strict=False)])
+    fields = {name: np.concatenate([getattr(result, name)
+                                    for result in results])
+              for name in ('values', 'counts', 'nx', 'ny', 'grid_edges',
+                           'kronflux', 'max_radius')}
+    return BatchFluxRadiusArgs(**fields, starts=starts,
+                               use_exact=results[0].use_exact,
+                               subpixels=results[0].subpixels)
 
 
 def _batch_gini(values):
@@ -481,13 +512,13 @@ class SourceCatalog:
         the Kron flux).
 
     n_threads : int, optional
-        The number of threads to use to compute the Kron radii and
-        Kron photometry (`kron_radius`, `kron_flux`, `kron_flux_err`,
-        and `kron_photometry`), and thus the measurements that depend
-        on them (e.g., `flux_radius` and `centroid_win`). The default
-        is 1 (no multithreading). When ``n_threads`` > 1, the sources
-        are divided into chunks that are processed concurrently. The
-        per-source results are independent, so they are identical to
+        The number of threads to use to compute the Kron radii, Kron
+        photometry, and flux radii (`kron_radius`, `kron_flux`,
+        `kron_flux_err`, `kron_photometry`, and `flux_radius`), and thus
+        the measurements that depend on them (e.g., `centroid_win`). The
+        default is 1 (no multithreading). When ``n_threads`` > 1, the
+        sources are divided into chunks that are processed concurrently.
+        The per-source results are independent, so they are identical to
         the single-threaded computation. The underlying kernels release
         the Python global interpreter lock (GIL), so multithreading can
         significantly speed up these measurements for many sources.
@@ -906,6 +937,10 @@ class SourceCatalog:
         keys = (set(self.__dict__.keys())
                 & (set(self._cached_properties)
                    | set(self._custom_properties)))
+        # The packed flux-radius inputs cannot be sliced per source.
+        # The sliced catalog recomputes them on demand (its flux_radius
+        # cache is sliced above).
+        keys.discard('_flux_radius_optimizer_args')
         for key in keys:
             value = self.__dict__[key]
 
@@ -1116,21 +1151,23 @@ class SourceCatalog:
         return tuple(np.ascontiguousarray(col)
                      for col in self._batch_bboxes.T)
 
-    def _threaded_batch(self, func, per_source, *, merge=np.concatenate,
-                        **fixed):
+    def _threaded_batch(self, func, per_source, *, packed=None,
+                        merge=np.concatenate, **fixed):
         """
         Call a per-source batch kernel over contiguous chunks of
         sources, concurrently when ``n_threads`` > 1.
 
-        The kernel is called as ``func(**per_source, **fixed)``. When
-        ``n_threads`` > 1, the sources are divided into ``min(n_threads,
-        n_sources)`` contiguous ranges. Each worker receives the
-        corresponding row slices of the ``per_source`` arrays (row
-        slices of C-contiguous arrays are themselves C-contiguous) and
-        the ``fixed`` arguments (e.g., the full-image arrays and scalar
-        options) unchanged, so the kernels run concurrently on disjoint
-        sources. The per-chunk outputs are combined with ``merge``, so
-        the result is identical to the single-chunk call.
+        The kernel is called as ``func(**per_source, **packed,
+        **fixed)``. When ``n_threads`` > 1, the sources are divided into
+        ``min(n_threads, n_sources)`` contiguous ranges. Each worker
+        receives the corresponding row slices of the ``per_source``
+        arrays (row slices of C-contiguous arrays are themselves
+        C-contiguous), the corresponding regions of the ``packed``
+        buffers, and the ``fixed`` arguments (e.g., the full-image
+        arrays and scalar options) unchanged, so the kernels run
+        concurrently on disjoint sources. The per-chunk outputs are
+        combined with ``merge``, so the result is identical to the
+        single-chunk call.
 
         Parameters
         ----------
@@ -1140,6 +1177,13 @@ class SourceCatalog:
         per_source : dict
             The per-source arrays (one row per source), keyed by the
             kernel keyword name. A `None` value is passed unchanged.
+
+        packed : dict, optional
+            Packed per-pixel buffers, keyed by the kernel keyword name.
+            Each source occupies the region given by the ``'starts'``
+            and ``'counts'`` entries of ``per_source``, which must then
+            be present. The chunk ``starts`` are rebased to the chunk
+            buffer region.
 
         merge : callable, optional
             The function that combines the list of per-chunk outputs.
@@ -1154,17 +1198,31 @@ class SourceCatalog:
         result : object
             The (merged) kernel output.
         """
+        packed = {} if packed is None else packed
         n_src = next(len(arr) for arr in per_source.values()
                      if arr is not None)
         n_chunks = min(self.n_threads, n_src)
         if n_chunks <= 1:  # 0 for no sources
-            return func(**per_source, **fixed)
+            return func(**per_source, **packed, **fixed)
 
         edges = np.arange(n_chunks + 1) * n_src // n_chunks
+        if packed:
+            starts = per_source['starts']
+            counts = per_source['counts']
+            buffer_ends = starts + counts
 
         def run_chunk(i0, i1):
             chunk = {key: None if arr is None else arr[i0:i1]
                      for key, arr in per_source.items()}
+            if packed:
+                # The chunk region spans from the first source start to
+                # the last source end (a skipped source may have a zero
+                # count).
+                buf0 = starts[i0]
+                buf1 = buffer_ends[i0:i1].max(initial=buf0)
+                chunk['starts'] = chunk['starts'] - buf0
+                chunk.update({key: buffer[buf0:buf1]
+                              for key, buffer in packed.items()})
             return func(**chunk, **fixed)
 
         with ThreadPoolExecutor(max_workers=n_chunks) as executor:
@@ -5232,16 +5290,17 @@ class SourceCatalog:
     @use_detcat
     def _flux_radius_optimizer_args(self):
         """
-        The prepared per-source arguments of the flux-radius root-find
-        (see ``batch_flux_radius_prepare``), always as a list with one
-        entry per source.
+        The prepared per-source inputs of the flux-radius
+        root-find (see ``batch_flux_radius_prepare``), as a
+        `~photutils.segmentation._batch_results.BatchFluxRadiusArgs`
+        with one entry per source.
 
-        Each entry is `None` for a source that cannot have a solution
-        or the list ``[clean_data, grid_params, kronflux,
-        max_radius]``. This cached property snapshots the current
+        A source that cannot have a solution has a zero pixel count.
+        This cached property snapshots the current
         ``_aperture_mask_kwargs['flux_radius']`` settings. Changing
         them (e.g., via ``_set_semode``) after the first flux_radius
-        call has no effect.
+        call has no effect. The preparation is multithreaded when
+        ``n_threads`` > 1.
         """
         kron_flux = np.ascontiguousarray(self._kron_photometry[:, 0],
                                          dtype=np.float64)  # unitless
@@ -5263,11 +5322,14 @@ class SourceCatalog:
                 | (kron_flux == 0)).astype(np.uint8)
 
         arrays = self._get_batch_arrays()
-        return batch_flux_radius_prepare(
-            arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
-            labels=self._batch_labels(),
-            xcen=x_centroid, ycen=y_centroid, local_bkg=local_bkg,
-            kronflux=kron_flux, max_radius=max_radius, skip=skip,
+        return self._threaded_batch(
+            batch_flux_radius_prepare,
+            {'labels': self._batch_labels(), 'xcen': x_centroid,
+             'ycen': y_centroid, 'local_bkg': local_bkg,
+             'kronflux': kron_flux, 'max_radius': max_radius,
+             'skip': skip},
+            merge=_concatenate_flux_radius_args,
+            data=arrays['data'], mask=arrays['mask'], segm=arrays['segm'],
             seg_method=SEG_METHOD_CODES[self.aperture_mask_method],
             use_exact=use_exact, subpixels=subpixels,
             max_aper_size=max(self._data.size, 1_000_000))
@@ -5314,7 +5376,14 @@ class SourceCatalog:
             return self._make_scalar(result)
 
         args = self._flux_radius_optimizer_args
-        radius = batch_flux_radius_solve(args, fraction=fraction)
+        radius = self._threaded_batch(
+            batch_flux_radius_solve,
+            {'starts': args.starts, 'counts': args.counts, 'nx': args.nx,
+             'ny': args.ny, 'grid_edges': args.grid_edges,
+             'kronflux': args.kronflux, 'max_radius': args.max_radius},
+            packed={'values': args.values},
+            fraction=fraction, use_exact=args.use_exact,
+            subpixels=args.subpixels)
         result = radius << u.pix
         self._flux_radius_cache[fraction] = result
 

--- a/photutils/segmentation/tests/test_batch_flux_radius.py
+++ b/photutils/segmentation/tests/test_batch_flux_radius.py
@@ -278,6 +278,34 @@ def test_solve_length_guard(scene):
             fraction=0.5, use_exact=1, subpixels=1)
 
 
+def test_solve_grid_edges_guard(scene):
+    cat = make_catalog(scene)
+    args = cat._flux_radius_optimizer_args
+    grid_edges = np.ascontiguousarray(args.grid_edges[:, :3])
+    with pytest.raises(ValueError, match='grid_edges must have 4 columns'):
+        _solve(args._replace(grid_edges=grid_edges), 0.5)
+
+
+def test_solve_buffer_guard(scene):
+    """
+    Test that a region that runs past the end of the packed buffer, a
+    negative start, and a negative count are each rejected
+    """
+    cat = make_catalog(scene)
+    args = cat._flux_radius_optimizer_args
+    match = 'must lie within the values buffer'
+    with pytest.raises(ValueError, match=match):
+        _solve(args._replace(values=args.values[:-1]), 0.5)
+    starts = args.starts.copy()
+    starts[0] = -1
+    with pytest.raises(ValueError, match=match):
+        _solve(args._replace(starts=starts), 0.5)
+    counts = args.counts.copy()
+    counts[0] = -1
+    with pytest.raises(ValueError, match=match):
+        _solve(args._replace(counts=counts), 0.5)
+
+
 def test_all_skipped(scene):
     cat = make_catalog(scene)
     n_src = cat.n_labels

--- a/photutils/segmentation/tests/test_batch_flux_radius.py
+++ b/photutils/segmentation/tests/test_batch_flux_radius.py
@@ -16,6 +16,7 @@ from photutils.geometry import circular_overlap_grid
 from photutils.segmentation import SourceCatalog
 from photutils.segmentation._batch_catalog import (batch_flux_radius_prepare,
                                                    batch_flux_radius_solve)
+from photutils.segmentation._batch_results import BatchFluxRadiusArgs
 from photutils.segmentation.tests._batch_scene import (make_batch_scene,
                                                        make_catalog)
 from photutils.segmentation.utils import _mask_to_mirrored_value
@@ -125,9 +126,72 @@ def _reference_optimizer_args(cat):
     return args
 
 
+def _unpack_args(args):
+    """
+    Convert packed ``BatchFluxRadiusArgs`` to the per-source list of
+    ``[clean_data, grid_params, kronflux, max_radius]`` entries (or
+    `None`) of the reference implementation.
+    """
+    entries = []
+    for i, count in enumerate(args.counts):
+        if count == 0:
+            entries.append(None)
+            continue
+        nx = int(args.nx[i])
+        ny = int(args.ny[i])
+        start = args.starts[i]
+        clean_data = args.values[start:start + count].reshape(ny, nx)
+        grid_params = (*(float(edge) for edge in args.grid_edges[i]),
+                       nx, ny, args.use_exact, args.subpixels)
+        entries.append([clean_data, grid_params, float(args.kronflux[i]),
+                        float(args.max_radius[i])])
+    return entries
+
+
+def _pack_entries(entries, *, use_exact=1, subpixels=1):
+    """
+    Pack per-source reference entries (or `None`) into
+    ``BatchFluxRadiusArgs``.
+    """
+    n_src = len(entries)
+    counts = np.zeros(n_src, dtype=np.intp)
+    nx = np.zeros(n_src, dtype=np.intp)
+    ny = np.zeros(n_src, dtype=np.intp)
+    grid_edges = np.zeros((n_src, 4))
+    kronflux = np.zeros(n_src)
+    max_radius = np.zeros(n_src)
+    values = []
+    for i, entry in enumerate(entries):
+        if entry is None:
+            continue
+        clean_data, grid_params, kronflux[i], max_radius[i] = entry
+        counts[i] = clean_data.size
+        ny[i], nx[i] = clean_data.shape
+        grid_edges[i] = grid_params[:4]
+        values.append(clean_data.ravel())
+    starts = np.concatenate(([0], np.cumsum(counts)[:-1])).astype(np.intp)
+    values = (np.concatenate(values) if values
+              else np.zeros(0, dtype=np.float64))
+    return BatchFluxRadiusArgs(values=values, starts=starts, counts=counts,
+                               nx=nx, ny=ny, grid_edges=grid_edges,
+                               kronflux=kronflux, max_radius=max_radius,
+                               use_exact=use_exact, subpixels=subpixels)
+
+
+def _solve(args, fraction):
+    return batch_flux_radius_solve(
+        args.values, starts=args.starts, counts=args.counts, nx=args.nx,
+        ny=args.ny, grid_edges=args.grid_edges, kronflux=args.kronflux,
+        max_radius=args.max_radius, fraction=fraction,
+        use_exact=args.use_exact, subpixels=args.subpixels)
+
+
 def _assert_args_equal(args, expected):
-    assert len(args) == len(expected)
-    for entry, ref in zip(args, expected, strict=True):
+    assert args.values.dtype == np.float64
+    assert args.values.flags.c_contiguous
+    assert len(args.counts) == len(expected)
+    entries = _unpack_args(args)
+    for entry, ref in zip(entries, expected, strict=True):
         if ref is None:
             assert entry is None
             continue
@@ -187,20 +251,39 @@ def scene():
 def test_matches_reference(scene, method, fraction):
     cat = make_catalog(scene, aperture_mask_method=method)
     args = cat._flux_radius_optimizer_args
-    expected = _reference_solve(args, fraction)
-    result = batch_flux_radius_solve(args, fraction=fraction)
+    expected = _reference_solve(_unpack_args(args), fraction)
+    result = _solve(args, fraction)
     assert_allclose(result, expected, rtol=1e-12, atol=RADIUS_ATOL,
                     equal_nan=True)
 
 
 def test_none_entries(scene):
     cat = make_catalog(scene)
-    args = list(cat._flux_radius_optimizer_args)
-    args[0] = None
-    result = batch_flux_radius_solve(args, fraction=0.5)
+    entries = _unpack_args(cat._flux_radius_optimizer_args)
+    entries[0] = None
+    result = _solve(_pack_entries(entries), 0.5)
     assert np.isnan(result[0])
-    assert_allclose(result, _reference_solve(args, 0.5), rtol=1e-12,
+    assert_allclose(result, _reference_solve(entries, 0.5), rtol=1e-12,
                     atol=RADIUS_ATOL, equal_nan=True)
+
+
+def test_solve_length_guard(scene):
+    cat = make_catalog(scene)
+    args = cat._flux_radius_optimizer_args
+    with pytest.raises(ValueError, match='same length as counts'):
+        batch_flux_radius_solve(
+            args.values, starts=args.starts, counts=args.counts[:-1],
+            nx=args.nx, ny=args.ny, grid_edges=args.grid_edges,
+            kronflux=args.kronflux, max_radius=args.max_radius,
+            fraction=0.5, use_exact=1, subpixels=1)
+
+
+def test_all_skipped(scene):
+    cat = make_catalog(scene)
+    n_src = cat.n_labels
+    args = _pack_entries([None] * n_src)
+    assert args.values.size == 0
+    assert np.all(np.isnan(_solve(args, 0.5)))
 
 
 def test_bracket_shrink_and_no_solution(scene):
@@ -208,7 +291,7 @@ def test_bracket_shrink_and_no_solution(scene):
     # enclosed flux non-monotonic, so the initial bracket has equal
     # signs at both ends
     cat = make_catalog(scene)
-    entry = [e for e in cat._flux_radius_optimizer_args
+    entry = [e for e in _unpack_args(cat._flux_radius_optimizer_args)
              if e is not None][0]
     clean_data = entry[0].copy()
     yc = entry[0].shape[0] / 2
@@ -218,7 +301,7 @@ def test_bracket_shrink_and_no_solution(scene):
     clean_data[rr > 3] = -np.abs(clean_data[rr > 3]) - 1.0
     forced = [[np.ascontiguousarray(clean_data), entry[1], entry[2],
                entry[3]]]
-    assert_allclose(batch_flux_radius_solve(forced, fraction=0.5),
+    assert_allclose(_solve(_pack_entries(forced), 0.5),
                     _reference_solve(forced, 0.5), rtol=1e-12,
                     atol=RADIUS_ATOL, equal_nan=True)
 
@@ -230,15 +313,14 @@ def test_bracket_shrink_and_no_solution(scene):
                entry[3]]]
     expected = _reference_solve(shrink, 0.5)
     assert np.isfinite(expected[0])
-    assert_allclose(batch_flux_radius_solve(shrink, fraction=0.5),
+    assert_allclose(_solve(_pack_entries(shrink), 0.5),
                     expected, rtol=1e-12, atol=RADIUS_ATOL)
 
     # And a hopeless case that shrinks to no solution -> NaN
     hopeless = [[np.ascontiguousarray(np.full_like(clean_data,
                                                    -1.0)),
                  entry[1], entry[2], entry[3]]]
-    assert np.isnan(batch_flux_radius_solve(hopeless,
-                                            fraction=0.5)[0])
+    assert np.isnan(_solve(_pack_entries(hopeless), 0.5)[0])
 
 
 @pytest.mark.parametrize('method', ['correct', 'mask', 'none'])
@@ -293,7 +375,38 @@ def test_prepare_skipped_sources(scene):
     _ = cat._kron_photometry
     cat.__dict__['_max_circular_kron_radius'] = np.full(cat.n_labels,
                                                         2000.0)
-    assert all(entry is None for entry in cat._flux_radius_optimizer_args)
+    assert np.all(cat._flux_radius_optimizer_args.counts == 0)
+    assert cat._flux_radius_optimizer_args.values.size == 0
+
+
+@pytest.mark.parametrize('n_threads', [2, 3, 8])
+def test_n_threads(scene, n_threads):
+    # The chunked preparation (whose packed buffers are merged with
+    # rebased starts) and the chunked solve give identical results
+    kwargs = {'error': scene['error'], 'mask': scene['mask']}
+    cat1 = SourceCatalog(scene['data'], scene['segm'], **kwargs)
+    cat2 = SourceCatalog(scene['data'], scene['segm'], n_threads=n_threads,
+                         **kwargs)
+    # Skip the first and last sources (non-finite centroid) so that
+    # zero-count sources fall at the chunk boundaries
+    for cat in (cat1, cat2):
+        _ = cat._kron_photometry
+        xcen = cat.x_centroid.copy()
+        xcen[0] = np.nan
+        xcen[-1] = np.nan
+        cat.__dict__['x_centroid'] = xcen
+    args1 = cat1._flux_radius_optimizer_args
+    args2 = cat2._flux_radius_optimizer_args
+    assert args1.counts[0] == 0
+    assert args1.counts[-1] == 0
+    assert np.any(args1.counts > 0)
+    for name in ('values', 'starts', 'counts', 'nx', 'ny', 'grid_edges',
+                 'kronflux', 'max_radius'):
+        assert_array_equal(getattr(args2, name), getattr(args1, name))
+    assert args2.use_exact == args1.use_exact
+    assert args2.subpixels == args1.subpixels
+    assert_array_equal(cat2.flux_radius(0.5), cat1.flux_radius(0.5))
+    assert_array_equal(cat2.flux_radius(0.9), cat1.flux_radius(0.9))
 
 
 def _prepare_inputs(cat):
@@ -346,12 +459,13 @@ def test_prepare_thread_safety(scene):
     with ThreadPoolExecutor(max_workers=4) as pool:
         results = list(pool.map(run, range(8)))
     for result in results:
-        _assert_args_equal(result, expected)
+        _assert_args_equal(result, _unpack_args(expected))
 
 
 def test_catalog_flux_radius(scene):
     cat = make_catalog(scene)
-    expected = _reference_solve(cat._flux_radius_optimizer_args, 0.5)
+    expected = _reference_solve(
+        _unpack_args(cat._flux_radius_optimizer_args), 0.5)
     result = cat.flux_radius(0.5)
     assert result.unit == u.pix
     assert_allclose(result.value, expected, rtol=1e-12, atol=RADIUS_ATOL,
@@ -361,5 +475,6 @@ def test_catalog_flux_radius(scene):
     cat.flux_radius(0.3, name='r30')
     assert_allclose(cat.r30.value,
                     _reference_solve(
-                        cat._flux_radius_optimizer_args, 0.3),
+                        _unpack_args(cat._flux_radius_optimizer_args),
+                        0.3),
                     rtol=1e-12, atol=RADIUS_ATOL, equal_nan=True)

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1947,17 +1947,19 @@ class TestThreadSafety:
         self.data = g1(xx, yy) + g2(xx, yy) + g3(xx, yy)
         self.segm = detect_sources(self.data, 10.0, n_pixels=5)
 
-    def test_concurrent_cached_property_access(self):
+    @pytest.mark.parametrize('n_threads', [1, 4])
+    def test_concurrent_cached_property_access(self, n_threads):
         """
         Test concurrent first access of cached properties on a shared
-        catalog.
+        catalog, with and without the catalog's own n_threads chunking
+        (whose thread pools then run inside the caller's threads).
 
         cached_property does not lock, so concurrent first accesses may
         run a getter more than once, but every thread must see values
         identical to the serial computation.
         """
         expected = SourceCatalog(self.data, self.segm)
-        cat = SourceCatalog(self.data, self.segm)
+        cat = SourceCatalog(self.data, self.segm, n_threads=n_threads)
 
         n_threads = 8
         barrier = threading.Barrier(n_threads)
@@ -1974,16 +1976,19 @@ class TestThreadSafety:
             assert_equal(centroid, expected.centroid)
             assert_equal(kron_flux, expected.kron_flux)
 
-    def test_concurrent_flux_radius(self):
+    @pytest.mark.parametrize('n_threads', [1, 4])
+    def test_concurrent_flux_radius(self, n_threads):
         """
-        Test concurrent first flux_radius calls on a shared catalog.
+        Test concurrent first flux_radius calls on a shared catalog,
+        with and without the catalog's own n_threads chunking of the
+        preparation and the solve.
 
         The _flux_radius_cache dict uses an unlocked check-then-set, so
         concurrent first calls may compute more than once, but every
         thread must see values identical to the serial computation.
         """
         expected = SourceCatalog(self.data, self.segm).flux_radius(0.5)
-        cat = SourceCatalog(self.data, self.segm)
+        cat = SourceCatalog(self.data, self.segm, n_threads=n_threads)
 
         n_threads = 8
         barrier = threading.Barrier(n_threads)
@@ -3679,6 +3684,34 @@ class TestNThreads:
         assert_equal(obj.kron_flux, cat.kron_flux[3])
         assert_equal(obj.kron_photometry((2.0, 1.0))[0],
                      cat.kron_photometry((2.0, 1.0))[0][3])
+
+    def test_sliced_catalog_new_fraction(self, many_source_inputs):
+        """
+        Test that a multi-source slice of a threaded catalog computes
+        a flux radius for a new fraction identically to the parent.
+
+        Slicing drops the packed flux-radius inputs, so the slice
+        recomputes them (chunked over its own sources) on the first
+        call for a fraction that the parent had not cached, while the
+        parent's cached fractions are carried over.
+        """
+        data, segm, error, _ = many_source_inputs
+        cat1 = SourceCatalog(data, segm, error=error)
+        cat2 = SourceCatalog(data, segm, error=error, n_threads=4)
+        cat1.flux_radius(0.5)
+        cat2.flux_radius(0.5)
+
+        index = slice(2, segm.n_labels - 3)
+        sub1 = cat1[index]
+        sub2 = cat2[index]
+        assert '_flux_radius_optimizer_args' not in sub2.__dict__
+        assert_equal(sub2.flux_radius(0.5), cat1.flux_radius(0.5)[index])
+        assert '_flux_radius_optimizer_args' not in sub2.__dict__
+
+        # A new fraction recomputes the packed inputs on the slice
+        assert_equal(sub2.flux_radius(0.3), sub1.flux_radius(0.3))
+        assert_equal(sub2.flux_radius(0.3), cat1.flux_radius(0.3)[index])
+        assert '_flux_radius_optimizer_args' in sub2.__dict__
 
     def test_indexing_preserves_n_threads(self, many_source_inputs):
         """

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2595,8 +2595,8 @@ def test_centroid_win_aperture_mask_mask(centroid_win_data):
 
 def test_make_scalar(single_source_catalog):
     """
-    Test the scalar collapse of method results: a length-1 sequence is
-    collapsed for a scalar catalog, a value without a length is returned
+    Test the scalar collapse of method results: a length-1 sequence
+    is collapsed for a scalar catalog, a longer sequence is returned
     unchanged, and a multi-source catalog never collapses.
     """
     _data, _segm, cat = single_source_catalog
@@ -2607,10 +2607,8 @@ def test_make_scalar(single_source_catalog):
     assert obj._make_scalar([7.0]) == 7.0
     assert obj._make_scalar(np.array([3.0]) << u.pix) == 3.0 * u.pix
 
-    # Values without a length (e.g., a float or a 0-d Quantity) are
-    # returned unchanged.
-    assert obj._make_scalar(5.0) == 5.0
-    value = 2.0 * u.pix
+    # A sequence that is not length-1 is returned unchanged
+    value = [5.0, 6.0]
     assert obj._make_scalar(value) is value
 
     # A multi-source catalog never collapses

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -3547,3 +3547,105 @@ class TestPartialPixelErrorWeights:
         aperture = catalog.kron_aperture[0]
         expected = self._expected_error(aperture, catalog._error)
         assert_allclose(catalog.kron_flux_err, expected)
+
+
+@pytest.fixture
+def many_source_inputs():
+    """
+    Multi-source inputs for the n_threads tests.
+
+    Returns ``(data, segm, error, mask)``.
+    """
+    data = make_100gaussians_image() - 5.0  # subtract the background
+    segm = detect_sources(data, 9.0, n_pixels=5)
+    error = make_noise_image(data.shape, mean=0, stddev=2.0, seed=0)
+    error = np.abs(error) + 1.0
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[0:40, 0:60] = True
+    return data, segm, error, mask
+
+
+class TestNThreads:
+    """
+    Tests for the n_threads keyword.
+    """
+
+    @pytest.mark.parametrize('n_threads', [2, 8])
+    @pytest.mark.parametrize('aperture_mask_method',
+                             ['correct', 'mask', 'none'])
+    def test_identical_results(self, many_source_inputs, n_threads,
+                               aperture_mask_method):
+        """
+        Test that the Kron measurements are identical for any number
+        of threads, for both circular and elliptical Kron apertures.
+        """
+        data, segm, error, mask = many_source_inputs
+        kwargs = {'error': error, 'mask': mask, 'local_bkg_width': 10,
+                  'aperture_mask_method': aperture_mask_method,
+                  'kron_params': (2.5, 1.4, 5.0)}
+        cat1 = SourceCatalog(data, segm, **kwargs)
+        cat2 = SourceCatalog(data, segm, n_threads=n_threads, **kwargs)
+        assert cat1.n_threads == 1
+        assert cat2.n_threads == n_threads
+        assert segm.n_labels > n_threads
+
+        # The minimum circular radius makes some apertures circular
+        n_circ = sum(isinstance(aper, CircularAperture)
+                     for aper in cat1.kron_aperture)
+        assert 0 < n_circ < segm.n_labels
+
+        for name in ('kron_radius', 'kron_flux', 'kron_flux_err', 'flags'):
+            assert_equal(getattr(cat2, name), getattr(cat1, name))
+
+        assert_equal(cat2.kron_photometry((2.0, 1.0)),
+                     cat1.kron_photometry((2.0, 1.0)))
+        assert_equal(cat2.flux_radius(0.5), cat1.flux_radius(0.5))
+
+    def test_n_threads_exceeds_sources(self, many_source_inputs):
+        """
+        Test that n_threads larger than the number of sources gives
+        the same results.
+        """
+        data, segm, error, _ = many_source_inputs
+        cat1 = SourceCatalog(data, segm, error=error)
+        cat2 = SourceCatalog(data, segm, error=error,
+                             n_threads=10 * segm.n_labels)
+        assert_equal(cat2.kron_flux, cat1.kron_flux)
+        assert_equal(cat2.kron_flux_err, cat1.kron_flux_err)
+
+    def test_scalar_catalog(self, many_source_inputs):
+        """
+        Test that a scalar (single-source) catalog with n_threads > 1
+        gives the same results as the parent catalog.
+        """
+        data, segm, error, _ = many_source_inputs
+        cat = SourceCatalog(data, segm, error=error, n_threads=4)
+        obj = cat[3]
+        assert obj.n_threads == 4
+        assert obj.isscalar
+        assert_equal(obj.kron_radius, cat.kron_radius[3])
+        assert_equal(obj.kron_flux, cat.kron_flux[3])
+        assert_equal(obj.kron_photometry((2.0, 1.0))[0],
+                     cat.kron_photometry((2.0, 1.0))[0][3])
+
+    def test_indexing_preserves_n_threads(self, many_source_inputs):
+        """
+        Test that slicing and copying a catalog preserve n_threads.
+        """
+        data, segm, _, _ = many_source_inputs
+        cat = SourceCatalog(data, segm, n_threads=4)
+        assert cat[1:].n_threads == 4
+        assert cat[[0, 2]].n_threads == 4
+        assert cat[0].n_threads == 4
+        assert cat.copy().n_threads == 4
+
+    def test_invalid_n_threads(self, many_source_inputs):
+        """
+        Test that an error is raised if n_threads is not a positive
+        integer.
+        """
+        data, segm, _, _ = many_source_inputs
+        match = 'n_threads must be a positive integer'
+        for n_threads in (0, -1, 2.5):
+            with pytest.raises(ValueError, match=match):
+                SourceCatalog(data, segm, n_threads=n_threads)

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2617,8 +2617,9 @@ def test_make_scalar(single_source_catalog):
 
 def test_flux_radius_optimizer_args_oom_guard(gauss_101_catalog):
     """
-    Test that _flux_radius_optimizer_args returns None for sources whose
-    max-radius aperture bbox exceeds max_aper_size.
+    Test that _flux_radius_optimizer_args gives a zero pixel count (and
+    thus a NaN flux radius) for sources whose max-radius aperture bbox
+    exceeds max_aper_size.
     """
     data, segm, cat = gauss_101_catalog
 
@@ -2637,8 +2638,9 @@ def test_flux_radius_optimizer_args_oom_guard(gauss_101_catalog):
 
 def test_flux_radius_optimizer_args_off_image(gauss_101_catalog):
     """
-    Test that _flux_radius_optimizer_args returns None for sources whose
-    max-radius aperture bbox doesn't overlap the data.
+    Test that _flux_radius_optimizer_args gives a zero pixel count (and
+    thus a NaN flux radius) for sources whose max-radius aperture bbox
+    doesn't overlap the data.
     """
     _data, _segm, cat = gauss_101_catalog
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2588,6 +2588,30 @@ def test_centroid_win_aperture_mask_mask(centroid_win_data):
     assert np.isfinite(cwin[0, 0])
 
 
+def test_make_scalar(single_source_catalog):
+    """
+    Test the scalar collapse of method results: a length-1 sequence is
+    collapsed for a scalar catalog, a value without a length is returned
+    unchanged, and a multi-source catalog never collapses.
+    """
+    _data, _segm, cat = single_source_catalog
+    assert not cat.isscalar
+    obj = cat[0]
+    assert obj.isscalar
+
+    assert obj._make_scalar([7.0]) == 7.0
+    assert obj._make_scalar(np.array([3.0]) << u.pix) == 3.0 * u.pix
+
+    # Values without a length (e.g., a float or a 0-d Quantity) are
+    # returned unchanged.
+    assert obj._make_scalar(5.0) == 5.0
+    value = 2.0 * u.pix
+    assert obj._make_scalar(value) is value
+
+    # A multi-source catalog never collapses
+    assert cat._make_scalar([7.0]) == [7.0]
+
+
 def test_flux_radius_optimizer_args_oom_guard(gauss_101_catalog):
     """
     Test that _flux_radius_optimizer_args returns None for sources whose

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -3731,6 +3731,6 @@ class TestNThreads:
         """
         data, segm, _, _ = many_source_inputs
         match = 'n_threads must be a positive integer'
-        for n_threads in (0, -1, 2.5):
+        for n_threads in (0, -1, 2.5, True):
             with pytest.raises(ValueError, match=match):
                 SourceCatalog(data, segm, n_threads=n_threads)

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -3565,6 +3565,25 @@ def many_source_inputs():
     return data, segm, error, mask
 
 
+def _assert_same_value(value, expected):
+    """
+    Assert that two catalog property values are identical, for arrays,
+    Quantity, SkyCoord, and lists of per-source arrays.
+    """
+    if isinstance(value, SkyCoord):
+        assert_equal(value.ra.deg, expected.ra.deg)
+        assert_equal(value.dec.deg, expected.dec.deg)
+    elif isinstance(value, u.Quantity):
+        assert value.unit == expected.unit
+        assert_equal(value.value, expected.value)
+    elif isinstance(value, list):
+        assert len(value) == len(expected)
+        for item, ref in zip(value, expected, strict=True):
+            assert_equal(item, ref)
+    else:
+        assert_equal(value, expected)
+
+
 class TestNThreads:
     """
     Tests for the n_threads keyword.
@@ -3573,16 +3592,22 @@ class TestNThreads:
     @pytest.mark.parametrize('n_threads', [2, 8])
     @pytest.mark.parametrize('aperture_mask_method',
                              ['correct', 'mask', 'none'])
+    @pytest.mark.parametrize('with_error', [True, False])
     def test_identical_results(self, many_source_inputs, n_threads,
-                               aperture_mask_method):
+                               aperture_mask_method, with_error):
         """
-        Test that the Kron measurements are identical for any number
-        of threads, for both circular and elliptical Kron apertures.
+        Test that every property and measurement is identical for any
+        number of threads, for both circular and elliptical Kron
+        apertures, with and without an error array.
         """
         data, segm, error, mask = many_source_inputs
-        kwargs = {'error': error, 'mask': mask, 'local_bkg_width': 10,
+        kwargs = {'mask': mask, 'local_bkg_width': 10,
                   'aperture_mask_method': aperture_mask_method,
-                  'kron_params': (2.5, 1.4, 5.0)}
+                  'kron_params': (2.5, 1.4, 5.0),
+                  'background': np.full(data.shape, 0.1),
+                  'wcs': make_wcs(data.shape)}
+        if with_error:
+            kwargs['error'] = error
         cat1 = SourceCatalog(data, segm, **kwargs)
         cat2 = SourceCatalog(data, segm, n_threads=n_threads, **kwargs)
         assert cat1.n_threads == 1
@@ -3594,12 +3619,15 @@ class TestNThreads:
                      for aper in cat1.kron_aperture)
         assert 0 < n_circ < segm.n_labels
 
-        for name in ('kron_radius', 'kron_flux', 'kron_flux_err', 'flags'):
-            assert_equal(getattr(cat2, name), getattr(cat1, name))
+        for name in cat1.properties:
+            _assert_same_value(getattr(cat2, name), getattr(cat1, name))
 
-        assert_equal(cat2.kron_photometry((2.0, 1.0)),
-                     cat1.kron_photometry((2.0, 1.0)))
-        assert_equal(cat2.flux_radius(0.5), cat1.flux_radius(0.5))
+        _assert_same_value(cat2.kron_photometry((2.0, 1.0)),
+                           cat1.kron_photometry((2.0, 1.0)))
+        _assert_same_value(cat2.circular_photometry(3.0),
+                           cat1.circular_photometry(3.0))
+        _assert_same_value(cat2.flux_radius(0.5), cat1.flux_radius(0.5))
+        _assert_same_value(cat2.flux_radius(0.9), cat1.flux_radius(0.9))
 
     def test_n_threads_exceeds_sources(self, many_source_inputs):
         """


### PR DESCRIPTION
This PR adds an ``n_threads`` keyword to ``SourceCatalog`` to compute the compiled per-source measurements (the isophotal moments and their errors, the segment pixel statistics, the windowed and quadratic centroids, ``perimeter``, the Kron radii and photometry, ``circular_photometry``, and ``flux_radius``), and thus every property derived from them, using multiple threads. The sources are divided into chunks that are processed concurrently, producing results identical to the single-threaded computation.