### PR TITLE
Add n_threads keyword to deblend_sources and SourceFinder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -301,6 +301,15 @@ New Features
     small blended sources and for large segments with many markers.
     [#2408]
 
+  - Added an ``n_threads`` keyword to ``deblend_sources`` and
+    ``SourceFinder`` to deblend the sources using multiple threads.
+    The sources are divided into chunks and processed concurrently,
+    producing results identical to the single-threaded computation.
+    The marker-building kernels release the GIL, as do the
+    watershed and most of the array operations, so multithreading
+    can significantly speed up deblending, especially for large
+    sources. [#2409]
+
 - ``photutils.utils``
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's

--- a/benchmarks/bench_deblend.py
+++ b/benchmarks/bench_deblend.py
@@ -32,7 +32,7 @@ from functools import partial
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 from astropy.stats import gaussian_fwhm_to_sigma
-from bench_helpers import print_environment, time_best
+from bench_helpers import parse_thread_counts, print_environment, time_best
 from bench_segmentation import N_PIXELS, THRESHOLD, make_inputs
 
 from photutils.segmentation import detect_sources
@@ -572,6 +572,11 @@ def main():
                         help='comma-separated peak counts for the '
                              'many-peak benchmark '
                              '(default: 10,25,50,100)')
+    parser.add_argument('--n-threads', type=parse_thread_counts,
+                        default=[1, 2, 4, 8],
+                        help='comma-separated n_threads values for the '
+                             'thread-scaling benchmark '
+                             '(default: 1,2,4,8)')
     parser.add_argument('--repeats', type=int, default=3,
                         help='number of repeats per timing; the best '
                              'time is reported (default: %(default)s)')
@@ -602,7 +607,8 @@ def main():
         bench_stages(contrast=0.03, repeats=args.repeats,
                      seed=args.seed)
     if args.which in ('all', 'threads'):
-        bench_threads(repeats=args.repeats, seed=args.seed)
+        bench_threads(thread_counts=args.n_threads,
+                      repeats=args.repeats, seed=args.seed)
     if args.which == 'profile':
         bench_profile(seed=args.seed)
 

--- a/benchmarks/bench_deblend.py
+++ b/benchmarks/bench_deblend.py
@@ -32,7 +32,8 @@ from functools import partial
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 from astropy.stats import gaussian_fwhm_to_sigma
-from bench_helpers import parse_thread_counts, print_environment, time_best
+from bench_helpers import (format_sweep_cells, parse_int_list,
+                           parse_thread_counts, print_environment, time_best)
 from bench_segmentation import N_PIXELS, THRESHOLD, make_inputs
 
 from photutils.segmentation import detect_sources
@@ -501,8 +502,6 @@ def bench_threads(*, n_sources=4000, size=1000, n_peaks=25,
     seed : int, optional
         The random number generator seed.
     """
-    from bench_helpers import format_sweep_cells
-
     _, data, segm = make_inputs(n_sources, seed=seed)
     tile = make_blended_image(size, n_peaks, seed=seed)
     grid = np.empty((2 * size, 2 * size))
@@ -528,27 +527,6 @@ def bench_threads(*, n_sources=4000, size=1000, n_peaks=25,
         cells = ''.join(f'{cell:>18}'
                         for cell in format_sweep_cells(times))
         print(f'{name:>24}{cells}')
-
-
-def parse_int_list(text):
-    """
-    Parse a comma-separated list of positive integers.
-
-    Parameters
-    ----------
-    text : str
-        The comma-separated integers (e.g., ``'250,500,1000'``).
-
-    Returns
-    -------
-    result : list of int
-        The parsed integers.
-    """
-    values = [int(item) for item in text.split(',')]
-    if any(value < 1 for value in values):
-        msg = 'values must be positive integers'
-        raise ValueError(msg)
-    return values
 
 
 def main():

--- a/benchmarks/bench_deblend.py
+++ b/benchmarks/bench_deblend.py
@@ -471,6 +471,65 @@ def bench_profile(*, n_sources=2000, size=1000, n_peaks=25, seed=0):
         partial(deblend_sources, data, segm, N_PIXELS))
 
 
+def bench_threads(*, n_sources=4000, size=1000, n_peaks=25,
+                  thread_counts=(1, 2, 4, 8), repeats=3, seed=0):
+    """
+    Benchmark deblend_sources thread scaling.
+
+    Two regimes are timed: a field of many small blended pairs and a
+    2x2 grid of large blended sources (whose per-source work is
+    dominated by the GIL-releasing watershed and marker kernels).
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources for the many-source
+        scene.
+
+    size : int, optional
+        The tile size for the large-source grid scene.
+
+    n_peaks : int, optional
+        The number of compact peaks per large source.
+
+    thread_counts : tuple of int, optional
+        The n_threads values.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    from bench_helpers import format_sweep_cells
+
+    _, data, segm = make_inputs(n_sources, seed=seed)
+    tile = make_blended_image(size, n_peaks, seed=seed)
+    grid = np.empty((2 * size, 2 * size))
+    for iy in range(2):
+        for ix in range(2):
+            grid[iy * size:(iy + 1) * size,
+                 ix * size:(ix + 1) * size] = tile
+    segm_grid = detect_sources(grid, BLEND_THRESHOLD, N_PIXELS)
+
+    scenes = [
+        (f'{segm.n_labels} small segments', data, segm),
+        (f'{segm_grid.n_labels} large segments', grid, segm_grid),
+    ]
+    print('\n== deblend_sources: thread scaling ==')
+    header = ''.join(f'{f"{n} thr":>18}' for n in thread_counts)
+    print(f'{"scene":>24}{header}')
+    for name, scene_data, scene_segm in scenes:
+        times = []
+        for n_threads in thread_counts:
+            bench = partial(deblend_sources, scene_data, scene_segm,
+                            N_PIXELS, n_threads=n_threads)
+            times.append(time_best(bench, repeats=repeats))
+        cells = ''.join(f'{cell:>18}'
+                        for cell in format_sweep_cells(times))
+        print(f'{name:>24}{cells}')
+
+
 def parse_int_list(text):
     """
     Parse a comma-separated list of positive integers.
@@ -521,7 +580,7 @@ def main():
                              '(default: %(default)s)')
     parser.add_argument('--which', default='all',
                         choices=['all', 'many', 'large', 'peaks',
-                                 'stages', 'profile'],
+                                 'stages', 'threads', 'profile'],
                         help='which benchmark to run '
                              '(default: %(default)s)')
     args = parser.parse_args()
@@ -542,6 +601,8 @@ def main():
         bench_stages(repeats=args.repeats, seed=args.seed)
         bench_stages(contrast=0.03, repeats=args.repeats,
                      seed=args.seed)
+    if args.which in ('all', 'threads'):
+        bench_threads(repeats=args.repeats, seed=args.seed)
     if args.which == 'profile':
         bench_profile(seed=args.seed)
 

--- a/benchmarks/bench_detection.py
+++ b/benchmarks/bench_detection.py
@@ -363,7 +363,7 @@ def main():
                         help='number of concurrent find_stars calls for '
                              'the thread-scaling benchmark '
                              '(default: %(default)s)')
-    parser.add_argument('--threads', type=parse_thread_counts,
+    parser.add_argument('--n-threads', type=parse_thread_counts,
                         default=[1, 2, 4, 8],
                         help='comma-separated thread counts for the '
                              'thread-scaling benchmark (default: 1,2,4,8)')
@@ -393,7 +393,7 @@ def main():
                              repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'threads'):
         bench_finder_threads(n_sources=args.n_sources, n_calls=args.n_calls,
-                             thread_counts=args.threads,
+                             thread_counts=args.n_threads,
                              repeats=args.repeats, seed=args.seed)
 
 

--- a/benchmarks/bench_helpers.py
+++ b/benchmarks/bench_helpers.py
@@ -82,6 +82,27 @@ def print_environment():
     print(f'photutils path: {os.path.dirname(photutils.__file__)}')
 
 
+def parse_int_list(text):
+    """
+    Parse a comma-separated list of positive integers.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated integers (e.g., ``'250,500,1000'``).
+
+    Returns
+    -------
+    result : list of int
+        The parsed integers.
+    """
+    values = [int(item) for item in text.split(',')]
+    if any(value < 1 for value in values):
+        msg = 'values must be positive integers'
+        raise ValueError(msg)
+    return values
+
+
 def parse_thread_counts(text):
     """
     Parse a comma-separated list of thread counts.
@@ -96,11 +117,7 @@ def parse_thread_counts(text):
     result : list of int
         The thread counts.
     """
-    counts = [int(item) for item in text.split(',')]
-    if any(count < 1 for count in counts):
-        msg = 'thread counts must be positive integers'
-        raise ValueError(msg)
-    return counts
+    return parse_int_list(text)
 
 
 def format_sweep_cells(times):

--- a/benchmarks/bench_segmentation.py
+++ b/benchmarks/bench_segmentation.py
@@ -5,7 +5,7 @@ Benchmarks for the photutils.segmentation subpackage.
 
 The benchmarks cover source detection (detect_threshold and
 detect_sources), source deblending (deblend_sources) across the
-threshold modes and process counts, the combined SourceFinder class,
+threshold modes and thread counts, the combined SourceFinder class,
 SegmentationImage operations (relabeling, border-label removal,
 source masks, and polygons), SourceCatalog property calculations, the
 SourceCatalog n_threads keyword, and concurrent SourceCatalog runs
@@ -567,7 +567,7 @@ def main():
     parser.add_argument('--n-sources', type=int, default=1000,
                         help='total number of Gaussian sources in the '
                              'image (default: %(default)s)')
-    parser.add_argument('--deblend-threads', type=parse_int_list,
+    parser.add_argument('--deblend-n-threads', type=parse_int_list,
                         default=[1, 4],
                         help='comma-separated n_threads values for the '
                              'deblending benchmark (default: 1,4)')
@@ -575,7 +575,7 @@ def main():
                         help='number of concurrent catalog jobs for the '
                              'thread-scaling benchmark '
                              '(default: %(default)s)')
-    parser.add_argument('--threads', type=parse_thread_counts,
+    parser.add_argument('--n-threads', type=parse_thread_counts,
                         default=[1, 2, 4, 8],
                         help='comma-separated thread counts for the '
                              'thread-scaling and n_threads benchmarks '
@@ -601,7 +601,7 @@ def main():
                      seed=args.seed)
     if args.which in ('all', 'deblend'):
         bench_deblend(n_sources=args.n_sources,
-                      thread_counts=args.deblend_threads,
+                      thread_counts=args.deblend_n_threads,
                       repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'finder'):
         bench_finder(n_sources=args.n_sources, repeats=args.repeats,
@@ -614,12 +614,12 @@ def main():
                       seed=args.seed)
     if args.which in ('all', 'n-threads'):
         bench_catalog_n_threads(n_sources=args.n_sources,
-                                thread_counts=args.threads,
+                                thread_counts=args.n_threads,
                                 repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'threads'):
         bench_catalog_threads(n_sources=args.n_sources,
                               n_calls=args.n_calls,
-                              thread_counts=args.threads,
+                              thread_counts=args.n_threads,
                               repeats=args.repeats, seed=args.seed)
 
 

--- a/benchmarks/bench_segmentation.py
+++ b/benchmarks/bench_segmentation.py
@@ -25,8 +25,8 @@ import numpy as np
 from astropy.convolution import convolve
 from astropy.modeling.models import Gaussian2D
 from astropy.stats import gaussian_fwhm_to_sigma
-from bench_helpers import (format_sweep_cells, parse_thread_counts,
-                           print_environment, time_best)
+from bench_helpers import (format_sweep_cells, parse_int_list,
+                           parse_thread_counts, print_environment, time_best)
 
 from photutils.datasets import make_wcs
 from photutils.segmentation import (SegmentationImage, SourceCatalog,
@@ -535,27 +535,6 @@ def bench_catalog_n_threads(*, n_sources=1000, thread_counts=(1, 2, 4, 8),
                  for n_threads in thread_counts]
         cells = ''.join(f'{cell:>18}' for cell in format_sweep_cells(times))
         print(f'{name:>32}{cells}')
-
-
-def parse_int_list(text):
-    """
-    Parse a comma-separated list of positive integers.
-
-    Parameters
-    ----------
-    text : str
-        The comma-separated integers (e.g., ``'1,4'``).
-
-    Returns
-    -------
-    result : list of int
-        The parsed integers.
-    """
-    values = [int(item) for item in text.split(',')]
-    if any(value < 1 for value in values):
-        msg = 'values must be positive integers'
-        raise ValueError(msg)
-    return values
 
 
 def main():

--- a/benchmarks/bench_segmentation.py
+++ b/benchmarks/bench_segmentation.py
@@ -169,18 +169,18 @@ def bench_detect(*, n_sources=1000, repeats=3, seed=0):
         print(f'{name:>34}{f"{t_best:.4f}s":>12}{segm.n_labels:>10}')
 
 
-def bench_deblend(*, n_sources=1000, process_counts=(1, 4), repeats=3,
+def bench_deblend(*, n_sources=1000, thread_counts=(1, 4), repeats=3,
                   seed=0):
     """
-    Benchmark deblend_sources across modes and process counts.
+    Benchmark deblend_sources across modes and thread counts.
 
     Parameters
     ----------
     n_sources : int, optional
         The total number of Gaussian sources in the image.
 
-    process_counts : tuple of int, optional
-        The n_processes values (for mode='exponential').
+    thread_counts : tuple of int, optional
+        The n_threads values (for mode='exponential').
 
     repeats : int, optional
         The number of repeats for each timing (best time is kept).
@@ -205,13 +205,13 @@ def bench_deblend(*, n_sources=1000, process_counts=(1, 4), repeats=3,
         print(f'{name:>36}{f"{t_best:.4f}s":>12}'
               f'{segm_deblended.n_labels:>10}')
 
-    for n_processes in process_counts:
-        if n_processes == 1:
+    for n_threads in thread_counts:
+        if n_threads == 1:
             continue
         bench = partial(deblend_sources, convolved_data, segm, N_PIXELS,
-                        mode='exponential', n_processes=n_processes)
+                        mode='exponential', n_threads=n_threads)
         t_best = time_best(bench, repeats=repeats)
-        name = f'mode=exponential, n_processes={n_processes}'
+        name = f'mode=exponential, n_threads={n_threads}'
         print(f'{name:>36}{f"{t_best:.4f}s":>12}{"":>10}')
 
 
@@ -567,8 +567,9 @@ def main():
     parser.add_argument('--n-sources', type=int, default=1000,
                         help='total number of Gaussian sources in the '
                              'image (default: %(default)s)')
-    parser.add_argument('--n-processes', type=parse_int_list, default=[1, 4],
-                        help='comma-separated n_processes values for the '
+    parser.add_argument('--deblend-threads', type=parse_int_list,
+                        default=[1, 4],
+                        help='comma-separated n_threads values for the '
                              'deblending benchmark (default: 1,4)')
     parser.add_argument('--n-calls', type=int, default=8,
                         help='number of concurrent catalog jobs for the '
@@ -600,7 +601,7 @@ def main():
                      seed=args.seed)
     if args.which in ('all', 'deblend'):
         bench_deblend(n_sources=args.n_sources,
-                      process_counts=args.n_processes,
+                      thread_counts=args.deblend_threads,
                       repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'finder'):
         bench_finder(n_sources=args.n_sources, repeats=args.repeats,

--- a/benchmarks/bench_utils.py
+++ b/benchmarks/bench_utils.py
@@ -503,7 +503,7 @@ def main():
     parser.add_argument('--size', type=int, default=1000,
                         help='image size for the ImageDepth and cutout '
                              'benchmarks (default: %(default)s)')
-    parser.add_argument('--threads', type=parse_thread_counts,
+    parser.add_argument('--n-threads', type=parse_thread_counts,
                         default=[1, 2, 4, 8],
                         help='comma-separated thread counts for the '
                              'ImageDepth thread-scaling benchmark '
@@ -524,7 +524,7 @@ def main():
     if args.which in ('all', 'image-depth'):
         bench_image_depth(size=args.size, repeats=args.repeats)
     if args.which in ('all', 'depth-threads'):
-        bench_depth_threads(thread_counts=args.threads,
+        bench_depth_threads(thread_counts=args.n_threads,
                             repeats=args.repeats)
     if args.which in ('all', 'idw'):
         bench_idw(repeats=args.repeats)

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -662,6 +662,14 @@ The compiled watershed kernel produces results identical to
 required for source deblending (it remains an optional dependency
 for `~photutils.utils.ImageDepth`).
 
+A new ``n_threads`` keyword in
+:func:`~photutils.segmentation.deblend_sources` and
+`~photutils.segmentation.SourceFinder` deblends the sources using
+multiple threads. The sources are divided into chunks and processed
+concurrently, producing results identical to the single-threaded
+computation. The compiled kernels release the GIL, so multithreading can
+significantly speed up deblending, especially for large sources.
+
 
 ``GriddedPSFModel`` Performance Improvements
 ============================================
@@ -699,7 +707,8 @@ removed in version 4.0, and both keywords no longer have any effect.
 Deblending is now dominated by compiled code, so no progress bar is
 displayed, and the multiprocessing implementation has been removed
 because its process startup and data-pickling overheads made it slower
-than the serial implementation.
+than the serial implementation. Use the new ``n_threads`` keyword for
+multithreaded deblending instead.
 
 ``EPSFBuildResult`` Renamed to ``EPSFBuildResults``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -30,6 +30,45 @@ __all__ = ['deblend_sources']
 _MAX_MARKERS = 200
 
 
+def _validate_deblend_kwargs(*, n_levels, contrast, mode, connectivity,
+                             n_threads):
+    """
+    Validate the deblending keywords shared by `deblend_sources` and
+    `~photutils.segmentation.SourceFinder`.
+
+    Parameters
+    ----------
+    n_levels, contrast, mode, connectivity, n_threads
+        The keyword values to validate. See `deblend_sources`.
+
+    Raises
+    ------
+    ValueError
+        If any of the values is invalid.
+    """
+    if (n_levels < 1) or (int(n_levels) != n_levels):
+        msg = f'n_levels must be a positive integer, got {n_levels!r}'
+        raise ValueError(msg)
+
+    if contrast < 0 or contrast > 1:
+        msg = 'contrast must be >= 0 and <= 1'
+        raise ValueError(msg)
+
+    if mode not in ('exponential', 'linear', 'sinh'):
+        msg = "mode must be 'exponential', 'linear', or 'sinh'"
+        raise ValueError(msg)
+
+    if connectivity not in (4, 8):
+        msg = f'Invalid connectivity={connectivity}. Options are 4 or 8'
+        raise ValueError(msg)
+
+    if (isinstance(n_threads, bool)
+            or not isinstance(n_threads, (int, np.integer))
+            or n_threads < 1):
+        msg = f'n_threads must be a positive integer, got {n_threads!r}'
+        raise ValueError(msg)
+
+
 @dataclass
 class _DeblendParams:
     n_pixels: int
@@ -210,20 +249,9 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         msg = f'n_pixels must be a positive integer, got {n_pixels!r}'
         raise ValueError(msg)
 
-    if (n_levels < 1) or (int(n_levels) != n_levels):
-        msg = f'n_levels must be a positive integer, got {n_levels!r}'
-        raise ValueError(msg)
-    if contrast < 0 or contrast > 1:
-        msg = 'contrast must be >= 0 and <= 1'
-        raise ValueError(msg)
-
-    if mode not in ('exponential', 'linear', 'sinh'):
-        msg = "mode must be 'exponential', 'linear', or 'sinh'"
-        raise ValueError(msg)
-
-    if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
-        msg = 'n_threads must be a positive integer'
-        raise ValueError(msg)
+    _validate_deblend_kwargs(n_levels=n_levels, contrast=contrast,
+                             mode=mode, connectivity=connectivity,
+                             n_threads=n_threads)
 
     if contrast == 1:  # no deblending
         segm_img = segmentation_image.copy()
@@ -271,10 +299,19 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
 
     n_chunks = min(int(n_threads), len(labels))
     if n_chunks > 1:
-        # The sources are divided into chunks processed concurrently.
-        # The results are assembled in the input order, so they are
-        # identical to the single-threaded computation
-        chunk_indices = np.array_split(np.arange(len(labels)), n_chunks)
+        # The sources are dealt out to the chunks in decreasing order of
+        # their bounding-box area (the size of the cutouts the kernels
+        # work on), so that the chunks carry similar amounts of work
+        # regardless of the source ordering. The chunks are processed
+        # concurrently and the per-source results are scattered back
+        # into the input order, so they are identical to the
+        # single-threaded computation.
+        bbox_areas = np.array([(slc[0].stop - slc[0].start)
+                               * (slc[1].stop - slc[1].start)
+                               for slc in all_slices])
+        order = np.argsort(bbox_areas, kind='stable')[::-1]
+        chunk_indices = [np.sort(order[i::n_chunks])
+                         for i in range(n_chunks)]
 
         def _run_chunk(indices):
             chunk_slices = [all_slices[idx] for idx in indices]
@@ -282,11 +319,14 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
                                           driver_segm, labels[indices],
                                           chunk_slices, deblend_params)
 
+        results = [None] * len(labels)
         with ThreadPoolExecutor(max_workers=n_chunks) as executor:
-            results = [result
-                       for chunk in executor.map(_run_chunk,
-                                                 chunk_indices)
-                       for result in chunk]
+            for indices, chunk_results in zip(
+                    chunk_indices, executor.map(_run_chunk, chunk_indices),
+                    strict=True):
+                for index, result in zip(indices, chunk_results,
+                                         strict=True):
+                    results[index] = result
     else:
         results = _deblend_sources_chunk(data, segm_data, driver_data,
                                          driver_segm, labels,

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -5,6 +5,7 @@ image.
 """
 
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 import numpy as np
@@ -47,7 +48,7 @@ class _DeblendParams:
 @deprecated_renamed_argument('progress_bar', None, '3.1', until='4.0')
 def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
                     n_levels=32, contrast=0.001, mode='exponential',
-                    connectivity=8, relabel=True,
+                    connectivity=8, relabel=True, n_threads=1,
                     nproc=1,  # noqa: ARG001
                     n_processes=1,  # noqa: ARG001
                     progress_bar=True):  # noqa: ARG001
@@ -124,6 +125,17 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         relabeled such that the labels are in consecutive order starting
         from 1.
 
+    n_threads : int, optional
+        The number of threads to use to deblend the sources. The
+        default is 1 (no multithreading). When ``n_threads`` > 1, the
+        sources are divided into chunks and processed concurrently. The
+        per-source results are independent and are assembled in the
+        input-label order, so they are identical to the single-threaded
+        computation. The marker-building kernels release the Python
+        global interpreter lock (GIL), as do the watershed and most of
+        the array operations, so multithreading can significantly speed
+        up the deblending, especially for large sources.
+
     nproc : int, optional
         This keyword is deprecated and has no effect. It was the name of
         the ``n_processes`` keyword before version 3.0.
@@ -137,7 +149,8 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         no longer provides any benefit. The deblending computation is
         now dominated by compiled code, and the process startup and
         data-pickling overheads of multiprocessing made it slower than
-        the serial implementation.
+        the serial implementation. Use the ``n_threads`` keyword
+        instead.
 
         .. deprecated:: 3.1
             The ``n_processes`` keyword is deprecated and will be
@@ -208,6 +221,10 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         msg = "mode must be 'exponential', 'linear', or 'sinh'"
         raise ValueError(msg)
 
+    if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+        msg = 'n_threads must be a positive integer'
+        raise ValueError(msg)
+
     if contrast == 1:  # no deblending
         segm_img = segmentation_image.copy()
         if relabel:
@@ -252,9 +269,28 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         driver_dtype = np.int64
     driver_segm = np.ascontiguousarray(segm_data, dtype=driver_dtype)
 
-    results = _deblend_sources_chunk(data, segm_data, driver_data,
-                                     driver_segm, labels, all_slices,
-                                     deblend_params)
+    n_chunks = min(int(n_threads), len(labels))
+    if n_chunks > 1:
+        # The sources are divided into chunks processed concurrently.
+        # The results are assembled in the input order, so they are
+        # identical to the single-threaded computation
+        chunk_indices = np.array_split(np.arange(len(labels)), n_chunks)
+
+        def _run_chunk(indices):
+            chunk_slices = [all_slices[idx] for idx in indices]
+            return _deblend_sources_chunk(data, segm_data, driver_data,
+                                          driver_segm, labels[indices],
+                                          chunk_slices, deblend_params)
+
+        with ThreadPoolExecutor(max_workers=n_chunks) as executor:
+            results = [result
+                       for chunk in executor.map(_run_chunk,
+                                                 chunk_indices)
+                       for result in chunk]
+    else:
+        results = _deblend_sources_chunk(data, segm_data, driver_data,
+                                         driver_segm, labels,
+                                         all_slices, deblend_params)
 
     deblend_label_map = {}
     max_label = segmentation_image.max_label

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -476,10 +476,15 @@ def _deblend_sources_chunk(data, segm_data, driver_data, driver_segm,
         thresholds, fallback = _compute_thresholds(smin, smax, n_levels,
                                                    mode)
         nonposmin[active] = fallback
+        # Sources with too many markers are only retried with linearly
+        # spaced levels (below), so only then may the kernel skip
+        # building their markers.
+        can_retry = mode != 'linear'
+        max_markers = _MAX_MARKERS if can_retry else -1
         markers, n_markers = deblend_markers_chunk(
             driver_data, driver_segm, labels[active], y0[active],
             y1[active], x0[active], x1[active], thresholds,
-            max_markers=_MAX_MARKERS, **chunk_kwargs)
+            max_markers=max_markers, **chunk_kwargs)
         for index, source_markers in zip(active, markers, strict=True):
             markers_list[index] = source_markers
 
@@ -487,7 +492,7 @@ def _deblend_sources_chunk(data, segm_data, driver_data, driver_segm,
         # sources are deblended again with linearly spaced levels. A
         # source that already fell back to the linear spacing keeps its
         # markers
-        if mode != 'linear':
+        if can_retry:
             retry = np.flatnonzero((n_markers > _MAX_MARKERS) & ~fallback)
             if retry.size > 0:
                 thresholds, _ = _compute_thresholds(

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -95,6 +95,14 @@ class SourceFinder:
         consecutive order starting from 1. This keyword is ignored
         unless ``deblend=True``.
 
+    n_threads : int, optional
+        The number of threads to use to deblend the sources. The
+        default is 1 (no multithreading). When ``n_threads`` > 1,
+        the sources are divided into chunks and processed
+        concurrently, producing results identical to the
+        single-threaded computation. This keyword is ignored unless
+        ``deblend=True``.
+
     nproc : int, optional
         This keyword is deprecated and has no effect. It was the name of
         the ``n_processes`` keyword before version 3.0.
@@ -105,7 +113,8 @@ class SourceFinder:
 
     n_processes : int, optional
         This keyword is deprecated and has no effect. Multiprocessing
-        no longer provides any benefit for source deblending.
+        no longer provides any benefit for source deblending. Use the
+        ``n_threads`` keyword instead.
 
         .. deprecated:: 3.1
             The ``n_processes`` keyword is deprecated and will be
@@ -170,6 +179,7 @@ class SourceFinder:
     @deprecated_renamed_argument('progress_bar', None, '3.1', until='4.0')
     def __init__(self, n_pixels, *, connectivity=8, deblend=True, n_levels=32,
                  contrast=0.001, mode='exponential', relabel=True,
+                 n_threads=1,
                  nproc=1,  # noqa: ARG002
                  n_processes=1, progress_bar=True):
         self.n_pixels = as_pair('n_pixels', n_pixels, check_odd=False)
@@ -179,13 +189,14 @@ class SourceFinder:
         self.contrast = contrast
         self.mode = mode
         self.relabel = relabel
+        self.n_threads = n_threads
         self.n_processes = n_processes
         self.progress_bar = progress_bar
 
     def __repr__(self):
         params = ('n_pixels', 'deblend', 'connectivity', 'n_levels',
-                  'contrast', 'mode', 'relabel', 'n_processes',
-                  'progress_bar')
+                  'contrast', 'mode', 'relabel', 'n_threads',
+                  'n_processes', 'progress_bar')
         return make_repr(self, params)
 
     # Remove in 4.0
@@ -238,6 +249,7 @@ class SourceFinder:
                                           contrast=self.contrast,
                                           mode=self.mode,
                                           connectivity=self.connectivity,
-                                          relabel=self.relabel)
+                                          relabel=self.relabel,
+                                          n_threads=self.n_threads)
 
         return segment_img

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -3,7 +3,10 @@
 Tools for detecting sources in an image.
 """
 
-from photutils.segmentation.deblend import deblend_sources
+import numpy as np
+
+from photutils.segmentation.deblend import (_validate_deblend_kwargs,
+                                            deblend_sources)
 from photutils.segmentation.detect import detect_sources
 from photutils.utils._deprecation import (deprecated_getattr,
                                           deprecated_positional_kwargs,
@@ -183,6 +186,13 @@ class SourceFinder:
                  nproc=1,  # noqa: ARG002
                  n_processes=1, progress_bar=True):
         self.n_pixels = as_pair('n_pixels', n_pixels, check_odd=False)
+        for name, value in (('deblend', deblend), ('relabel', relabel)):
+            if not isinstance(value, (bool, np.bool_)):
+                msg = f'{name} must be a boolean, got {value!r}'
+                raise TypeError(msg)
+        _validate_deblend_kwargs(n_levels=n_levels, contrast=contrast,
+                                 mode=mode, connectivity=connectivity,
+                                 n_threads=n_threads)
         self.deblend = deblend
         self.connectivity = connectivity
         self.n_levels = n_levels

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -789,6 +789,42 @@ def test_chunk_driver_matches_python_path(dtype, scene):
     assert result._flags_map == expected._flags_map
 
 
+def test_n_threads_identical():
+    """
+    Test that multithreaded deblending produces results identical to
+    the single-threaded computation, including when there are more
+    threads than sources.
+    """
+    y, x = np.mgrid[0:101, 0:301]
+    data = (Gaussian2D(100, 50, 50, 5, 5)(x, y)
+            + Gaussian2D(100, 35, 50, 5, 5)(x, y)
+            + Gaussian2D(80, 150, 50, 5, 5)(x, y)
+            + Gaussian2D(60, 165, 50, 5, 5)(x, y)
+            + Gaussian2D(50, 250, 50, 5, 5)(x, y))
+    segm = detect_sources(data, 10, 5)
+    assert segm.n_labels == 3
+
+    expected = deblend_sources(data, segm, 5)
+    assert expected.n_labels == 5
+    for n_threads in (2, 3, 64):
+        result = deblend_sources(data, segm, 5, n_threads=n_threads)
+        assert_equal(result.data, expected.data)
+        assert result._flags_map == expected._flags_map
+        assert_equal(result.parent_to_deblended_labels,
+                     expected.parent_to_deblended_labels)
+
+
+@pytest.mark.parametrize('n_threads', [0, -1, 1.5])
+def test_n_threads_invalid(n_threads):
+    """
+    Test that invalid n_threads values raise a ValueError.
+    """
+    data, segm = make_multipeak_source()
+    match = 'n_threads must be a positive integer'
+    with pytest.raises(ValueError, match=match):
+        deblend_sources(data, segm, 5, n_threads=n_threads)
+
+
 def test_deblend_segm_dtype():
     """
     Test that deblending a segmentation image with a non-native

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -689,7 +689,8 @@ def python_deblend_chunk(data, segm_data, driver_data,  # noqa: ARG001
                                    'gaussian', 'flat',
                                    'contrast-batch', 'contrast-single',
                                    'contrast-all', 'contrast-negmin',
-                                   'neighbors', 'nan'])
+                                   'neighbors', 'nan',
+                                   'checkerboard-linear'])
 def test_chunk_driver_matches_python_path(dtype, scene):
     """
     Test that the compiled chunk driver and contrast loop produce
@@ -704,10 +705,12 @@ def test_chunk_driver_matches_python_path(dtype, scene):
     removal, the one-at-a-time removal, the removal of all but one
     basin, and the removal path for sources with a negative minimum
     (which always removes one marker at a time), a scene of several
-    segments with overlapping bounding boxes, and NaN pixels within a
-    segment.
+    segments with overlapping bounding boxes, NaN pixels within a
+    segment, and the checkerboard deblended in linear mode, which keeps
+    all of its markers instead of falling back.
     """
     contrast = 0.001
+    mode = 'linear' if scene == 'checkerboard-linear' else 'exponential'
     if scene == 'blend':
         data = make_marker_test_image('blend')
         threshold, n_pixels = 0.5, 5
@@ -773,11 +776,11 @@ def test_chunk_driver_matches_python_path(dtype, scene):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeblendWarning)
         result = deblend_sources(data, segm, n_pixels,
-                                 contrast=contrast)
+                                 contrast=contrast, mode=mode)
         with patch.object(deblend_module, '_deblend_sources_chunk',
                           python_deblend_chunk):
             expected = deblend_sources(data, segm, n_pixels,
-                                       contrast=contrast)
+                                       contrast=contrast, mode=mode)
 
     assert_equal(result.data, expected.data)
     assert result.info.keys() == expected.info.keys()

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -792,8 +792,9 @@ def test_chunk_driver_matches_python_path(dtype, scene):
 def test_n_threads_identical():
     """
     Test that multithreaded deblending produces results identical to
-    the single-threaded computation, including when there are more
-    threads than sources.
+    the single-threaded computation, including the mode-fallback
+    warning, info, and flags, and when there are more threads than
+    sources.
     """
     y, x = np.mgrid[0:101, 0:301]
     data = (Gaussian2D(100, 50, 50, 5, 5)(x, y)
@@ -803,18 +804,49 @@ def test_n_threads_identical():
             + Gaussian2D(50, 250, 50, 5, 5)(x, y))
     segm = detect_sources(data, 10, 5)
     assert segm.n_labels == 3
+    data -= 20  # non-positive minima trigger the mode fallback
 
-    expected = deblend_sources(data, segm, 5)
+    match = 'The deblending mode of one or more source labels'
+    with pytest.warns(DeblendWarning, match=match):
+        expected = deblend_sources(data, segm, 5)
     assert expected.n_labels == 5
+    assert_equal(expected.info['nonposmin_labels'], [1, 2, 3])
     for n_threads in (2, 3, 64):
-        result = deblend_sources(data, segm, 5, n_threads=n_threads)
+        with pytest.warns(DeblendWarning, match=match) as record:
+            result = deblend_sources(data, segm, 5, n_threads=n_threads)
+        assert len(record) == 1
         assert_equal(result.data, expected.data)
         assert result._flags_map == expected._flags_map
         assert_equal(result.parent_to_deblended_labels,
                      expected.parent_to_deblended_labels)
+        assert result.info.keys() == expected.info.keys()
+        for key in expected.info:
+            assert_equal(result.info[key], expected.info[key])
 
 
-@pytest.mark.parametrize('n_threads', [0, -1, 1.5])
+def test_n_threads_worker_error():
+    """
+    Test that an error raised while deblending a chunk in a worker
+    thread propagates to the caller.
+    """
+    tile = np.zeros((51, 51))
+    tile[15:36, 15:36] = 10.0
+    tile[13, 13] = 10.0
+    tile[14, 14] = 5.0
+    tile[36, 36] = 10.0
+    tile[37, 37] = 10.0
+    data = np.zeros((51, 120))
+    data[:, :51] = tile
+    data[:, 60:111] = tile
+    segm = detect_sources(data, 0.1, 1, connectivity=8)
+    assert segm.n_labels == 2
+    match = 'Deblending failed for source'
+    with pytest.raises(ValueError, match=match):
+        deblend_sources(data, segm, 1, mode='linear', connectivity=4,
+                        n_threads=2)
+
+
+@pytest.mark.parametrize('n_threads', [0, -1, 1.5, True])
 def test_n_threads_invalid(n_threads):
     """
     Test that invalid n_threads values raise a ValueError.

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -113,6 +113,21 @@ def test_finder_deprecations():
         assert len(record) == 1
 
 
+def test_finder_n_threads():
+    """
+    Test that SourceFinder n_threads produces results identical to
+    the single-threaded computation.
+    """
+    yy, xx = np.mgrid[0:101, 0:101]
+    data = (Gaussian2D(100, 50, 50, 5, 5)(xx, yy)
+            + Gaussian2D(100, 35, 50, 5, 5)(xx, yy))
+    expected = SourceFinder(n_pixels=5)(data, 10)
+    finder = SourceFinder(n_pixels=5, n_threads=4)
+    assert 'n_threads=4' in repr(finder)
+    segm = finder(data, 10)
+    np.testing.assert_array_equal(segm.data, expected.data)
+
+
 def test_finder_flags_passthrough():
     """
     Test that deblending provenance flags survive the SourceFinder

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -9,6 +9,7 @@ import pytest
 from astropy.convolution import convolve
 from astropy.modeling.models import Gaussian2D
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from numpy.testing import assert_equal
 
 from photutils.datasets import make_100gaussians_image
 from photutils.segmentation.finder import SourceFinder
@@ -125,7 +126,34 @@ def test_finder_n_threads():
     finder = SourceFinder(n_pixels=5, n_threads=4)
     assert 'n_threads=4' in repr(finder)
     segm = finder(data, 10)
-    np.testing.assert_array_equal(segm.data, expected.data)
+    assert_equal(segm.data, expected.data)
+
+
+@pytest.mark.parametrize(('kwargs', 'match'), [
+    ({'connectivity': 3}, 'Invalid connectivity'),
+    ({'n_levels': 0}, 'n_levels must be a positive integer'),
+    ({'n_levels': 2.5}, 'n_levels must be a positive integer'),
+    ({'contrast': 1.5}, 'contrast must be'),
+    ({'mode': 'invalid'}, 'mode must be'),
+    ({'n_threads': 0}, 'n_threads must be a positive integer'),
+    ({'n_threads': True}, 'n_threads must be a positive integer'),
+])
+def test_finder_invalid_kwargs(kwargs, match):
+    """
+    Test that invalid keyword values are rejected at construction.
+    """
+    with pytest.raises(ValueError, match=match):
+        SourceFinder(n_pixels=5, **kwargs)
+
+
+@pytest.mark.parametrize('name', ['deblend', 'relabel'])
+def test_finder_invalid_bool_kwargs(name):
+    """
+    Test that the boolean keywords must be booleans.
+    """
+    with pytest.raises(TypeError, match=f'{name} must be a boolean'):
+        SourceFinder(n_pixels=5, **{name: 'yes'})
+    assert SourceFinder(n_pixels=5, **{name: np.True_}) is not None
 
 
 def test_finder_flags_passthrough():


### PR DESCRIPTION
This PR adds an ``n_threads`` keyword to ``deblend_sources`` and ``SourceFinder`` to deblend the sources using multiple threads. The sources are divided into chunks and processed concurrently, producing results identical to the single-threaded computation. The marker-building kernels release the GIL, as do the watershed and most of the array operations, so multithreading can significantly speed up deblending, especially for large sources.