### PR TITLE
Change deblending-mode fallback to use "sinh"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1044,6 +1044,17 @@ API Changes
     slower than the serial implementation at any number of sources.
     [#2408]
 
+  - The ``deblend_sources`` and ``SourceFinder`` deblending-mode
+    fallback for sources with non-positive minimum data values (used
+    with ``mode='exponential'``, for which such sources are
+    undefined) was changed from "linear" to "sinh". The sinh
+    spacing keeps the threshold levels concentrated near the source
+    minimum, recovering faint companions of bright sources that the
+    linear spacing misses, so deblending results can change for the
+    affected sources. The ``'nonposmin_labels'`` info key and the
+    ``deblend_nonposmin`` flag are unchanged and continue to record
+    the affected sources. [#2410]
+
 - ``photutils.utils``
 
   - The ``ShepardIDWInterpolator`` ``ncoords`` attribute has been

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -314,8 +314,8 @@ New Features
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's
     ``AstropyUserWarning``, which is raised by ``deblend_sources``
-    when the deblending mode is changed to "linear" for one or more
-    sources. [#2378]
+    when the deblending mode is changed to a fallback mode for one or
+    more sources. [#2378]
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -833,7 +833,7 @@ quality flags via its ``flags`` attribute (also included in the default
 table columns). The flags combine deblending provenance recorded by
 :func:`~photutils.segmentation.deblend_sources` (e.g., whether a source
 was produced by deblending, or whether its deblending mode fell back
-to "linear") with measurement-time conditions: the source touches
+to another mode) with measurement-time conditions: the source touches
 an image boundary, masked or non-finite pixels within the segment,
 undefined or degenerate shape properties, windowed or quadratic
 centroid failures, and Kron-aperture issues (``kron_``-prefixed

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -765,7 +765,10 @@ concentrated near the source minimum, recovering faint companions of
 bright sources that the linear spacing misses. Deblending results can
 therefore change for the affected sources, which continue to be recorded
 under the ``'nonposmin_labels'`` key of the ``info`` attribute and
-flagged with ``deblend_nonposmin``.
+flagged with ``deblend_nonposmin``. To reproduce the previous spacing
+for such sources, pass ``mode='linear'``. Note that this applies the
+linear spacing to every source, which is the only way to obtain the
+previous behavior.
 
 PSF ``decode_flags`` Methods Return a Dictionary
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -841,9 +844,9 @@ Deblending Warning Information
 
 `~photutils.segmentation.deblend_sources` now emits a
 `~photutils.utils.DeblendWarning` (a subclass of astropy's
-``AstropyUserWarning``) when the deblending mode is changed to "linear"
-for one or more sources. The affected input labels are now stored as
-arrays directly under ``'nonposmin_labels'`` and ``'n_markers_labels'``
-keys in the returned `~photutils.segmentation.SegmentationImage`
-``info`` dictionary, replacing the nested ``info['warnings']``
-dictionary.
+``AstropyUserWarning``) when the deblending mode is changed
+to a fallback mode for one or more sources. The affected
+input labels are now stored as arrays directly under
+``'nonposmin_labels'`` and ``'n_markers_labels'`` keys in the returned
+`~photutils.segmentation.SegmentationImage` ``info`` dictionary,
+replacing the nested ``info['warnings']`` dictionary.

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -753,6 +753,20 @@ Removed Deprecations
 Breaking Changes
 ----------------
 
+Deblending Fallback for Non-Positive Minima Changed to sinh
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When deblending with ``mode='exponential'`` (the default), sources with
+non-positive minimum data values cannot use the exponential threshold
+spacing and fall back to another mode. The fallback mode has changed
+from "linear" to "sinh". Like the linear spacing, the sinh spacing is
+well defined for any data values, but it keeps the threshold levels
+concentrated near the source minimum, recovering faint companions of
+bright sources that the linear spacing misses. Deblending results can
+therefore change for the affected sources, which continue to be recorded
+under the ``'nonposmin_labels'`` key of the ``info`` attribute and
+flagged with ``deblend_nonposmin``.
+
 PSF ``decode_flags`` Methods Return a Dictionary
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/segmentation/_deblend_reference.py
+++ b/photutils/segmentation/_deblend_reference.py
@@ -156,7 +156,7 @@ class _SingleSourceDeblender:
 
         Note that this method has side effects. When the mode is
         "exponential" and the source minimum is non-positive, it
-        changes ``self.mode`` to "linear" and records the fallback in
+        changes ``self.mode`` to "sinh" and records the fallback in
         ``self.warnings``. Later calls (e.g., from ``make_markers``)
         therefore use the fallback mode, mirroring the sticky per-source
         mode fallback in the compiled pipeline.
@@ -167,8 +167,11 @@ class _SingleSourceDeblender:
             The multi-level detection thresholds for the source.
         """
         if self.mode == 'exponential' and self.source_min <= 0:
+            # The exponential spacing is undefined for non-positive
+            # minima. sinh keeps the levels concentrated near the
+            # source minimum and is defined for any data values.
             self.warnings['nonposmin'] = 'non-positive minimum'
-            self.mode = 'linear'
+            self.mode = 'sinh'
 
         if self.mode == 'linear':
             thresholds = self.linear_thresholds

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -360,10 +360,9 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
     if nonposmin_labels or n_markers_labels:
         msg = ('The deblending mode of one or more source labels from the '
                f'input segmentation image was changed from "{mode}" to a '
-               'fallback mode ("sinh" for non-positive minimum data '
-               'values, "linear" for too many potential deblended '
-               'sources). See the "info" attribute of the returned '
-               'segmentation image for the affected input labels.')
+               'fallback mode. See the "info" attribute of the returned '
+               'segmentation image for the affected input labels and the '
+               '"mode" documentation for the fallback rules.')
         warnings.warn(msg, DeblendWarning)
 
     relabel_map = None
@@ -474,6 +473,9 @@ def _compute_thresholds(source_min, source_max, n_levels, mode):
     if mode != 'linear':
         delta = source_max - source_min
         normalized = (thresholds - source_min[:, None]) / delta[:, None]
+        # The exponential rows keep the data dtype of the reference
+        # implementation (widened exactly below) while the sinh rows
+        # are float64, so the rows are combined in float64
         thresholds = thresholds.astype(np.float64)
         if mode == 'exponential':
             use_sinh = nonposmin

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -148,8 +148,10 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         the ``'exponential'`` levels are dependent on the source
         maximum/minimum ratio (smaller ratios are more linear and
         larger ratios are more exponential), while the ``'sinh'`` levels
-        are not. Also, the ``'exponential'`` mode will be changed to
-        ``'linear'`` for sources with non-positive minimum data values.
+        are not. Unlike the ``'exponential'`` mode, the ``'sinh'``
+        and ``'linear'`` modes are well defined for sources with
+        non-positive minimum data values. For such sources, the
+        ``'exponential'`` mode will be changed to ``'sinh'``.
 
     connectivity : {8, 4}, optional
         The type of pixel connectivity used in determining how pixels
@@ -210,20 +212,22 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         sources are marked by different positive integer values. A value
         of zero is reserved for the background. The ``info`` attribute
         of the returned segmentation image is a dictionary that stores
-        the input labels for which the deblending mode was changed to
-        "linear" as arrays under ``'nonposmin_labels'`` (non-positive
-        minimum data values) and ``'n_markers_labels'`` (too many
-        potential deblended sources) keys. The dictionary is empty if no
-        mode fallbacks occurred. The ``flags`` attribute of the returned
+        the input labels for which the deblending mode was changed
+        to a fallback mode as arrays under ``'nonposmin_labels'``
+        (non-positive minimum data values, changed to "sinh") and
+        ``'n_markers_labels'`` (too many potential deblended sources,
+        changed to "linear") keys. The dictionary is empty if no mode
+        fallbacks occurred. The ``flags`` attribute of the returned
         segmentation image records per-source deblending provenance. See
         `~photutils.segmentation.decode_segmentation_flags`.
 
     Warns
     -----
     DeblendWarning
-        If the deblending mode for one or more sources was changed from
-        ``mode`` to "linear" due to non-positive minimum data values or
-        too many potential deblended sources.
+        If the deblending mode for one or more sources was changed
+        from ``mode`` to "sinh" due to non-positive minimum data
+        values or to "linear" due to too many potential deblended
+        sources.
 
     See Also
     --------
@@ -355,8 +359,10 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
 
     if nonposmin_labels or n_markers_labels:
         msg = ('The deblending mode of one or more source labels from the '
-               f'input segmentation image was changed from "{mode}" to '
-               '"linear". See the "info" attribute of the returned '
+               f'input segmentation image was changed from "{mode}" to a '
+               'fallback mode ("sinh" for non-positive minimum data '
+               'values, "linear" for too many potential deblended '
+               'sources). See the "info" attribute of the returned '
                'segmentation image for the affected input labels.')
         warnings.warn(msg, DeblendWarning)
 
@@ -445,7 +451,7 @@ def _compute_thresholds(source_min, source_max, n_levels, mode):
 
     mode : {'exponential', 'linear', 'sinh'}
         The level spacing. For the ``'exponential'`` mode, the sources
-        with a non-positive minimum use the ``'linear'`` spacing.
+        with a non-positive minimum use the ``'sinh'`` spacing.
 
     Returns
     -------
@@ -455,7 +461,7 @@ def _compute_thresholds(source_min, source_max, n_levels, mode):
         minimum and maximum are excluded.
 
     nonposmin : 1D bool `~numpy.ndarray`
-        Whether each source fell back to the ``'linear'`` spacing
+        Whether each source fell back to the ``'sinh'`` spacing
         because of a non-positive minimum.
     """
     source_min = np.asarray(source_min)
@@ -468,16 +474,25 @@ def _compute_thresholds(source_min, source_max, n_levels, mode):
     if mode != 'linear':
         delta = source_max - source_min
         normalized = (thresholds - source_min[:, None]) / delta[:, None]
-        if mode == 'sinh':
-            a = 0.25
-            thresholds = np.sinh(normalized / a) / np.sinh(1.0 / a)
-            thresholds *= delta[:, None]
-            thresholds += source_min[:, None]
-        else:
+        thresholds = thresholds.astype(np.float64)
+        if mode == 'exponential':
+            use_sinh = nonposmin
             keep = ~nonposmin
             ratio = source_max[keep] / source_min[keep]
             thresholds[keep] = (source_min[keep, None]
                                 * ratio[:, None] ** normalized[keep])
+        else:
+            use_sinh = np.ones(source_min.shape, dtype=bool)
+        if np.any(use_sinh):
+            # The exponential spacing is undefined for non-positive
+            # minima, so those sources use the sinh spacing, which
+            # keeps the levels concentrated near the source minimum and
+            # is defined for any data values
+            a = 0.25
+            levels = np.sinh(normalized[use_sinh] / a) / np.sinh(1.0 / a)
+            levels *= delta[use_sinh, None]
+            levels += source_min[use_sinh, None]
+            thresholds[use_sinh] = levels
 
     # Do not include the source minimum and maximum
     return (np.ascontiguousarray(thresholds[:, 1:-1], dtype=np.float64),
@@ -565,11 +580,9 @@ def _deblend_sources_chunk(data, segm_data, driver_data, driver_segm,
             markers_list[index] = source_markers
 
         # Too many markers make the watershed step very slow, so such
-        # sources are deblended again with linearly spaced levels. A
-        # source that already fell back to the linear spacing keeps its
-        # markers
+        # sources are deblended again with linearly spaced levels
         if can_retry:
-            retry = np.flatnonzero((n_markers > _MAX_MARKERS) & ~fallback)
+            retry = np.flatnonzero(n_markers > _MAX_MARKERS)
             if retry.size > 0:
                 thresholds, _ = _compute_thresholds(
                     smin[retry], smax[retry], n_levels, 'linear')

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -88,9 +88,11 @@ class SourceFinder:
         the ``'exponential'`` levels are dependent on the source
         maximum/minimum ratio (smaller ratios are more linear and
         larger ratios are more exponential), while the ``'sinh'`` levels
-        are not. Also, the ``'exponential'`` mode will be changed to
-        ``'linear'`` for sources with non-positive minimum data values.
-        This keyword is ignored unless ``deblend=True``.
+        are not. Unlike the ``'exponential'`` mode, the ``'sinh'``
+        and ``'linear'`` modes are well defined for sources with
+        non-positive minimum data values. For such sources, the
+        ``'exponential'`` mode will be changed to ``'sinh'``. This
+        keyword is ignored unless ``deblend=True``.
 
     relabel : bool, optional
         If `True` (default), then the segmentation image will be

--- a/photutils/segmentation/flags.py
+++ b/photutils/segmentation/flags.py
@@ -100,11 +100,11 @@ class _SegmentationFlags(FlagRegistry):
         FlagDefinition(
             bit_value=64,
             name='deblend_nonposmin',
-            description=('deblending mode changed to linear: '
+            description=('deblending mode changed to sinh: '
                          'non-positive minimum'),
             detailed_description=('The deblending mode for the '
                                   'parent source was changed to '
-                                  '"linear" because of a '
+                                  '"sinh" because of a '
                                   'non-positive minimum data value '
                                   'within the parent source '
                                   'segment.'),

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -690,7 +690,8 @@ def python_deblend_chunk(data, segm_data, driver_data,  # noqa: ARG001
                                    'contrast-batch', 'contrast-single',
                                    'contrast-all', 'contrast-negmin',
                                    'neighbors', 'nan',
-                                   'checkerboard-linear'])
+                                   'checkerboard-linear',
+                                   'checkerboard-negmin'])
 def test_chunk_driver_matches_python_path(dtype, scene):
     """
     Test that the compiled chunk driver and contrast loop produce
@@ -706,8 +707,10 @@ def test_chunk_driver_matches_python_path(dtype, scene):
     basin, and the removal path for sources with a negative minimum
     (which always removes one marker at a time), a scene of several
     segments with overlapping bounding boxes, NaN pixels within a
-    segment, and the checkerboard deblended in linear mode, which keeps
-    all of its markers instead of falling back.
+    segment, the checkerboard deblended in linear mode, which keeps
+    all of its markers instead of falling back, and the checkerboard
+    with a non-positive minimum, which falls back to sinh and is then
+    retried with linear levels.
     """
     contrast = 0.001
     mode = 'linear' if scene == 'checkerboard-linear' else 'exponential'
@@ -766,6 +769,10 @@ def test_chunk_driver_matches_python_path(dtype, scene):
 
     data = data.astype(dtype)
     segm = detect_sources(data, threshold, n_pixels)
+    if scene == 'checkerboard-negmin':
+        # A non-positive minimum (sinh fallback) combined with too many
+        # markers (linear retry), applied after the detection
+        data = data - 2
     if scene == 'nan':
         # NaN pixels within the segment, set after the detection
         rng = np.random.default_rng(11)

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -932,6 +932,37 @@ def test_compute_thresholds_matches_reference(dtype, mode, n_levels):
         assert nonposmin[i] == ('nonposmin' in deblender.warnings)
 
 
+def test_nonposmin_fallback_sinh():
+    """
+    Test that the non-positive-minimum fallback uses sinh mode.
+
+    The sinh spacing keeps the threshold levels concentrated near the
+    source minimum, recovering a faint companion of a bright source that
+    the linear spacing misses.
+    """
+    y, x = np.mgrid[0:61, 0:81]
+    data = (Gaussian2D(1000, 36, 30, 1.7, 1.7)(x, y)
+            + Gaussian2D(20, 44, 30, 1.7, 1.7)(x, y) - 1.2)
+    segm = detect_sources(data, -0.2, 5)
+    assert segm.n_labels == 1
+
+    match = 'The deblending mode of one or more source labels'
+    with pytest.warns(DeblendWarning, match=match):
+        result = deblend_sources(data, segm, 5, mode='exponential',
+                                 contrast=1e-6)
+    assert result.n_labels == 2
+    assert_equal(result.info['nonposmin_labels'], [1])
+    bit = SEGMENTATION_FLAGS.DEBLEND_NONPOSMIN
+    assert_equal(result.flags & bit, [bit, bit])
+
+    # The linear mode does not recover this companion, so the sinh
+    # fallback is a real sensitivity improvement over the previous
+    # linear fallback.
+    result_linear = deblend_sources(data, segm, 5, mode='linear',
+                                    contrast=1e-6)
+    assert result_linear.n_labels == 1
+
+
 def test_python_path_connectivity_mismatch():
     """
     Test that the pure-Python reference path raises the same error


### PR DESCRIPTION
The ``deblend_sources`` and ``SourceFinder`` deblending-mode fallback for sources with non-positive minimum data values (used with ``mode='exponential'``, for which such sources are undefined) was changed from "linear" to "sinh". The sinh spacing keeps the threshold levels concentrated near the source minimum, recovering faint companions of bright sources that the linear spacing misses, so deblending results can change for the affected sources.