### PR TITLE
Add contrast_method keyword to deblend_sources and SourceFinder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -311,14 +311,14 @@ New Features
     sources. [#2409]
 
   - Added a ``contrast_method`` keyword to ``deblend_sources`` and
-    ``SourceFinder`` to select the flux used by the deblending
-    contrast criterion. The default of `None` currently resolves
-    to ``'basin'``, which preserves the existing behavior (the
-    fraction is the total flux in the source's watershed basin, with
-    iterative removal of below-contrast basins), and may change to
-    ``'saddle'`` in version 4.0. The new
-    ``'saddle'`` method instead measures the flux a source holds above
-    the saddle level where it separates from its neighbors. [#2411]
+    ``SourceFinder`` to select the flux used by the deblending contrast
+    criterion. The default of `None` currently resolves to ``'basin'``,
+    which preserves the existing behavior (the fraction is the total
+    flux in the source's watershed basin, with iterative removal of
+    below-contrast basins), and may change to ``'saddle'`` in version
+    4.0. The new ``'saddle'`` method instead measures the flux a source
+    holds above the saddle level where it separates from its neighbors.
+    [#2411]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -310,6 +310,14 @@ New Features
     can significantly speed up deblending, especially for large
     sources. [#2409]
 
+  - Added a ``contrast_method`` keyword to ``deblend_sources`` and
+    ``SourceFinder`` to select the flux used by the deblending
+    contrast criterion. The default ``'basin'`` preserves the existing
+    behavior (the fraction is the total flux in the source's watershed
+    basin, with iterative removal of below-contrast basins). The new
+    ``'saddle'`` method instead measures the flux a source holds above
+    the saddle level where it separates from its neighbors. [#2411]
+
 - ``photutils.utils``
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -312,9 +312,11 @@ New Features
 
   - Added a ``contrast_method`` keyword to ``deblend_sources`` and
     ``SourceFinder`` to select the flux used by the deblending
-    contrast criterion. The default ``'basin'`` preserves the existing
-    behavior (the fraction is the total flux in the source's watershed
-    basin, with iterative removal of below-contrast basins). The new
+    contrast criterion. The default of `None` currently resolves
+    to ``'basin'``, which preserves the existing behavior (the
+    fraction is the total flux in the source's watershed basin, with
+    iterative removal of below-contrast basins), and may change to
+    ``'saddle'`` in version 4.0. The new
     ``'saddle'`` method instead measures the flux a source holds above
     the saddle level where it separates from its neighbors. [#2411]
 

--- a/benchmarks/bench_deblend.py
+++ b/benchmarks/bench_deblend.py
@@ -529,6 +529,63 @@ def bench_threads(*, n_sources=4000, size=1000, n_peaks=25,
         print(f'{name:>24}{cells}')
 
 
+def bench_contrast_method(*, n_sources=4000, size=1000, n_peaks=100,
+                          repeats=3, seed=0):
+    """
+    Benchmark the basin and saddle contrast criteria.
+
+    The saddle criterion selects the markers in the component tree
+    and floods once, while the basin criterion floods and then
+    iteratively removes below-contrast basins, so the interesting
+    comparisons are the removal-heavy large-segment cases.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources for the many-source
+        scene.
+
+    size : int, optional
+        The image size for the large-segment scene.
+
+    n_peaks : int, optional
+        The number of compact peaks in the large segment.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    _, data, segm = make_inputs(n_sources, seed=seed)
+    blend_data, blend_segm = make_blended_inputs(size, n_peaks,
+                                                 seed=seed)
+
+    print('\n== deblend_sources: contrast_method ==')
+    print(f'{"benchmark":>40}{"basin":>18}{"saddle":>18}')
+    cases = [
+        (f'{segm.n_labels} small segments, c=0.001', data, segm,
+         0.001),
+        (f'{n_peaks}-peak segment, c=0.001', blend_data, blend_segm,
+         0.001),
+        (f'{n_peaks}-peak segment, c=0.01', blend_data, blend_segm,
+         0.01),
+        (f'{n_peaks}-peak segment, c=0.03', blend_data, blend_segm,
+         0.03),
+    ]
+    for name, case_data, case_segm, contrast in cases:
+        cells = []
+        for method in ('basin', 'saddle'):
+            bench = partial(deblend_sources, case_data, case_segm,
+                            N_PIXELS, contrast=contrast,
+                            contrast_method=method)
+            result = bench()
+            t_best = time_best(bench, repeats=repeats)
+            cells.append(f'{t_best:.4f}s ({result.n_labels})')
+        row = ''.join(f'{cell:>18}' for cell in cells)
+        print(f'{name:>40}{row}')
+
+
 def main():
     """
     Run the source deblending benchmarks.
@@ -563,7 +620,7 @@ def main():
                              '(default: %(default)s)')
     parser.add_argument('--which', default='all',
                         choices=['all', 'many', 'large', 'peaks',
-                                 'stages', 'threads', 'profile'],
+                                 'stages', 'threads', 'criterion', 'profile'],
                         help='which benchmark to run '
                              '(default: %(default)s)')
     args = parser.parse_args()
@@ -587,6 +644,8 @@ def main():
     if args.which in ('all', 'threads'):
         bench_threads(thread_counts=args.n_threads,
                       repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'criterion'):
+        bench_contrast_method(repeats=args.repeats, seed=args.seed)
     if args.which == 'profile':
         bench_profile(seed=args.seed)
 

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -155,8 +155,13 @@ watershed assigns to the source, including its share of any surrounding
 envelope. Basins below the contrast are removed iteratively and their
 territory is re-flooded. With the ``'saddle'`` method, it is only
 the flux the source holds above the saddle level where it separates
-from its neighbors, which is equivalent to the `SourceExtractor`_
-``DEBLEND_MINCONT`` criterion. The saddle flux measures the significance
+from its neighbors. This is the significance criterion that
+`SourceExtractor`_ applies with its ``DEBLEND_MINCONT`` parameter,
+although the two codes space their threshold levels differently
+(SourceExtractor between the detection threshold and the peak,
+photutils between the source minimum and maximum) and assign the
+remaining pixels differently (SourceExtractor with a profile model,
+photutils with a watershed). The saddle flux measures the significance
 of the peak itself, independently of how much envelope territory the
 source would inherit, which makes it stricter for faint peaks sitting
 on bright envelopes. Because it excludes the flux below the saddle, the

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -148,6 +148,26 @@ and ``contrast``. ``n_levels`` is the number of multi-thresholding
 levels to use. ``contrast`` is the fraction of the total source flux
 that a local peak must have to be considered as a separate object.
 
+The ``contrast_method`` keyword selects the flux to which the
+``contrast`` fraction refers. With the ``'basin'`` method, it is the
+total flux in the source's watershed basin, i.e., everything the
+watershed assigns to the source, including its share of any surrounding
+envelope. Basins below the contrast are removed iteratively and their
+territory is re-flooded. With the ``'saddle'`` method, it is only
+the flux the source holds above the saddle level where it separates
+from its neighbors, which is equivalent to the `SourceExtractor`_
+``DEBLEND_MINCONT`` criterion. The saddle flux measures the significance
+of the peak itself, independently of how much envelope territory the
+source would inherit, which makes it stricter for faint peaks sitting
+on bright envelopes. Because it excludes the flux below the saddle, the
+same ``contrast`` value selects sources differently between the two
+methods. The saddle method is evaluated once during marker construction
+and needs only a single watershed pass, so it is never slower than
+the basin method and is substantially faster when many below-contrast
+basins would otherwise be removed one at a time. The default of
+`None` currently resolves to ``'basin'``. The default may change to
+``'saddle'`` in version 4.0.
+
 Here's a simple example of source deblending::
 
     >>> from photutils.segmentation import deblend_sources

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -671,15 +671,19 @@ computation. The compiled kernels release the GIL, so multithreading can
 significantly speed up deblending, especially for large sources.
 
 A new ``contrast_method`` keyword selects the flux used by the
-deblending contrast criterion. The default ``'basin'`` preserves
-the existing behavior: the contrast fraction is the total flux
-in the source's watershed basin, and below-contrast basins are
-removed iteratively. The new ``'saddle'`` method instead measures
-the flux a source holds above the saddle level where it separates
-from its neighbors. It measures the significance of the peak itself,
-independently of how much envelope territory the source would inherit
-from the watershed, and requires only a single watershed pass, so it is
-also faster.
+deblending contrast criterion. The ``'basin'`` method preserves
+the existing behavior where the contrast fraction is the total
+flux in the source's watershed basin, and below-contrast basins
+are removed iteratively. The new ``'saddle'`` method instead
+measures the flux a source holds above the saddle level where it
+separates from its neighbors, equivalent to the SourceExtractor
+``DEBLEND_MINCONT`` criterion. It measures the significance of the
+peak itself, independently of how much envelope territory the source
+would inherit from the watershed, and requires only a single watershed
+pass, so it is never slower and is substantially faster when many
+below-contrast basins would otherwise be removed iteratively. The
+default of `None` currently resolves to ``'basin'``. The default may
+change to ``'saddle'`` in version 4.0.
 
 
 ``GriddedPSFModel`` Performance Improvements

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -671,19 +671,20 @@ computation. The compiled kernels release the GIL, so multithreading can
 significantly speed up deblending, especially for large sources.
 
 A new ``contrast_method`` keyword selects the flux used by the
-deblending contrast criterion. The ``'basin'`` method preserves
-the existing behavior where the contrast fraction is the total
-flux in the source's watershed basin, and below-contrast basins
-are removed iteratively. The new ``'saddle'`` method instead
-measures the flux a source holds above the saddle level where it
-separates from its neighbors, equivalent to the SourceExtractor
-``DEBLEND_MINCONT`` criterion. It measures the significance of the
-peak itself, independently of how much envelope territory the source
-would inherit from the watershed, and requires only a single watershed
-pass, so it is never slower and is substantially faster when many
-below-contrast basins would otherwise be removed iteratively. The
-default of `None` currently resolves to ``'basin'``. The default may
-change to ``'saddle'`` in version 4.0.
+deblending contrast criterion. The ``'basin'`` method preserves the
+existing behavior where the contrast fraction is the total flux in
+the source's watershed basin, and below-contrast basins are removed
+iteratively. The new ``'saddle'`` method instead measures the flux
+a source holds above the saddle level where it separates from its
+neighbors, the significance criterion that SourceExtractor applies
+with its ``DEBLEND_MINCONT`` parameter (the threshold levels and the
+assignment of the remaining pixels differ between the two codes). It
+measures the significance of the peak itself, independently of how much
+envelope territory the source would inherit from the watershed, and
+requires only a single watershed pass, so it is never slower and is
+substantially faster when many below-contrast basins would otherwise
+be removed iteratively. The default of `None` currently resolves to
+``'basin'``. The default may change to ``'saddle'`` in version 4.0.
 
 
 ``GriddedPSFModel`` Performance Improvements

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -670,6 +670,17 @@ concurrently, producing results identical to the single-threaded
 computation. The compiled kernels release the GIL, so multithreading can
 significantly speed up deblending, especially for large sources.
 
+A new ``contrast_method`` keyword selects the flux used by the
+deblending contrast criterion. The default ``'basin'`` preserves
+the existing behavior: the contrast fraction is the total flux
+in the source's watershed basin, and below-contrast basins are
+removed iteratively. The new ``'saddle'`` method instead measures
+the flux a source holds above the saddle level where it separates
+from its neighbors. It measures the significance of the peak itself,
+independently of how much envelope territory the source would inherit
+from the watershed, and requires only a single watershed pass, so it is
+also faster.
+
 
 ``GriddedPSFModel`` Performance Improvements
 ============================================

--- a/photutils/segmentation/_deblend_markers.pyx
+++ b/photutils/segmentation/_deblend_markers.pyx
@@ -60,6 +60,8 @@ cdef struct _Nodes:
     int* repr_pix
     int* child
     int* sib
+    int* area
+    double* flux
     unsigned char* kept
     Py_ssize_t n
     Py_ssize_t cap
@@ -87,6 +89,15 @@ cdef inline bint _nodes_grow(_Nodes* nodes) noexcept nogil:
     if sib == NULL:
         return False
     nodes.sib = sib
+    cdef int* area = <int*>realloc(nodes.area, cap * sizeof(int))
+    if area == NULL:
+        return False
+    nodes.area = area
+    cdef double* flux = <double*>realloc(nodes.flux,
+                                         cap * sizeof(double))
+    if flux == NULL:
+        return False
+    nodes.flux = flux
     cdef unsigned char* kept = <unsigned char*>realloc(
         nodes.kept, cap * sizeof(unsigned char))
     if kept == NULL:
@@ -111,10 +122,13 @@ cdef inline Py_ssize_t _find(int* parent, Py_ssize_t x) noexcept nogil:
     return root
 
 
-cdef inline void _union(int* parent, int* size, Py_ssize_t a,
-                        Py_ssize_t b) noexcept nogil:
+cdef inline void _union(int* parent, int* size, double* fsum,
+                        Py_ssize_t a, Py_ssize_t b) noexcept nogil:
     """
     Union the components containing ``a`` and ``b`` by size.
+
+    The per-component flux sums are also merged when a ``fsum``
+    workspace is provided.
     """
     cdef Py_ssize_t ra = _find(parent, a)
     cdef Py_ssize_t rb = _find(parent, b)
@@ -127,11 +141,16 @@ cdef inline void _union(int* parent, int* size, Py_ssize_t a,
         rb = tmp
     parent[rb] = <int>ra
     size[ra] += size[rb]
+    if fsum != NULL:
+        fsum[ra] += fsum[rb]
 
 
 cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                               Py_ssize_t nx, int n_pixels, bint conn8,
-                              int* parent, int* size,
+                              const double* posimg,
+                              const double* thresholds,
+                              double saddle_limit, bint use_saddle,
+                              int* parent, int* size, double* fsum,
                               unsigned char* added, int* stamp,
                               int* node_of_root, int* order,
                               int* flood, int* markers) noexcept nogil:
@@ -145,18 +164,25 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
     quantized level (the caller is responsible for treating the
     other ``markers`` entries as zero).
 
-    Returns the number of markers (0 if no threshold level has at
-    least two sufficiently large components), or -1 if a memory
-    allocation failed.
+    With ``use_saddle``, the markers are instead selected with the
+    saddle contrast criterion, which requires the ``posimg`` pixel
+    values, the ``thresholds`` level values, the ``fsum`` pixel-sized
+    workspace, and the ``saddle_limit`` flux (the contrast times the
+    total source flux). These may be NULL/0 otherwise.
+
+    Returns the number of markers (0 if the source does not split),
+    or -1 if a memory allocation failed.
     """
     cdef Py_ssize_t n_tot = ny * nx
     cdef Py_ssize_t result = 0
     cdef Py_ssize_t p, i, j, s, m, batch_start, nid, pid, root, nb
     cdef Py_ssize_t prev_lo, prev_hi, n_snaps, kept_cnt, base
     cdef Py_ssize_t node, chain, child, first_kept, n_kept_children
-    cdef Py_ssize_t n_stack, n_final, fs, vthr, mn, rank
+    cdef Py_ssize_t n_stack, n_final, fs, vthr, mn, rank, n_pass
     cdef Py_ssize_t py, px, dy, dx
     cdef int v, lbl
+    cdef bint splitting
+    cdef double prominence
 
     # Count the active (nonzero) pixels and the maximum level
     cdef int qmax = 0
@@ -176,6 +202,8 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
     nodes.repr_pix = <int*>malloc(nodes.cap * sizeof(int))
     nodes.child = <int*>malloc(nodes.cap * sizeof(int))
     nodes.sib = <int*>malloc(nodes.cap * sizeof(int))
+    nodes.area = <int*>malloc(nodes.cap * sizeof(int))
+    nodes.flux = <double*>malloc(nodes.cap * sizeof(double))
     nodes.kept = <unsigned char*>malloc(nodes.cap
                                         * sizeof(unsigned char))
 
@@ -195,9 +223,12 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
     cdef Py_ssize_t* min_pix = NULL
     cdef Py_ssize_t* order_rank = NULL
     cdef int* lut = NULL
+    cdef unsigned char* passer = NULL
+    cdef unsigned char* has_split = NULL
 
     if (nodes.level == NULL or nodes.repr_pix == NULL
             or nodes.child == NULL or nodes.sib == NULL
+            or nodes.area == NULL or nodes.flux == NULL
             or nodes.kept == NULL or counts == NULL or fill == NULL
             or snap_lo == NULL or snap_hi == NULL
             or snap_kept == NULL):
@@ -240,6 +271,8 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                 p = order[i]
                 parent[p] = <int>p
                 size[p] = 1
+                if use_saddle:
+                    fsum[p] = posimg[p]
                 added[p] = 1
                 py = p // nx
                 px = p % nx
@@ -255,7 +288,7 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                             continue
                         nb = p + dy * nx + dx
                         if added[nb]:
-                            _union(parent, size, p, nb)
+                            _union(parent, size, fsum, p, nb)
                 i += 1
 
             # Snapshot the components of the level set with threshold
@@ -272,6 +305,9 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                     nodes.level[nodes.n] = v - 1
                     nodes.repr_pix[nodes.n] = <int>root
                     nodes.child[nodes.n] = -1
+                    nodes.area[nodes.n] = size[root]
+                    if use_saddle:
+                        nodes.flux[nodes.n] = fsum[root]
                     nodes.kept[nodes.n] = size[root] >= n_pixels
                     kept_cnt += nodes.kept[nodes.n]
                     node_of_root[root] = <int>nodes.n
@@ -293,6 +329,9 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                     nodes.level[nodes.n] = v - 1
                     nodes.repr_pix[nodes.n] = <int>root
                     nodes.child[nodes.n] = -1
+                    nodes.area[nodes.n] = size[root]
+                    if use_saddle:
+                        nodes.flux[nodes.n] = fsum[root]
                     nodes.kept[nodes.n] = size[root] >= n_pixels
                     kept_cnt += nodes.kept[nodes.n]
                     node_of_root[root] = <int>nodes.n
@@ -307,7 +346,71 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
             prev_hi = nodes.n
             n_snaps += 1
 
-    if result == 0:
+    n_final = 0
+    if result == 0 and use_saddle:
+        # Saddle criterion: a junction splits where at least two
+        # sufficiently large children hold more flux above the junction
+        # level than the saddle limit. The markers are the passing
+        # children of splitting junctions that contain no deeper split
+        # themselves.
+        final = <Py_ssize_t*>malloc(nodes.n * sizeof(Py_ssize_t))
+        passer = <unsigned char*>malloc(nodes.n
+                                        * sizeof(unsigned char))
+        has_split = <unsigned char*>malloc(nodes.n
+                                           * sizeof(unsigned char))
+        if final == NULL or passer == NULL or has_split == NULL:
+            result = -1
+        else:
+            for nid in range(nodes.n):
+                prominence = (nodes.flux[nid]
+                              - thresholds[nodes.level[nid]]
+                              * nodes.area[nid])
+                passer[nid] = (nodes.kept[nid]
+                               and prominence > saddle_limit)
+
+            # Node ids ascend from the treetops down, so children are
+            # always visited before their parents
+            for nid in range(nodes.n):
+                n_pass = 0
+                child = nodes.child[nid]
+                while child != -1:
+                    if passer[child]:
+                        n_pass += 1
+                    child = nodes.sib[child]
+                splitting = n_pass >= 2
+                if splitting:
+                    child = nodes.child[nid]
+                    while child != -1:
+                        if passer[child] and not has_split[child]:
+                            final[n_final] = child
+                            n_final += 1
+                        child = nodes.sib[child]
+                has_split[nid] = splitting
+                child = nodes.child[nid]
+                while child != -1:
+                    if has_split[child]:
+                        has_split[nid] = 1
+                    child = nodes.sib[child]
+
+            # The lowest-level components form a virtual root
+            # junction at the first threshold level
+            n_pass = 0
+            for nid in range(snap_lo[n_snaps - 1],
+                             snap_hi[n_snaps - 1]):
+                if passer[nid]:
+                    n_pass += 1
+            if n_pass >= 2:
+                for nid in range(snap_lo[n_snaps - 1],
+                                 snap_hi[n_snaps - 1]):
+                    if passer[nid] and not has_split[nid]:
+                        final[n_final] = nid
+                        n_final += 1
+
+            if n_final < 2:
+                # A splitting junction always yields at least two
+                # markers, so this only happens with none at all
+                n_final = 0
+    elif result == 0:
         # Find the base snapshot: the lowest level with at least two
         # sufficiently large components
         base = -1
@@ -326,7 +429,6 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                 result = -1
             else:
                 n_stack = 0
-                n_final = 0
                 for nid in range(snap_lo[base], snap_hi[base]):
                     if nodes.kept[nid]:
                         stack[n_stack] = nid
@@ -362,75 +464,74 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                         n_final += 1
                         break
 
-                # Paint each final marker by flood filling its
-                # component from the recorded representative pixel;
-                # the marker regions are disjoint, so each pixel is
-                # visited at most once
-                min_pix = <Py_ssize_t*>malloc(n_final
-                                              * sizeof(Py_ssize_t))
-                order_rank = <Py_ssize_t*>malloc(n_final
-                                                 * sizeof(Py_ssize_t))
-                lut = <int*>malloc((n_final + 1) * sizeof(int))
-                if min_pix == NULL or order_rank == NULL or lut == NULL:
-                    result = -1
+    if result == 0 and n_final >= 2:
+        # Paint each final marker by flood filling its component from
+        # the recorded representative pixel. The marker regions are
+        # disjoint, so each pixel is visited at most once.
+        min_pix = <Py_ssize_t*>malloc(n_final * sizeof(Py_ssize_t))
+        order_rank = <Py_ssize_t*>malloc(n_final
+                                         * sizeof(Py_ssize_t))
+        lut = <int*>malloc((n_final + 1) * sizeof(int))
+        if min_pix == NULL or order_rank == NULL or lut == NULL:
+            result = -1
 
-            if result == 0:
-                for m in range(n_final):
-                    nid = final[m]
-                    vthr = nodes.level[nid] + 1
-                    lbl = <int>(m + 1)
-                    p = nodes.repr_pix[nid]
-                    markers[p] = lbl
-                    flood[0] = <int>p
-                    fs = 1
-                    mn = p
-                    while fs > 0:
-                        fs -= 1
-                        p = flood[fs]
-                        if p < mn:
-                            mn = p
-                        py = p // nx
-                        px = p % nx
-                        for dy in range(-1, 2):
-                            if py + dy < 0 or py + dy >= ny:
+        if result == 0:
+            for m in range(n_final):
+                nid = final[m]
+                vthr = nodes.level[nid] + 1
+                lbl = <int>(m + 1)
+                p = nodes.repr_pix[nid]
+                markers[p] = lbl
+                flood[0] = <int>p
+                fs = 1
+                mn = p
+                while fs > 0:
+                    fs -= 1
+                    p = flood[fs]
+                    if p < mn:
+                        mn = p
+                    py = p // nx
+                    px = p % nx
+                    for dy in range(-1, 2):
+                        if py + dy < 0 or py + dy >= ny:
+                            continue
+                        for dx in range(-1, 2):
+                            if px + dx < 0 or px + dx >= nx:
                                 continue
-                            for dx in range(-1, 2):
-                                if px + dx < 0 or px + dx >= nx:
-                                    continue
-                                if dy == 0 and dx == 0:
-                                    continue
-                                if not conn8 and dy != 0 and dx != 0:
-                                    continue
-                                nb = p + dy * nx + dx
-                                if markers[nb] == 0 and qflat[nb] >= vthr:
-                                    markers[nb] = lbl
-                                    flood[fs] = <int>nb
-                                    fs += 1
-                    min_pix[m] = mn
+                            if dy == 0 and dx == 0:
+                                continue
+                            if not conn8 and dy != 0 and dx != 0:
+                                continue
+                            nb = p + dy * nx + dx
+                            if markers[nb] == 0 and qflat[nb] >= vthr:
+                                markers[nb] = lbl
+                                flood[fs] = <int>nb
+                                fs += 1
+                min_pix[m] = mn
 
-                # Relabel the markers in raster-scan order of their
-                # first pixels (an insertion sort, as the first pixels
-                # are distinct), matching the ordering that per-level
-                # labeling would produce
-                for m in range(n_final):
-                    order_rank[m] = m
-                for m in range(1, n_final):
-                    j = m
-                    while (j > 0 and min_pix[order_rank[j - 1]]
-                           > min_pix[order_rank[j]]):
-                        rank = order_rank[j - 1]
-                        order_rank[j - 1] = order_rank[j]
-                        order_rank[j] = rank
-                        j -= 1
-                lut[0] = 0
-                for m in range(n_final):
-                    lut[order_rank[m] + 1] = <int>(m + 1)
-                for i in range(n_active):
-                    p = order[i]
-                    if markers[p] != 0:
-                        markers[p] = lut[markers[p]]
+            # Relabel the markers in raster-scan order of their first
+            # pixels (an insertion sort, as the first pixels are
+            # distinct), matching the ordering that per-level labeling
+            # would produce.
+            for m in range(n_final):
+                order_rank[m] = m
+            for m in range(1, n_final):
+                j = m
+                while (j > 0 and min_pix[order_rank[j - 1]]
+                       > min_pix[order_rank[j]]):
+                    rank = order_rank[j - 1]
+                    order_rank[j - 1] = order_rank[j]
+                    order_rank[j] = rank
+                    j -= 1
+            lut[0] = 0
+            for m in range(n_final):
+                lut[order_rank[m] + 1] = <int>(m + 1)
+            for i in range(n_active):
+                p = order[i]
+                if markers[p] != 0:
+                    markers[p] = lut[markers[p]]
 
-                result = n_final
+            result = n_final
 
     # Restore the workspace invariants for the added and stamp
     # arrays. The active pixels are found from qflat rather than from
@@ -444,7 +545,11 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
     free(nodes.repr_pix)
     free(nodes.child)
     free(nodes.sib)
+    free(nodes.area)
+    free(nodes.flux)
     free(nodes.kept)
+    free(passer)
+    free(has_split)
     free(counts)
     free(fill)
     free(snap_lo)
@@ -522,8 +627,9 @@ def make_deblend_markers(const int[:, ::1] quantized, int n_pixels,
     cdef Py_ssize_t n_markers
     with nogil:
         n_markers = _markers_core(qflat, ny, nx, n_pixels,
-                                  connectivity == 8,
-                                  &parent_mv[0], &size_mv[0],
+                                  connectivity == 8, NULL, NULL,
+                                  0.0, False,
+                                  &parent_mv[0], &size_mv[0], NULL,
                                   &added_mv[0], &stamp_mv[0],
                                   &node_of_root_mv[0], &order_mv[0],
                                   &flood_mv[0], &markers_mv[0, 0])
@@ -644,7 +750,9 @@ cdef Py_ssize_t _source_markers(const data_t* data, const segm_t* segm,
                                 Py_ssize_t y0, Py_ssize_t y1,
                                 Py_ssize_t x0, Py_ssize_t x1,
                                 int n_pixels, bint conn8, int n_levels,
-                                const double* thresholds, int* q,
+                                const double* thresholds,
+                                double saddle_limit, bint use_saddle,
+                                int* q, double* posimg, double* fsum,
                                 int* parent, int* size,
                                 unsigned char* added, int* stamp,
                                 int* node_of_root, int* order,
@@ -655,8 +763,9 @@ cdef Py_ssize_t _source_markers(const data_t* data, const segm_t* segm,
     Quantizes the cutout against the multithreshold levels of the
     source (the number of levels strictly below each pixel value, with
     the pixels outside the segment and the NaN pixels at 0) and runs
-    the component-tree core. Returns the number of markers (0 means the
-    source does not split) or -1 if a memory allocation failed.
+    the component-tree core with the selected contrast criterion.
+    Returns the number of markers (0 means the source does not split)
+    or -1 if a memory allocation failed.
     """
     cdef Py_ssize_t ny_c = y1 - y0
     cdef Py_ssize_t nx_c = x1 - x0
@@ -666,6 +775,8 @@ cdef Py_ssize_t _source_markers(const data_t* data, const segm_t* segm,
     for iy in range(ny_c):
         for ix in range(nx_c):
             idx = (y0 + iy) * img_nx + x0 + ix
+            if use_saddle:
+                posimg[iy * nx_c + ix] = <double>data[idx]
             if segm[idx] != label:
                 q[iy * nx_c + ix] = 0
                 continue
@@ -676,9 +787,10 @@ cdef Py_ssize_t _source_markers(const data_t* data, const segm_t* segm,
             q[iy * nx_c + ix] = _count_below(thresholds, n_levels,
                                              value)
 
-    return _markers_core(q, ny_c, nx_c, n_pixels, conn8, parent, size,
-                         added, stamp, node_of_root, order, flood,
-                         markers)
+    return _markers_core(q, ny_c, nx_c, n_pixels, conn8, posimg,
+                         thresholds, saddle_limit, use_saddle, parent,
+                         size, fsum, added, stamp, node_of_root, order,
+                         flood, markers)
 
 
 def deblend_markers_chunk(const data_t[:, ::1] data,
@@ -690,7 +802,7 @@ def deblend_markers_chunk(const data_t[:, ::1] data,
                           const long long[::1] x1,
                           const double[:, ::1] thresholds, *,
                           int n_pixels, int connectivity,
-                          int max_markers):
+                          int max_markers, saddle_limits=None):
     """
     Build the deblending watershed markers for a chunk of sources.
 
@@ -730,6 +842,14 @@ def deblend_markers_chunk(const data_t[:, ::1] data,
         caller can retry the source with other levels. A negative value
         disables the limit.
 
+    saddle_limits : 1D float64 `~numpy.ndarray` or `None`, optional
+        If given, the markers are selected with the saddle contrast
+        criterion instead of building all candidate markers. A
+        junction of the component tree splits only where at least two
+        sufficiently large components each hold more flux above the
+        junction level than this per-source limit (the contrast times
+        the total source flux).
+
     Returns
     -------
     markers_list : list of 2D int `~numpy.ndarray` or `None`
@@ -745,6 +865,7 @@ def deblend_markers_chunk(const data_t[:, ::1] data,
     cdef int n_levels = thresholds.shape[1]
     cdef Py_ssize_t isrc, n_tot, max_ntot, ny_c, nx_c
     cdef Py_ssize_t n_markers
+    cdef bint use_saddle = saddle_limits is not None
 
     if thresholds.shape[0] != n_src:
         msg = 'thresholds must have one row per source'
@@ -778,16 +899,35 @@ def deblend_markers_chunk(const data_t[:, ::1] data,
     cdef int[::1] markers_mv = markers_arr
     cdef Py_ssize_t[::1] n_markers_mv = n_markers_arr
 
+    # Workspaces used only by the saddle criterion
+    cdef const double[::1] saddle_limits_mv = None
+    cdef double[::1] posimg_mv = None
+    cdef double[::1] fsum_mv = None
+    cdef double* posimg = NULL
+    cdef double* fsum = NULL
+    cdef double saddle_limit = 0.0
+    if use_saddle:
+        saddle_limits_mv = saddle_limits
+        posimg_arr = np.empty(max_ntot, dtype=np.float64)
+        fsum_arr = np.empty(max_ntot, dtype=np.float64)
+        posimg_mv = posimg_arr
+        fsum_mv = fsum_arr
+        posimg = &posimg_mv[0]
+        fsum = &fsum_mv[0]
+
     markers_list = []
     for isrc in range(n_src):
         ny_c = y1[isrc] - y0[isrc]
         nx_c = x1[isrc] - x0[isrc]
+        if use_saddle:
+            saddle_limit = saddle_limits_mv[isrc]
         with nogil:
             n_markers = _source_markers(
                 &data[0, 0], &segm_data[0, 0], img_nx, labels[isrc],
                 y0[isrc], y1[isrc], x0[isrc], x1[isrc], n_pixels,
                 connectivity == 8, n_levels, &thresholds[isrc, 0],
-                &q_mv[0], &parent_mv[0], &size_mv[0], &added_mv[0],
+                saddle_limit, use_saddle, &q_mv[0], posimg, fsum,
+                &parent_mv[0], &size_mv[0], &added_mv[0],
                 &stamp_mv[0], &node_of_root_mv[0], &order_mv[0],
                 &flood_mv[0], &markers_mv[0])
         if n_markers < 0:

--- a/photutils/segmentation/_deblend_markers.pyx
+++ b/photutils/segmentation/_deblend_markers.pyx
@@ -67,6 +67,16 @@ cdef struct _Nodes:
     Py_ssize_t cap
 
 
+cdef struct _SaddleArgs:
+    # Inputs of the saddle contrast criterion (see _markers_core).
+    # Only enabled is read when the criterion is not in use
+    bint enabled
+    const double* thresholds
+    double limit
+    double* posimg
+    double* fsum
+
+
 cdef inline bint _nodes_grow(_Nodes* nodes) noexcept nogil:
     """
     Double the node storage capacity and return False on failure.
@@ -147,10 +157,8 @@ cdef inline void _union(int* parent, int* size, double* fsum,
 
 cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
                               Py_ssize_t nx, int n_pixels, bint conn8,
-                              const double* posimg,
-                              const double* thresholds,
-                              double saddle_limit, bint use_saddle,
-                              int* parent, int* size, double* fsum,
+                              int* parent, int* size,
+                              const _SaddleArgs* saddle,
                               unsigned char* added, int* stamp,
                               int* node_of_root, int* order,
                               int* flood, int* markers) noexcept nogil:
@@ -164,11 +172,17 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
     quantized level (the caller is responsible for treating the
     other ``markers`` entries as zero).
 
-    With ``use_saddle``, the markers are instead selected with the
-    saddle contrast criterion, which requires the ``posimg`` pixel
+    With ``saddle.enabled``, the markers are instead selected with
+    the saddle contrast criterion, which requires the ``posimg`` pixel
     values, the ``thresholds`` level values, the ``fsum`` pixel-sized
-    workspace, and the ``saddle_limit`` flux (the contrast times the
-    total source flux). These may be NULL/0 otherwise.
+    workspace, and the ``limit`` flux (the contrast times the total
+    source flux) of the ``saddle`` arguments. A branch passes when the
+    flux it holds above the level at which it separates from its
+    siblings exceeds the limit. The component fluxes are accumulated
+    in the union-find merge order, so they can differ in the last bits
+    from the raster-order sums of the pure-Python reference
+    implementation. This only matters for a branch whose flux above
+    its level equals the limit to within rounding.
 
     Returns the number of markers (0 if the source does not split),
     or -1 if a memory allocation failed.
@@ -183,6 +197,18 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
     cdef int v, lbl
     cdef bint splitting
     cdef double prominence
+
+    # Unpack the saddle criterion inputs
+    cdef bint use_saddle = saddle.enabled
+    cdef const double* posimg = NULL
+    cdef const double* thresholds = NULL
+    cdef double* fsum = NULL
+    cdef double saddle_limit = 0.0
+    if use_saddle:
+        posimg = saddle.posimg
+        thresholds = saddle.thresholds
+        fsum = saddle.fsum
+        saddle_limit = saddle.limit
 
     # Count the active (nonzero) pixels and the maximum level
     cdef int qmax = 0
@@ -361,12 +387,29 @@ cdef Py_ssize_t _markers_core(const int* qflat, Py_ssize_t ny,
         if final == NULL or passer == NULL or has_split == NULL:
             result = -1
         else:
-            for nid in range(nodes.n):
+            # A branch passes when the flux it holds above the level at
+            # which it separates from its siblings (the level above its
+            # parent junction) exceeds the saddle limit. A node
+            # represents its component over every level between two
+            # populated ones, so this is the lowest of those levels,
+            # as in the per-level reference construction. The
+            # lowest-level components separate at the first threshold
+            # level. Every other node is the child of exactly one node
+            for nid in range(snap_lo[n_snaps - 1],
+                             snap_hi[n_snaps - 1]):
                 prominence = (nodes.flux[nid]
-                              - thresholds[nodes.level[nid]]
-                              * nodes.area[nid])
+                              - thresholds[0] * nodes.area[nid])
                 passer[nid] = (nodes.kept[nid]
                                and prominence > saddle_limit)
+            for nid in range(nodes.n):
+                child = nodes.child[nid]
+                while child != -1:
+                    prominence = (nodes.flux[child]
+                                  - thresholds[nodes.level[nid] + 1]
+                                  * nodes.area[child])
+                    passer[child] = (nodes.kept[child]
+                                     and prominence > saddle_limit)
+                    child = nodes.sib[child]
 
             # Node ids ascend from the treetops down, so children are
             # always visited before their parents
@@ -624,15 +667,21 @@ def make_deblend_markers(const int[:, ::1] quantized, int n_pixels,
     cdef int[::1] order_mv = order_arr
     cdef int[::1] flood_mv = flood_arr
 
+    cdef _SaddleArgs saddle
+    saddle.enabled = False
+    saddle.thresholds = NULL
+    saddle.limit = 0.0
+    saddle.posimg = NULL
+    saddle.fsum = NULL
+
     cdef Py_ssize_t n_markers
     with nogil:
         n_markers = _markers_core(qflat, ny, nx, n_pixels,
-                                  connectivity == 8, NULL, NULL,
-                                  0.0, False,
-                                  &parent_mv[0], &size_mv[0], NULL,
-                                  &added_mv[0], &stamp_mv[0],
-                                  &node_of_root_mv[0], &order_mv[0],
-                                  &flood_mv[0], &markers_mv[0, 0])
+                                  connectivity == 8, &parent_mv[0],
+                                  &size_mv[0], &saddle, &added_mv[0],
+                                  &stamp_mv[0], &node_of_root_mv[0],
+                                  &order_mv[0], &flood_mv[0],
+                                  &markers_mv[0, 0])
     if n_markers < 0:
         raise MemoryError
 
@@ -751,8 +800,7 @@ cdef Py_ssize_t _source_markers(const data_t* data, const segm_t* segm,
                                 Py_ssize_t x0, Py_ssize_t x1,
                                 int n_pixels, bint conn8, int n_levels,
                                 const double* thresholds,
-                                double saddle_limit, bint use_saddle,
-                                int* q, double* posimg, double* fsum,
+                                const _SaddleArgs* saddle, int* q,
                                 int* parent, int* size,
                                 unsigned char* added, int* stamp,
                                 int* node_of_root, int* order,
@@ -775,8 +823,8 @@ cdef Py_ssize_t _source_markers(const data_t* data, const segm_t* segm,
     for iy in range(ny_c):
         for ix in range(nx_c):
             idx = (y0 + iy) * img_nx + x0 + ix
-            if use_saddle:
-                posimg[iy * nx_c + ix] = <double>data[idx]
+            if saddle.enabled:
+                saddle.posimg[iy * nx_c + ix] = <double>data[idx]
             if segm[idx] != label:
                 q[iy * nx_c + ix] = 0
                 continue
@@ -787,9 +835,8 @@ cdef Py_ssize_t _source_markers(const data_t* data, const segm_t* segm,
             q[iy * nx_c + ix] = _count_below(thresholds, n_levels,
                                              value)
 
-    return _markers_core(q, ny_c, nx_c, n_pixels, conn8, posimg,
-                         thresholds, saddle_limit, use_saddle, parent,
-                         size, fsum, added, stamp, node_of_root, order,
+    return _markers_core(q, ny_c, nx_c, n_pixels, conn8, parent, size,
+                         saddle, added, stamp, node_of_root, order,
                          flood, markers)
 
 
@@ -899,34 +946,38 @@ def deblend_markers_chunk(const data_t[:, ::1] data,
     cdef int[::1] markers_mv = markers_arr
     cdef Py_ssize_t[::1] n_markers_mv = n_markers_arr
 
-    # Workspaces used only by the saddle criterion
+    # The saddle criterion inputs, with workspaces used only by it
+    cdef _SaddleArgs saddle
     cdef const double[::1] saddle_limits_mv = None
     cdef double[::1] posimg_mv = None
     cdef double[::1] fsum_mv = None
-    cdef double* posimg = NULL
-    cdef double* fsum = NULL
-    cdef double saddle_limit = 0.0
+    saddle.enabled = use_saddle
+    saddle.thresholds = NULL
+    saddle.limit = 0.0
+    saddle.posimg = NULL
+    saddle.fsum = NULL
     if use_saddle:
         saddle_limits_mv = saddle_limits
         posimg_arr = np.empty(max_ntot, dtype=np.float64)
         fsum_arr = np.empty(max_ntot, dtype=np.float64)
         posimg_mv = posimg_arr
         fsum_mv = fsum_arr
-        posimg = &posimg_mv[0]
-        fsum = &fsum_mv[0]
+        saddle.posimg = &posimg_mv[0]
+        saddle.fsum = &fsum_mv[0]
 
     markers_list = []
     for isrc in range(n_src):
         ny_c = y1[isrc] - y0[isrc]
         nx_c = x1[isrc] - x0[isrc]
         if use_saddle:
-            saddle_limit = saddle_limits_mv[isrc]
+            saddle.limit = saddle_limits_mv[isrc]
+            saddle.thresholds = &thresholds[isrc, 0]
         with nogil:
             n_markers = _source_markers(
                 &data[0, 0], &segm_data[0, 0], img_nx, labels[isrc],
                 y0[isrc], y1[isrc], x0[isrc], x1[isrc], n_pixels,
                 connectivity == 8, n_levels, &thresholds[isrc, 0],
-                saddle_limit, use_saddle, &q_mv[0], posimg, fsum,
+                &saddle, &q_mv[0],
                 &parent_mv[0], &size_mv[0], &added_mv[0],
                 &stamp_mv[0], &node_of_root_mv[0], &order_mv[0],
                 &flood_mv[0], &markers_mv[0])

--- a/photutils/segmentation/_deblend_reference.py
+++ b/photutils/segmentation/_deblend_reference.py
@@ -291,6 +291,11 @@ class _SingleSourceDeblender:
         raster-scan order of their first pixel, as the compiled kernel
         labels them.
 
+        This method labels the cutout once per level and scans it once
+        per component, so its cost grows with the number of levels
+        times the number of components times the cutout area. It is a
+        reference for testing, not meant for large cutouts.
+
         Parameters
         ----------
         thresholds : 1D `~numpy.ndarray`

--- a/photutils/segmentation/_deblend_reference.py
+++ b/photutils/segmentation/_deblend_reference.py
@@ -90,6 +90,31 @@ def _detect_sources_deblend(data, threshold, n_pixels, *, footprint,
     return segment_img
 
 
+def _raster_relabel(markers):
+    """
+    Relabel a marker image consecutively in raster-scan order of the
+    first pixel of each marker.
+
+    Parameters
+    ----------
+    markers : 2D int `~numpy.ndarray`
+        The marker image.
+
+    Returns
+    -------
+    result : 2D int `~numpy.ndarray`
+        The relabeled marker image.
+    """
+    flat = markers.ravel()
+    labels, first = np.unique(flat, return_index=True)
+    keep = labels > 0
+    labels = labels[keep]
+    order = np.argsort(first[keep])
+    lut = np.zeros(labels.max() + 1, dtype=np.int32)
+    lut[labels[order]] = np.arange(1, labels.size + 1)
+    return lut[markers]
+
+
 class _SingleSourceDeblender:
     """
     Class to deblend a single labeled source.
@@ -121,6 +146,7 @@ class _SingleSourceDeblender:
         self.footprint = deblend_params.footprint
         self.n_levels = deblend_params.n_levels
         self.contrast = deblend_params.contrast
+        self.contrast_method = deblend_params.contrast_method
         self.mode = deblend_params.mode
 
         self.segment_mask = segment_data == label
@@ -218,11 +244,13 @@ class _SingleSourceDeblender:
         """
         Make markers (possible sources) for the watershed algorithm.
 
-        The markers are built from a single component-tree pass over
-        the level-quantized cutout (see
-        `~photutils.segmentation._deblend_markers.make_deblend_markers`),
+        With the basin contrast criterion, the markers are built from
+        a single component-tree pass over the level-quantized cutout
+        (see `~photutils.segmentation._deblend_markers.make_deblend_markers`),
         which produces markers identical to the per-level
         multithreshold construction of ``make_markers_per_level``.
+        With the saddle criterion, the markers are selected level by
+        level in Python by ``make_saddle_markers``.
 
         Returns
         -------
@@ -232,6 +260,8 @@ class _SingleSourceDeblender:
             at every threshold.
         """
         thresholds = self.compute_thresholds()
+        if self.contrast_method == 'saddle':
+            return self.make_saddle_markers(thresholds)
 
         # A pixel is above threshold level i if i < quantized. NaN
         # pixels compare as False against every threshold.
@@ -246,6 +276,84 @@ class _SingleSourceDeblender:
         if n_markers == 0:
             return None
         return markers
+
+    def make_saddle_markers(self, thresholds):
+        """
+        Make markers with the saddle contrast criterion, level by level.
+
+        The connected components above each threshold level form a
+        tree. A junction splits where at least two of its children
+        (the components at the next level) have at least ``n_pixels``
+        pixels and each hold more flux above their own level than the
+        saddle limit, the contrast times the total source flux. The
+        markers are the passing children of the splitting junctions
+        that contain no deeper split, labeled consecutively in
+        raster-scan order of their first pixel, as the compiled kernel
+        labels them.
+
+        Parameters
+        ----------
+        thresholds : 1D `~numpy.ndarray`
+            The multithreshold levels.
+
+        Returns
+        -------
+        markers : 2D int `~numpy.ndarray` or `None`
+            The marker image, or `None` if there are fewer than two
+            markers.
+        """
+        # A Python float, as the compiled chunk driver computes it
+        limit = self.contrast * float(self.source_sum)
+        level_labels = [
+            ndi_label((self.data > threshold) & self.segment_mask,
+                      structure=self.footprint)[0]
+            for threshold in thresholds]
+
+        passer = {}
+        children = {}
+        all_nodes = []
+        for level, labeled in enumerate(level_labels):
+            for comp in np.unique(labeled[labeled > 0]):
+                node = (level, int(comp))
+                all_nodes.append(node)
+                region = labeled == comp
+                area = int(region.sum())
+                flux = float(np.sum(self.data[region], dtype=np.float64))
+                prominence = flux - thresholds[level] * area
+                passer[node] = area >= self.n_pixels and prominence > limit
+                children[node] = []
+                if level > 0:
+                    parent_comp = int(level_labels[level - 1][region][0])
+                    children[(level - 1, parent_comp)].append(node)
+
+        def is_splitting(kids):
+            return sum(passer[kid] for kid in kids) >= 2
+
+        has_split = {}
+        for node in reversed(all_nodes):  # children before parents
+            has_split[node] = (is_splitting(children[node])
+                               or any(has_split[kid]
+                                      for kid in children[node]))
+
+        # The components at the first level form a virtual root
+        # junction
+        root_children = [(0, int(comp))
+                         for comp in np.unique(level_labels[0]
+                                               [level_labels[0] > 0])]
+        junctions = [root_children] + [children[node]
+                                       for node in all_nodes]
+        markers = []
+        for kids in junctions:
+            if is_splitting(kids):
+                markers.extend(kid for kid in kids
+                               if passer[kid] and not has_split[kid])
+
+        if len(markers) < 2:
+            return None
+        out = np.zeros(self.data.shape, dtype=np.int32)
+        for index, (level, comp) in enumerate(markers):
+            out[level_labels[level] == comp] = index + 1
+        return _raster_relabel(out)
 
     def make_markers_per_level(self):
         """
@@ -357,6 +465,8 @@ class _SingleSourceDeblender:
         # Deblend using watershed. If any source does not meet the
         # contrast criterion, then remove the faintest such source(s)
         # and repeat until all sources meet the contrast criterion.
+        # With the saddle criterion the markers are already
+        # contrast-selected, so a single pass is run.
         data_neg = np.ascontiguousarray(-self.data, dtype=np.float64)
         # NaN pixels are flooded after all finite pixels, as in the
         # compiled contrast loop
@@ -368,7 +478,7 @@ class _SingleSourceDeblender:
                                         self.segment_mask, connectivity)
 
             labels = _get_labels(markers)
-            if labels.size == 1:  # only 1 source left
+            if labels.size == 1 or self.contrast_method == 'saddle':
                 remove_marker = False
             else:
                 flux_frac = (sum_labels(self.data, markers, index=labels)
@@ -494,9 +604,12 @@ class _SingleSourceDeblender:
         # and/or small n_pixels), the watershed step can be very slow.
         # This mostly affects the "exponential" mode, where there are
         # many levels at low thresholds, so here we try again with
-        # "linear" mode.
+        # "linear" mode. The saddle criterion needs no retry because
+        # its markers are already contrast-selected and its watershed
+        # runs once.
         n_labels = len(_get_labels(markers))
-        if self.mode != 'linear' and n_labels > _MAX_MARKERS:
+        if (self.mode != 'linear' and self.contrast_method != 'saddle'
+                and n_labels > _MAX_MARKERS):
             del markers  # free memory
             self.warnings['n_markers'] = 'too many markers'
             self.mode = 'linear'

--- a/photutils/segmentation/_deblend_watershed.pyx
+++ b/photutils/segmentation/_deblend_watershed.pyx
@@ -278,26 +278,27 @@ cdef int _contrast_core(const double* posimg, const double* negimg,
                         unsigned char* mask, int* output,
                         Py_ssize_t ny, Py_ssize_t nx, bint conn8,
                         double contrast, double source_sum,
-                        double source_min,
-                        Py_ssize_t n_max_labels) noexcept nogil:
+                        double source_min, Py_ssize_t n_max_labels,
+                        bint apply_contrast) noexcept nogil:
     """
     Run the watershed contrast loop for one source in place.
 
     ``output`` holds the markers on input and the final relabeled
-    (consecutive from 1) basins on output. Returns the number of
-    final labels, or -1 if a memory allocation failed, or -2 if the
-    flooded basins do not cover the segment mask (a connectivity
-    mismatch).
+    (consecutive from 1) basins on output. Returns the number of final
+    labels, or -1 if a memory allocation failed, or -2 if the flooded
+    basins do not cover the segment mask (a connectivity mismatch). When
+    ``apply_contrast`` is false, the below-contrast basin removal is
+    skipped and a single watershed pass is run.
 
     The loop replicates the NumPy implementation operation for
     operation. The basin fluxes are accumulated in raster order in
     float64 (as np.bincount does), the below-contrast markers are
-    removed one at a time or in the largest provably equivalent
-    batch of the faintest markers, and NaN basin fluxes compare
-    false against every threshold, with np.argmin's first-NaN
-    behavior for the single-marker removal. The only divergence is
-    the order of bitwise-equal basin fluxes in the batch sort (NumPy
-    uses an unstable sort there, while this uses a stable one).
+    removed one at a time or in the largest provably equivalent batch
+    of the faintest markers, and NaN basin fluxes compare false
+    against every threshold, with np.argmin's first-NaN behavior for
+    the single-marker removal. The only divergence is the order of
+    bitwise-equal basin fluxes in the batch sort (NumPy uses an unstable
+    sort there, while this uses a stable one).
     """
     cdef Py_ssize_t n_tot = ny * nx
     cdef Py_ssize_t n_cap = n_max_labels + 1
@@ -353,10 +354,11 @@ cdef int _contrast_core(const double* posimg, const double* negimg,
             break
 
         remove_marker = False
-        for i in range(n_labels):
-            if frac[i] < contrast:
-                remove_marker = True
-                break
+        if apply_contrast:
+            for i in range(n_labels):
+                if frac[i] < contrast:
+                    remove_marker = True
+                    break
         if not remove_marker:
             break
 
@@ -456,7 +458,8 @@ def deblend_source_contrast(const data_t[:, ::1] data,
                             Py_ssize_t y1, Py_ssize_t x0,
                             Py_ssize_t x1, markers, *,
                             int connectivity, double contrast,
-                            double source_sum, double source_min):
+                            double source_sum, double source_min,
+                            bint apply_contrast=True):
     """
     Apply the watershed contrast loop to one source's markers.
 
@@ -500,6 +503,12 @@ def deblend_source_contrast(const data_t[:, ::1] data,
     source_min : float
         The minimum data value of the source segment (NaN pixels
         excluded).
+
+    apply_contrast : bool, optional
+        Whether to apply the contrast criterion. If `False`, a single
+        watershed pass is run with no basin removal. This is used with
+        the saddle contrast criterion, where the markers are already
+        contrast-selected.
 
     Returns
     -------
@@ -556,7 +565,8 @@ def deblend_source_contrast(const data_t[:, ::1] data,
                     n_max_labels = output[p]
         status = _contrast_core(posimg, negimg, mask, output, ny_c,
                                 nx_c, conn8, contrast, source_sum,
-                                source_min, n_max_labels)
+                                source_min, n_max_labels,
+                                apply_contrast)
 
     if status == -1:
         raise MemoryError

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -54,8 +54,8 @@ def _validate_deblend_kwargs(*, n_levels, contrast, contrast_method, mode,
         msg = 'contrast must be >= 0 and <= 1'
         raise ValueError(msg)
 
-    if contrast_method not in ('basin', 'saddle'):
-        msg = "contrast_method must be 'basin' or 'saddle'"
+    if contrast_method not in (None, 'basin', 'saddle'):
+        msg = "contrast_method must be None, 'basin', or 'saddle'"
         raise ValueError(msg)
 
     if mode not in ('exponential', 'linear', 'sinh'):
@@ -92,7 +92,7 @@ class _DeblendParams:
 @deprecated_renamed_argument('progress_bar', None, '3.1', until='4.0')
 def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
                     n_levels=32, contrast=0.001,
-                    contrast_method='basin', mode='exponential',
+                    contrast_method=None, mode='exponential',
                     connectivity=8, relabel=True, n_threads=1,
                     nproc=1,  # noqa: ARG001
                     n_processes=1,  # noqa: ARG001
@@ -145,20 +145,28 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         ``contrast_method`` keyword selects the flux to which the
         fraction refers.
 
-    contrast_method : {'basin', 'saddle'}, optional
-        The flux used by the contrast criterion. For ``'basin'``
-        (default), the fraction is the total flux in the source's
-        watershed basin, which includes the share of the surrounding
-        envelope territory assigned to the source. Basins below the
-        contrast are removed iteratively (faintest first, in batches
-        when provably equivalent) and their territory is re-flooded.
-        For ``'saddle'``, the fraction is the flux the source holds
-        above the saddle level where it separates from its neighbors,
-        evaluated once during marker construction with no iteration.
-        This is equivalent to the `SourceExtractor`_ ``DEBLEND_MINCONT``
-        criterion. It measures the significance of the peak itself
-        independently of how much envelope territory it would inherit,
-        and is faster because the watershed runs only once.
+    contrast_method : {`None`, 'basin', 'saddle'}, optional
+        The flux used by the contrast criterion. For ``'basin'``,
+        the fraction is the total flux in the source's watershed
+        basin, which includes the share of the surrounding envelope
+        territory assigned to the source. Basins below the contrast are
+        removed iteratively (faintest first, in batches when provably
+        equivalent) and their territory is re-flooded. For ``'saddle'``,
+        the fraction is the flux the source holds above the saddle
+        level where it separates from its neighbors, evaluated once
+        during marker construction with no iteration. This measures
+        the significance of the peak itself, independently of how much
+        envelope territory it would inherit. Because ``'saddle'``
+        needs only a single watershed pass, it is never slower than
+        ``'basin'`` and is substantially faster when many below-contrast
+        basins would otherwise be removed iteratively. Note that the
+        two methods measure different fluxes, so the same ``contrast``
+        value selects sources differently. The saddle flux excludes
+        all regions below the saddle and is therefore smaller than the
+        basin flux, making ``'saddle'`` stricter for faint peaks on
+        bright envelopes. If `None` (default), the ``'basin'`` method
+        is currently used. The default may change to ``'saddle'`` in
+        version 4.0.
 
     mode : {'exponential', 'linear', 'sinh'}, optional
         The mode used in defining the spacing between the
@@ -256,10 +264,6 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
     --------
     :func:`photutils.segmentation.detect_sources`
     :class:`photutils.segmentation.SourceFinder`
-
-    References
-    ----------
-    .. _SourceExtractor: https://sextractor.readthedocs.io/en/latest/
     """
     if isinstance(data, Quantity):
         data = data.value
@@ -284,6 +288,11 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
                              contrast_method=contrast_method, mode=mode,
                              connectivity=connectivity,
                              n_threads=n_threads)
+
+    if contrast_method is None:
+        # The default resolution is planned to change to 'saddle' in
+        # version 4.0
+        contrast_method = 'basin'
 
     if contrast == 1:  # no deblending
         segm_img = segmentation_image.copy()

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -30,15 +30,15 @@ __all__ = ['deblend_sources']
 _MAX_MARKERS = 200
 
 
-def _validate_deblend_kwargs(*, n_levels, contrast, mode, connectivity,
-                             n_threads):
+def _validate_deblend_kwargs(*, n_levels, contrast, contrast_method, mode,
+                             connectivity, n_threads):
     """
     Validate the deblending keywords shared by `deblend_sources` and
     `~photutils.segmentation.SourceFinder`.
 
     Parameters
     ----------
-    n_levels, contrast, mode, connectivity, n_threads
+    n_levels, contrast, contrast_method, mode, connectivity, n_threads
         The keyword values to validate. See `deblend_sources`.
 
     Raises
@@ -52,6 +52,10 @@ def _validate_deblend_kwargs(*, n_levels, contrast, mode, connectivity,
 
     if contrast < 0 or contrast > 1:
         msg = 'contrast must be >= 0 and <= 1'
+        raise ValueError(msg)
+
+    if contrast_method not in ('basin', 'saddle'):
+        msg = "contrast_method must be 'basin' or 'saddle'"
         raise ValueError(msg)
 
     if mode not in ('exponential', 'linear', 'sinh'):
@@ -76,6 +80,7 @@ class _DeblendParams:
     n_levels: int
     contrast: float
     mode: str
+    contrast_method: str = 'basin'
 
 
 @deprecated_renamed_argument('segment_img', 'segmentation_image', '3.0',
@@ -86,7 +91,8 @@ class _DeblendParams:
 @deprecated_renamed_argument('n_processes', None, '3.1', until='4.0')
 @deprecated_renamed_argument('progress_bar', None, '3.1', until='4.0')
 def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
-                    n_levels=32, contrast=0.001, mode='exponential',
+                    n_levels=32, contrast=0.001,
+                    contrast_method='basin', mode='exponential',
                     connectivity=8, relabel=True, n_threads=1,
                     nproc=1,  # noqa: ARG001
                     n_processes=1,  # noqa: ARG001
@@ -132,10 +138,27 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         The fraction of the total source flux that a local peak must
         have (at any one of the multi-thresholds) to be deblended
         as a separate object. ``contrast`` must be between 0 and 1,
-        inclusive. If ``contrast=0`` then every local peak will be made
-        a separate object (maximum deblending). If ``contrast=1`` then
-        no deblending will occur. The default is 0.001, which will
-        deblend sources with a 7.5 magnitude difference.
+        inclusive. If ``contrast=0`` then every local peak will be
+        made a separate object (maximum deblending). If ``contrast=1``
+        then no deblending will occur. The default is 0.001, which
+        will deblend sources with a 7.5 magnitude difference. The
+        ``contrast_method`` keyword selects the flux to which the
+        fraction refers.
+
+    contrast_method : {'basin', 'saddle'}, optional
+        The flux used by the contrast criterion. For ``'basin'``
+        (default), the fraction is the total flux in the source's
+        watershed basin, which includes the share of the surrounding
+        envelope territory assigned to the source. Basins below the
+        contrast are removed iteratively (faintest first, in batches
+        when provably equivalent) and their territory is re-flooded.
+        For ``'saddle'``, the fraction is the flux the source holds
+        above the saddle level where it separates from its neighbors,
+        evaluated once during marker construction with no iteration.
+        This is equivalent to the `SourceExtractor`_ ``DEBLEND_MINCONT``
+        criterion. It measures the significance of the peak itself
+        independently of how much envelope territory it would inherit,
+        and is faster because the watershed runs only once.
 
     mode : {'exponential', 'linear', 'sinh'}, optional
         The mode used in defining the spacing between the
@@ -233,6 +256,10 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
     --------
     :func:`photutils.segmentation.detect_sources`
     :class:`photutils.segmentation.SourceFinder`
+
+    References
+    ----------
+    .. _SourceExtractor: https://sextractor.readthedocs.io/en/latest/
     """
     if isinstance(data, Quantity):
         data = data.value
@@ -254,7 +281,8 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         raise ValueError(msg)
 
     _validate_deblend_kwargs(n_levels=n_levels, contrast=contrast,
-                             mode=mode, connectivity=connectivity,
+                             contrast_method=contrast_method, mode=mode,
+                             connectivity=connectivity,
                              n_threads=n_threads)
 
     if contrast == 1:  # no deblending
@@ -279,7 +307,7 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
 
     footprint = _make_binary_structure(data.ndim, connectivity)
     deblend_params = _DeblendParams(n_pixels, footprint, n_levels, contrast,
-                                    mode)
+                                    mode, contrast_method)
 
     segm_deblended = segmentation_image.data.copy()
     label_indices = segmentation_image.get_indices(labels)
@@ -562,6 +590,18 @@ def _deblend_sources_chunk(data, segm_data, driver_data, driver_segm,
     markers_list = [None] * len(labels)
     nonposmin = np.zeros(len(labels), dtype=bool)
     n_markers_fallback = np.zeros(len(labels), dtype=bool)
+
+    # The saddle criterion selects the markers against the total source
+    # fluxes, so those are computed up front. The basin criterion needs
+    # them only for the sources that split.
+    use_saddle = deblend_params.contrast_method == 'saddle'
+    source_sums = {}
+    if use_saddle:
+        for index in active:
+            slc = slices[index]
+            values = data[slc][segm_data[slc] == labels[index]]
+            source_sums[index] = float(nansum(values))
+
     if active.size > 0:
         values_dtype = data.dtype.newbyteorder('=')
         smin = source_min[active].astype(values_dtype)
@@ -569,15 +609,23 @@ def _deblend_sources_chunk(data, segm_data, driver_data, driver_segm,
         thresholds, fallback = _compute_thresholds(smin, smax, n_levels,
                                                    mode)
         nonposmin[active] = fallback
+        saddle_limits = None
+        if use_saddle:
+            saddle_limits = np.array([deblend_params.contrast
+                                      * source_sums[index]
+                                      for index in active])
         # Sources with too many markers are only retried with linearly
         # spaced levels (below), so only then may the kernel skip
-        # building their markers.
-        can_retry = mode != 'linear'
+        # building their markers. With the saddle criterion the markers
+        # are already contrast-selected and there is no iterative
+        # watershed, so no fallback is needed.
+        can_retry = mode != 'linear' and not use_saddle
         max_markers = _MAX_MARKERS if can_retry else -1
         markers, n_markers = deblend_markers_chunk(
             driver_data, driver_segm, labels[active], y0[active],
             y1[active], x0[active], x1[active], thresholds,
-            max_markers=max_markers, **chunk_kwargs)
+            max_markers=max_markers, saddle_limits=saddle_limits,
+            **chunk_kwargs)
         for index, source_markers in zip(active, markers, strict=True):
             markers_list[index] = source_markers
 
@@ -614,15 +662,21 @@ def _deblend_sources_chunk(data, segm_data, driver_data, driver_segm,
         # the per-source Python path (its rounding depends on the
         # summation order) and the source minimum comes from the
         # compiled extrema. Both are passed to the compiled contrast
-        # loop.
-        values = data[slc][segm_data[slc] == label]
+        # loop. With the saddle criterion, the markers are already
+        # contrast-selected, so the basin removal is disabled by an
+        # unreachable contrast.
+        if use_saddle:
+            source_sum = source_sums[index]
+            contrast = -np.inf
+        else:
+            values = data[slc][segm_data[slc] == label]
+            source_sum = float(nansum(values))
+            contrast = float(deblend_params.contrast)
         source_deblended = deblend_source_contrast(
             driver_data, driver_segm, int(label), int(y0[index]),
             int(y1[index]), int(x0[index]), int(x1[index]), markers,
-            connectivity=connectivity,
-            contrast=float(deblend_params.contrast),
-            source_sum=float(nansum(values)),
-            source_min=float(source_min[index]))
+            connectivity=connectivity, contrast=contrast,
+            source_sum=source_sum, source_min=float(source_min[index]))
         results.append((source_deblended, warns))
 
     return results

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -672,20 +672,19 @@ def _deblend_sources_chunk(data, segm_data, driver_data, driver_segm,
         # summation order) and the source minimum comes from the
         # compiled extrema. Both are passed to the compiled contrast
         # loop. With the saddle criterion, the markers are already
-        # contrast-selected, so the basin removal is disabled by an
-        # unreachable contrast.
+        # contrast-selected, so the basin removal is disabled.
         if use_saddle:
             source_sum = source_sums[index]
-            contrast = -np.inf
         else:
             values = data[slc][segm_data[slc] == label]
             source_sum = float(nansum(values))
-            contrast = float(deblend_params.contrast)
         source_deblended = deblend_source_contrast(
             driver_data, driver_segm, int(label), int(y0[index]),
             int(y1[index]), int(x0[index]), int(x1[index]), markers,
-            connectivity=connectivity, contrast=contrast,
-            source_sum=source_sum, source_min=float(source_min[index]))
+            connectivity=connectivity,
+            contrast=float(deblend_params.contrast),
+            source_sum=source_sum, source_min=float(source_min[index]),
+            apply_contrast=not use_saddle)
         results.append((source_deblended, warns))
 
     return results

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -77,14 +77,15 @@ class SourceFinder:
         deblend sources with a 7.5 magnitude difference. This keyword is
         ignored unless ``deblend=True``.
 
-    contrast_method : {'basin', 'saddle'}, optional
-        The flux used by the contrast criterion. For ``'basin'``
-        (default), the fraction is the total flux in the source's
-        watershed basin. For ``'saddle'``, the fraction is the flux the
-        source holds above the saddle level where it separates from its
-        neighbors, equivalent to the SourceExtractor ``DEBLEND_MINCONT``
-        criterion. See :func:`~photutils.segmentation.deblend_sources`
-        for details. This keyword is ignored unless ``deblend=True``.
+    contrast_method : {`None`, 'basin', 'saddle'}, optional
+        The flux used by the contrast criterion. For ``'basin'``, the
+        fraction is the total flux in the source's watershed basin.
+        For ``'saddle'``, the fraction is the flux the source holds
+        above the saddle level where it separates from its neighbors.
+        If `None` (default), the ``'basin'`` method is currently used.
+        The default may change to ``'saddle'`` in version 4.0. See
+        :func:`~photutils.segmentation.deblend_sources` for details.
+        This keyword is ignored unless ``deblend=True``.
 
     mode : {'exponential', 'linear', 'sinh'}, optional
         The mode used in defining the spacing between the
@@ -192,7 +193,7 @@ class SourceFinder:
     @deprecated_renamed_argument('n_processes', None, '3.1', until='4.0')
     @deprecated_renamed_argument('progress_bar', None, '3.1', until='4.0')
     def __init__(self, n_pixels, *, connectivity=8, deblend=True, n_levels=32,
-                 contrast=0.001, contrast_method='basin',
+                 contrast=0.001, contrast_method=None,
                  mode='exponential', relabel=True,
                  n_threads=1,
                  nproc=1,  # noqa: ARG002

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -77,6 +77,15 @@ class SourceFinder:
         deblend sources with a 7.5 magnitude difference. This keyword is
         ignored unless ``deblend=True``.
 
+    contrast_method : {'basin', 'saddle'}, optional
+        The flux used by the contrast criterion. For ``'basin'``
+        (default), the fraction is the total flux in the source's
+        watershed basin. For ``'saddle'``, the fraction is the flux the
+        source holds above the saddle level where it separates from its
+        neighbors, equivalent to the SourceExtractor ``DEBLEND_MINCONT``
+        criterion. See :func:`~photutils.segmentation.deblend_sources`
+        for details. This keyword is ignored unless ``deblend=True``.
+
     mode : {'exponential', 'linear', 'sinh'}, optional
         The mode used in defining the spacing between the
         multi-thresholding levels (see the ``n_levels`` keyword)
@@ -183,7 +192,8 @@ class SourceFinder:
     @deprecated_renamed_argument('n_processes', None, '3.1', until='4.0')
     @deprecated_renamed_argument('progress_bar', None, '3.1', until='4.0')
     def __init__(self, n_pixels, *, connectivity=8, deblend=True, n_levels=32,
-                 contrast=0.001, mode='exponential', relabel=True,
+                 contrast=0.001, contrast_method='basin',
+                 mode='exponential', relabel=True,
                  n_threads=1,
                  nproc=1,  # noqa: ARG002
                  n_processes=1, progress_bar=True):
@@ -193,12 +203,14 @@ class SourceFinder:
                 msg = f'{name} must be a boolean, got {value!r}'
                 raise TypeError(msg)
         _validate_deblend_kwargs(n_levels=n_levels, contrast=contrast,
+                                 contrast_method=contrast_method,
                                  mode=mode, connectivity=connectivity,
                                  n_threads=n_threads)
         self.deblend = deblend
         self.connectivity = connectivity
         self.n_levels = n_levels
         self.contrast = contrast
+        self.contrast_method = contrast_method
         self.mode = mode
         self.relabel = relabel
         self.n_threads = n_threads
@@ -207,8 +219,8 @@ class SourceFinder:
 
     def __repr__(self):
         params = ('n_pixels', 'deblend', 'connectivity', 'n_levels',
-                  'contrast', 'mode', 'relabel', 'n_threads',
-                  'n_processes', 'progress_bar')
+                  'contrast', 'contrast_method', 'mode', 'relabel',
+                  'n_threads', 'n_processes', 'progress_bar')
         return make_repr(self, params)
 
     # Remove in 4.0
@@ -259,6 +271,8 @@ class SourceFinder:
             segment_img = deblend_sources(data, segment_img, self.n_pixels[1],
                                           n_levels=self.n_levels,
                                           contrast=self.contrast,
+                                          contrast_method=(
+                                              self.contrast_method),
                                           mode=self.mode,
                                           connectivity=self.connectivity,
                                           relabel=self.relabel,

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -1049,6 +1049,11 @@ def test_saddle_deblend():
     Test deblending with the saddle contrast criterion through the
     public API, including a source that does not split, the parent
     label map, the deblended flags, and thread-count invariance.
+
+    The label counts are regression pins for the multipeak scene (its
+    watershed basin flux fractions are about 0.061, 0.062, 0.225, and
+    0.652). The results are also compared with the pure-Python
+    reference path.
     """
     y, x = np.mgrid[0:101, 0:181]
     data, _ = make_multipeak_source()
@@ -1074,6 +1079,15 @@ def test_saddle_deblend():
     result3 = deblend_sources(image, segm, 5, contrast=0.001,
                               contrast_method='saddle', n_threads=4)
     assert_equal(result3.data, result.data)
+
+    with patch.object(deblend_module, '_deblend_sources_chunk',
+                      python_deblend_chunk):
+        expected = deblend_sources(image, segm, 5, contrast=0.001,
+                                   contrast_method='saddle')
+        expected2 = deblend_sources(image, segm, 5, contrast=0.1,
+                                    contrast_method='saddle')
+    assert_equal(result.data, expected.data)
+    assert_equal(result2.data, expected2.data)
 
 
 def test_nonposmin_fallback_sinh():

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -17,6 +17,7 @@ from scipy import ndimage as ndi
 from photutils.segmentation import SegmentationImage
 from photutils.segmentation import deblend as deblend_module
 from photutils.segmentation import deblend_sources, detect_sources
+from photutils.segmentation._deblend_markers import deblend_markers_chunk
 from photutils.segmentation._deblend_reference import _SingleSourceDeblender
 from photutils.segmentation._deblend_watershed import deblend_watershed
 from photutils.segmentation.deblend import (_compute_thresholds,
@@ -937,6 +938,231 @@ def test_compute_thresholds_matches_reference(dtype, mode, n_levels):
         assert_equal(thresholds[i].view(np.int64),
                      expected.view(np.int64))
         assert nonposmin[i] == ('nonposmin' in deblender.warnings)
+
+
+def raster_relabel(markers):
+    """
+    Relabel a marker image consecutively in raster-scan order of the
+    first pixel of each marker.
+
+    Parameters
+    ----------
+    markers : 2D int `~numpy.ndarray`
+        The marker image.
+
+    Returns
+    -------
+    result : 2D int `~numpy.ndarray`
+        The relabeled marker image.
+    """
+    flat = markers.ravel()
+    labels, first = np.unique(flat, return_index=True)
+    keep = labels > 0
+    labels = labels[keep]
+    order = np.argsort(first[keep])
+    lut = np.zeros(labels.max() + 1, dtype=np.int32)
+    lut[labels[order]] = np.arange(1, labels.size + 1)
+    return lut[markers]
+
+
+def python_saddle_markers(data, segment_mask, thresholds, n_pixels,
+                          limit, footprint):
+    """
+    Reference implementation of the saddle-criterion marker selection.
+
+    Builds the per-level component tree with per-level labeling and
+    selects the markers with a global junction scan. A junction splits
+    where at least two children with at least ``n_pixels`` pixels each
+    hold more flux above the junction level than ``limit``, and the
+    markers are the passing children of splitting junctions that contain
+    no deeper split.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The source cutout.
+
+    segment_mask : 2D bool `~numpy.ndarray`
+        The source segment mask.
+
+    thresholds : 1D `~numpy.ndarray`
+        The multithreshold levels.
+
+    n_pixels : int
+        The minimum number of connected pixels per component.
+
+    limit : float
+        The saddle flux limit (the contrast times the total source
+        flux).
+
+    footprint : 2D `~numpy.ndarray`
+        The connectivity footprint.
+
+    Returns
+    -------
+    markers : 2D int `~numpy.ndarray` or `None`
+        The marker image, or `None` if there are fewer than two
+        markers.
+    """
+    from scipy.ndimage import label as ndi_label
+
+    n_levels = len(thresholds)
+    level_labels = [ndi_label((data > threshold) & segment_mask,
+                              structure=footprint)[0]
+                    for threshold in thresholds]
+
+    passer = {}
+    children = {}
+    all_nodes = []
+    for level in range(n_levels):
+        labeled = level_labels[level]
+        for comp in np.unique(labeled[labeled > 0]):
+            node = (level, int(comp))
+            all_nodes.append(node)
+            region = labeled == comp
+            area = int(region.sum())
+            flux = float(np.sum(data[region], dtype=np.float64))
+            prominence = flux - thresholds[level] * area
+            passer[node] = area >= n_pixels and prominence > limit
+            children[node] = []
+            if level > 0:
+                parent_comp = int(level_labels[level - 1][region][0])
+                children[(level - 1, parent_comp)].append(node)
+
+    def is_splitting(kids):
+        return sum(passer[kid] for kid in kids) >= 2
+
+    has_split = {}
+    for node in reversed(all_nodes):  # children before parents
+        has_split[node] = (is_splitting(children[node])
+                           or any(has_split[kid]
+                                  for kid in children[node]))
+
+    root_children = [(0, int(comp))
+                     for comp in np.unique(level_labels[0]
+                                           [level_labels[0] > 0])]
+    junctions = [root_children] + [children[node]
+                                   for node in all_nodes]
+    markers = []
+    for kids in junctions:
+        if is_splitting(kids):
+            markers.extend(kid for kid in kids
+                           if passer[kid] and not has_split[kid])
+
+    if len(markers) < 2:
+        return None
+    out = np.zeros(data.shape, dtype=np.int32)
+    for index, (level, comp) in enumerate(markers):
+        out[level_labels[level] == comp] = index + 1
+    return out
+
+
+@pytest.mark.parametrize('dtype', ['float64', 'float32'])
+@pytest.mark.parametrize('connectivity', [8, 4])
+@pytest.mark.parametrize(
+    ('scene', 'contrast'),
+    [('multipeak', 0.0), ('multipeak', 0.001), ('multipeak', 0.01),
+     ('multipeak', 0.1), ('hierarchical', 0.001),
+     ('hierarchical', 0.05), ('negmin', 0.01)])
+def test_saddle_markers_match_reference(dtype, connectivity, scene,
+                                        contrast):
+    """
+    Test that the compiled saddle-criterion marker selection matches
+    the pure-Python reference implementation, including nested splits,
+    dissolving below-contrast siblings, the sinh fallback for negative
+    minima, both connectivities, and float32 data.
+    """
+    y, x = np.mgrid[0:101, 0:101]
+    if scene == 'hierarchical':
+        data = (Gaussian2D(1.0, 50, 50, 30, 30)(x, y)
+                + Gaussian2D(100, 35, 50, 3, 3)(x, y)
+                + Gaussian2D(80, 45, 50, 3, 3)(x, y)
+                + Gaussian2D(60, 70, 50, 3, 3)(x, y))
+    else:
+        data, _ = make_multipeak_source()
+    threshold = 0.5
+    if scene == 'negmin':
+        data = data - 5.0
+        threshold = -4.5
+    data = data.astype(dtype)
+
+    footprint = _make_binary_structure(2, connectivity)
+    segm = detect_sources(data, threshold, 5,
+                          connectivity=connectivity)
+    slc = segm.slices[0]
+    cutout = data[slc]
+    segment_mask = segm.data[slc] == 1
+    values = cutout[segment_mask]
+    limit = contrast * float(np.nansum(values))
+
+    params = _DeblendParams(5, footprint, 32, contrast, 'exponential')
+    deblender = _SingleSourceDeblender(cutout, segm.data[slc], 1,
+                                       params)
+    thresholds = deblender.compute_thresholds()
+
+    expected = python_saddle_markers(cutout, segment_mask, thresholds,
+                                     5, limit, footprint)
+
+    y0 = np.array([slc[0].start], dtype=np.int64)
+    y1 = np.array([slc[0].stop], dtype=np.int64)
+    x0 = np.array([slc[1].start], dtype=np.int64)
+    x1 = np.array([slc[1].stop], dtype=np.int64)
+    thresholds_2d = np.ascontiguousarray(thresholds[None, :],
+                                         dtype=np.float64)
+    markers_list, _ = deblend_markers_chunk(
+        np.ascontiguousarray(data), segm.data,
+        np.array([1], dtype=np.int64), y0, y1, x0, x1, thresholds_2d,
+        n_pixels=5, connectivity=connectivity, max_markers=-1,
+        saddle_limits=np.array([limit]))
+    result = markers_list[0]
+
+    if expected is None or result is None:
+        assert expected is None
+        assert result is None
+    else:
+        assert_equal(raster_relabel(result), raster_relabel(expected))
+
+
+def test_contrast_method_invalid():
+    """
+    Test that an invalid contrast_method raises a ValueError.
+    """
+    data, segm = make_multipeak_source()
+    match = "contrast_method must be 'basin' or 'saddle'"
+    with pytest.raises(ValueError, match=match):
+        deblend_sources(data, segm, 5, contrast_method='invalid')
+
+
+def test_saddle_deblend():
+    """
+    Test deblending with the saddle contrast criterion through the
+    public API, including a source that does not split, the parent
+    label map, the deblended flags, and thread-count invariance.
+    """
+    y, x = np.mgrid[0:101, 0:181]
+    data, _ = make_multipeak_source()
+    image = np.zeros((101, 181))
+    image[:, :101] = data
+    image += Gaussian2D(10, 150, 50, 4, 4)(x, y)  # lone source
+    segm = detect_sources(image, 0.5, 5)
+    assert segm.n_labels == 2
+
+    result = deblend_sources(image, segm, 5, contrast=0.001,
+                             contrast_method='saddle')
+    assert result.n_labels == 5
+    assert_equal(result.parent_to_deblended_labels, {1: [2, 3, 4, 5]})
+    assert np.count_nonzero(result.flags
+                            & SEGMENTATION_FLAGS.DEBLENDED) == 4
+
+    # Higher contrast drops the faint basins entirely (they cannot
+    # combine and survive, as there is no removal iteration).
+    result2 = deblend_sources(image, segm, 5, contrast=0.1,
+                              contrast_method='saddle')
+    assert result2.n_labels == 3
+
+    result3 = deblend_sources(image, segm, 5, contrast=0.001,
+                              contrast_method='saddle', n_threads=4)
+    assert_equal(result3.data, result.data)
 
 
 def test_nonposmin_fallback_sinh():

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -685,6 +685,7 @@ def python_deblend_chunk(data, segm_data, driver_data,  # noqa: ARG001
     return results
 
 
+@pytest.mark.parametrize('contrast_method', ['basin', 'saddle'])
 @pytest.mark.parametrize('dtype', ['float64', 'float32', '>f4', 'int32'])
 @pytest.mark.parametrize('scene', ['blend', 'negmin', 'checkerboard',
                                    'gaussian', 'flat',
@@ -693,7 +694,7 @@ def python_deblend_chunk(data, segm_data, driver_data,  # noqa: ARG001
                                    'neighbors', 'nan',
                                    'checkerboard-linear',
                                    'checkerboard-negmin'])
-def test_chunk_driver_matches_python_path(dtype, scene):
+def test_chunk_driver_matches_python_path(dtype, scene, contrast_method):
     """
     Test that the compiled chunk driver and contrast loop produce
     results identical to the pure-Python per-source path, including
@@ -711,7 +712,7 @@ def test_chunk_driver_matches_python_path(dtype, scene):
     segment, the checkerboard deblended in linear mode, which keeps
     all of its markers instead of falling back, and the checkerboard
     with a non-positive minimum, which falls back to sinh and is then
-    retried with linear levels.
+    retried with linear levels, each with both contrast criteria.
     """
     contrast = 0.001
     mode = 'linear' if scene == 'checkerboard-linear' else 'exponential'
@@ -784,11 +785,13 @@ def test_chunk_driver_matches_python_path(dtype, scene):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeblendWarning)
         result = deblend_sources(data, segm, n_pixels,
-                                 contrast=contrast, mode=mode)
+                                 contrast=contrast, mode=mode,
+                                 contrast_method=contrast_method)
         with patch.object(deblend_module, '_deblend_sources_chunk',
                           python_deblend_chunk):
             expected = deblend_sources(data, segm, n_pixels,
-                                       contrast=contrast, mode=mode)
+                                       contrast=contrast, mode=mode,
+                                       contrast_method=contrast_method)
 
     assert_equal(result.data, expected.data)
     assert result.info.keys() == expected.info.keys()
@@ -940,144 +943,44 @@ def test_compute_thresholds_matches_reference(dtype, mode, n_levels):
         assert nonposmin[i] == ('nonposmin' in deblender.warnings)
 
 
-def raster_relabel(markers):
-    """
-    Relabel a marker image consecutively in raster-scan order of the
-    first pixel of each marker.
-
-    Parameters
-    ----------
-    markers : 2D int `~numpy.ndarray`
-        The marker image.
-
-    Returns
-    -------
-    result : 2D int `~numpy.ndarray`
-        The relabeled marker image.
-    """
-    flat = markers.ravel()
-    labels, first = np.unique(flat, return_index=True)
-    keep = labels > 0
-    labels = labels[keep]
-    order = np.argsort(first[keep])
-    lut = np.zeros(labels.max() + 1, dtype=np.int32)
-    lut[labels[order]] = np.arange(1, labels.size + 1)
-    return lut[markers]
-
-
-def python_saddle_markers(data, segment_mask, thresholds, n_pixels,
-                          limit, footprint):
-    """
-    Reference implementation of the saddle-criterion marker selection.
-
-    Builds the per-level component tree with per-level labeling and
-    selects the markers with a global junction scan. A junction splits
-    where at least two children with at least ``n_pixels`` pixels each
-    hold more flux above the junction level than ``limit``, and the
-    markers are the passing children of splitting junctions that contain
-    no deeper split.
-
-    Parameters
-    ----------
-    data : 2D `~numpy.ndarray`
-        The source cutout.
-
-    segment_mask : 2D bool `~numpy.ndarray`
-        The source segment mask.
-
-    thresholds : 1D `~numpy.ndarray`
-        The multithreshold levels.
-
-    n_pixels : int
-        The minimum number of connected pixels per component.
-
-    limit : float
-        The saddle flux limit (the contrast times the total source
-        flux).
-
-    footprint : 2D `~numpy.ndarray`
-        The connectivity footprint.
-
-    Returns
-    -------
-    markers : 2D int `~numpy.ndarray` or `None`
-        The marker image, or `None` if there are fewer than two
-        markers.
-    """
-    from scipy.ndimage import label as ndi_label
-
-    n_levels = len(thresholds)
-    level_labels = [ndi_label((data > threshold) & segment_mask,
-                              structure=footprint)[0]
-                    for threshold in thresholds]
-
-    passer = {}
-    children = {}
-    all_nodes = []
-    for level in range(n_levels):
-        labeled = level_labels[level]
-        for comp in np.unique(labeled[labeled > 0]):
-            node = (level, int(comp))
-            all_nodes.append(node)
-            region = labeled == comp
-            area = int(region.sum())
-            flux = float(np.sum(data[region], dtype=np.float64))
-            prominence = flux - thresholds[level] * area
-            passer[node] = area >= n_pixels and prominence > limit
-            children[node] = []
-            if level > 0:
-                parent_comp = int(level_labels[level - 1][region][0])
-                children[(level - 1, parent_comp)].append(node)
-
-    def is_splitting(kids):
-        return sum(passer[kid] for kid in kids) >= 2
-
-    has_split = {}
-    for node in reversed(all_nodes):  # children before parents
-        has_split[node] = (is_splitting(children[node])
-                           or any(has_split[kid]
-                                  for kid in children[node]))
-
-    root_children = [(0, int(comp))
-                     for comp in np.unique(level_labels[0]
-                                           [level_labels[0] > 0])]
-    junctions = [root_children] + [children[node]
-                                   for node in all_nodes]
-    markers = []
-    for kids in junctions:
-        if is_splitting(kids):
-            markers.extend(kid for kid in kids
-                           if passer[kid] and not has_split[kid])
-
-    if len(markers) < 2:
-        return None
-    out = np.zeros(data.shape, dtype=np.int32)
-    for index, (level, comp) in enumerate(markers):
-        out[level_labels[level] == comp] = index + 1
-    return out
-
-
 @pytest.mark.parametrize('dtype', ['float64', 'float32'])
 @pytest.mark.parametrize('connectivity', [8, 4])
 @pytest.mark.parametrize(
     ('scene', 'contrast'),
     [('multipeak', 0.0), ('multipeak', 0.001), ('multipeak', 0.01),
      ('multipeak', 0.1), ('hierarchical', 0.001),
-     ('hierarchical', 0.05), ('negmin', 0.01)])
+     ('hierarchical', 0.05), ('negmin', 0.01), ('discrete', 0.01),
+     ('discrete', 0.03), ('discrete', 0.05), ('quantized', 0.001),
+     ('quantized', 0.01)])
 def test_saddle_markers_match_reference(dtype, connectivity, scene,
                                         contrast):
     """
     Test that the compiled saddle-criterion marker selection matches
-    the pure-Python reference implementation, including nested splits,
+    the per-level reference implementation, including nested splits,
     dissolving below-contrast siblings, the sinh fallback for negative
-    minima, both connectivities, and float32 data.
+    minima, both connectivities, float32 data, and data with empty
+    threshold levels (discrete values and coarse quantization), where
+    a branch must be evaluated at the level above its junction rather
+    than at the top of its unchanged range of levels.
     """
     y, x = np.mgrid[0:101, 0:101]
+    mode = 'exponential'
     if scene == 'hierarchical':
         data = (Gaussian2D(1.0, 50, 50, 30, 30)(x, y)
                 + Gaussian2D(100, 35, 50, 3, 3)(x, y)
                 + Gaussian2D(80, 45, 50, 3, 3)(x, y)
                 + Gaussian2D(60, 70, 50, 3, 3)(x, y))
+    elif scene == 'discrete':
+        # A pedestal with two stepped blocks. Most of the linear levels
+        # between the steps are empty
+        data = np.zeros((41, 41))
+        data[2:39, 2:39] = 1.0
+        for cy, cx in ((12, 12), (28, 28)):
+            data[cy - 2:cy + 3, cx - 2:cx + 3] = 6.0
+            data[cy - 1:cy + 2, cx - 1:cx + 2] = 10.0
+        mode = 'linear'
+    elif scene == 'quantized':
+        data = make_marker_test_image('quantized')
     else:
         data, _ = make_multipeak_source()
     threshold = 0.5
@@ -1091,17 +994,12 @@ def test_saddle_markers_match_reference(dtype, connectivity, scene,
                           connectivity=connectivity)
     slc = segm.slices[0]
     cutout = data[slc]
-    segment_mask = segm.data[slc] == 1
-    values = cutout[segment_mask]
-    limit = contrast * float(np.nansum(values))
 
-    params = _DeblendParams(5, footprint, 32, contrast, 'exponential')
+    params = _DeblendParams(5, footprint, 32, contrast, mode, 'saddle')
     deblender = _SingleSourceDeblender(cutout, segm.data[slc], 1,
                                        params)
+    expected = deblender.make_markers()
     thresholds = deblender.compute_thresholds()
-
-    expected = python_saddle_markers(cutout, segment_mask, thresholds,
-                                     5, limit, footprint)
 
     y0 = np.array([slc[0].start], dtype=np.int64)
     y1 = np.array([slc[0].stop], dtype=np.int64)
@@ -1109,18 +1007,19 @@ def test_saddle_markers_match_reference(dtype, connectivity, scene,
     x1 = np.array([slc[1].stop], dtype=np.int64)
     thresholds_2d = np.ascontiguousarray(thresholds[None, :],
                                          dtype=np.float64)
+    limit = deblender.contrast * float(deblender.source_sum)
     markers_list, _ = deblend_markers_chunk(
         np.ascontiguousarray(data), segm.data,
         np.array([1], dtype=np.int64), y0, y1, x0, x1, thresholds_2d,
         n_pixels=5, connectivity=connectivity, max_markers=-1,
-        saddle_limits=np.array([limit]))
+        saddle_limits=np.array([limit], dtype=np.float64))
     result = markers_list[0]
 
     if expected is None or result is None:
         assert expected is None
         assert result is None
     else:
-        assert_equal(raster_relabel(result), raster_relabel(expected))
+        assert_equal(result, expected)
 
 
 def test_contrast_method_invalid():

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -1128,9 +1128,21 @@ def test_contrast_method_invalid():
     Test that an invalid contrast_method raises a ValueError.
     """
     data, segm = make_multipeak_source()
-    match = "contrast_method must be 'basin' or 'saddle'"
+    match = 'contrast_method must be None, .basin., or .saddle.'
     with pytest.raises(ValueError, match=match):
         deblend_sources(data, segm, 5, contrast_method='invalid')
+
+
+def test_contrast_method_default():
+    """
+    Test that the default contrast_method of None currently resolves
+    to the 'basin' method.
+    """
+    data, segm = make_multipeak_source()
+    result_default = deblend_sources(data, segm, 5, contrast=0.1)
+    result_basin = deblend_sources(data, segm, 5, contrast=0.1,
+                                   contrast_method='basin')
+    assert_equal(result_default.data, result_basin.data)
 
 
 def test_saddle_deblend():

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -134,6 +134,7 @@ def test_finder_n_threads():
     ({'n_levels': 0}, 'n_levels must be a positive integer'),
     ({'n_levels': 2.5}, 'n_levels must be a positive integer'),
     ({'contrast': 1.5}, 'contrast must be'),
+    ({'contrast_method': 'invalid'}, 'contrast_method must be'),
     ({'mode': 'invalid'}, 'mode must be'),
     ({'n_threads': 0}, 'n_threads must be a positive integer'),
     ({'n_threads': True}, 'n_threads must be a positive integer'),


### PR DESCRIPTION
This PR adds a ``contrast_method`` keyword to ``deblend_sources`` and ``SourceFinder`` to select the flux used by the deblending contrast criterion. The default of `None` currently resolves to ``'basin'``, which preserves the existing behavior (the fraction is the total flux in the source's watershed basin, with iterative removal of below-contrast basins), and may change to ``'saddle'`` in version 4.0. The new ``'saddle'`` method instead measures the flux a source holds above the saddle level where it separates from its neighbors.