### PR TITLE
Fix checkerboard ePSFs from heterogeneous stars with oversampling > 1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -792,6 +792,15 @@ Bug Fixes
     spline, and the edge that moved outside the grid was filled with
     zero instead of being extrapolated. [#2418]
 
+  - Fixed a checkerboard pattern in ePSFs built by ``EPSFBuilder``
+    with ``oversampling`` greater than one from heterogeneous or
+    contaminated stars. Each star pixel residual is now deposited on
+    every oversampled grid point inside its footprint, so that every
+    star contributes to every grid point regardless of its subpixel
+    phase. A warning is now emitted if the subpixel phases of the fitted
+    star centers are strongly non-uniform, which indicates biased star
+    centers. [#2419]
+
 - ``photutils.psf_matching``
 
   - ``make_wiener_kernel`` now validates a custom ``penalty`` array.

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -12,17 +12,18 @@ generally difficult to model. `Anderson and King 2000 (PASP 112, 1360)
 showed that accurate stellar photometry and astrometry can be derived
 by modeling the net PSF, which they call the effective PSF (ePSF). The
 ePSF is an empirical model describing what fraction of a star's light
-will land in a particular pixel. The constructed ePSF is typically
-oversampled with respect to the detector pixels.
+will land in a particular pixel. The constructed ePSF may be oversampled
+with respect to the detector pixels.
 
-The oversampling in the ePSF is crucial because it captures the PSF
-pixel phase effect. Since stars can land at fractional pixel positions
-on the detector, the PSF appearance varies depending on the star's
-position within a pixel. By building an oversampled ePSF, we capture
-this phase information across the full pixel-to-pixel variation.
-This allows for more accurate PSF modeling and improved photometric
-measurements, as the PSF can be interpolated to the exact position of
-any star.
+Oversampling matters when the PSF is undersampled by the detector, e.g.,
+a FWHM of only one or two pixels. Since stars can land at fractional
+pixel positions on the detector, the appearance of such a PSF varies
+with the star's position within a pixel, and an oversampled ePSF
+captures this pixel-phase variation so that the PSF can be interpolated
+to the exact position of any star. When the PSF is well sampled (a FWHM
+of a few pixels or more), an ePSF with no oversampling already captures
+its shape, and a larger oversampling factor only adds noise and requires
+more stars (see :ref:`epsf-guidelines`).
 
 
 Building an ePSF
@@ -46,11 +47,12 @@ or :class:`~photutils.detection.IRAFStarFinder`) to identify an initial
 sample of stars. However, the step of creating a good sample of stars
 generally requires visual inspection and manual selection to ensure
 stars are sufficiently isolated and of good quality (e.g., no cosmic
-rays, detector artifacts, etc.). To produce a good ePSF, one should have
-a reasonably large sample of stars (e.g., several hundred) in order to
-fully sample the PSF over the oversampled grid and to help reduce the
-effects of noise. Otherwise, the resulting ePSF may have holes or may be
-noisy.
+rays, detector artifacts, etc.). To produce a good ePSF, one should
+have a reasonably large sample of stars (e.g., several hundred for an
+oversampling factor of 4) in order to sample the PSF at all subpixel
+phases and to help reduce the effects of noise. Otherwise, the resulting
+ePSF may be noisy or biased. See :ref:`epsf-guidelines` for guidance on
+choosing the oversampling factor and the star sample.
 
 Let's start by loading a simulated HST/WFC3 image in the F160W band::
 
@@ -270,14 +272,16 @@ Constructing the ePSF
 ---------------------
 
 With the star cutouts, we are ready to construct the ePSF with the
-:class:`~photutils.psf.EPSFBuilder` class. We'll create an ePSF with
-an oversampling factor of 4. Here we limit the maximum number of
-iterations to 3 (to limit its run time), but in practice one should use
-about 10 or more iterations. The :class:`~photutils.psf.EPSFBuilder`
-class has many options to control the ePSF build process, including
-changing the recentering function, the smoothing kernel, and the
-convergence accuracy. Please see the :class:`~photutils.psf.EPSFBuilder`
-documentation for further details.
+:class:`~photutils.psf.EPSFBuilder` class. We'll create an ePSF
+with an oversampling factor of 4, which is appropriate for these
+undersampled stars (a FWHM of about 1.5 pixels). Here we limit
+the maximum number of iterations to 3 (to limit its run time).
+In practice the default of 10 iterations is usually enough, and
+the build stops early once the star centers have converged. The
+:class:`~photutils.psf.EPSFBuilder` class has many options to control
+the ePSF build process, including the smoothing kernel, the fitting box,
+the recentering function, and the convergence criterion. Please see the
+:class:`~photutils.psf.EPSFBuilder` documentation for further details.
 
 We first initialize an :class:`~photutils.psf.EPSFBuilder` instance with
 our desired parameters and then input the cutouts of our selected stars
@@ -388,11 +392,11 @@ Smoothing Kernel
 
 The ``smoothing_kernel`` parameter controls the smoothing applied to
 the ePSF during each iteration. The smoothing helps to reduce noise in
-the ePSF, especially when the number of stars is small. The default
-is ``'quartic'``, which uses a fourth-degree polynomial kernel. This
-kernel was initially developed by Anderson and King for HST data with an
-ePSF oversampling factor of 4. It is designed to provide a good balance
-between smoothing and preserving the shape of the ePSF.
+the ePSF, especially when the number of stars is small. The default is
+``'quartic'``, which uses a fourth-degree polynomial kernel. This 5x5
+pixel kernel was initially developed by Anderson and King for HST data
+with an ePSF oversampling factor of 4. It is designed to provide a good
+balance between smoothing and preserving the shape of the ePSF.
 
 You can also use ``'quadratic'`` for a second-degree polynomial kernel,
 provide a custom 2D array, or set it to `None` for no smoothing::
@@ -400,6 +404,14 @@ provide a custom 2D array, or set it to `None` for no smoothing::
     >>> epsf_builder = EPSFBuilder(oversampling=4, maxiters=3,
     ...                            smoothing_kernel='quadratic',
     ...                            progress_bar=False)  # doctest: +REMOTE_DATA
+
+The kernels are applied on the oversampled grid, so their physical width
+is ``5 / oversampling`` input pixels. For a heavily undersampled ePSF
+with only about four to six grid points per FWHM, even the ``'quartic'``
+kernel lowers the peak of the ePSF, and ``smoothing_kernel=None`` is a
+reasonable choice, especially when the stars have high signal-to-noise.
+Smoothing is most useful for well-sampled ePSFs built from noisy or few
+stars.
 
 Independently of the smoothing kernel, when the oversampling factor
 is greater than one the builder also applies a low-pass filter to the
@@ -474,6 +486,8 @@ any of the `~astropy.nddata.NDUncertainty` subclasses (e.g.,
     >>> nddata = NDData(data=data, uncertainty=uncertainty)  # doctest: +REMOTE_DATA, +SKIP
 
 
+.. _epsf-linked-stars:
+
 Linked Stars for Dithered Images
 --------------------------------
 
@@ -495,3 +509,70 @@ are constrained to have the same sky coordinate across all images.
     >>> catalog = Table()
     >>> catalog['skycoord'] = SkyCoord(ra=[...]*u.deg, dec=[...]*u.deg)
     >>> stars = extract_stars([nddata1, nddata2], catalog, size=25)
+
+
+.. _epsf-guidelines:
+
+Guidelines for Building a Good ePSF
+-----------------------------------
+
+The quality of an ePSF depends more on the input stars and on a
+sensible choice of the oversampling factor than on the other builder
+parameters. The following guidelines are based on `Anderson and King
+2000 (PASP 112, 1360)
+<https://ui.adsabs.harvard.edu/abs/2000PASP..112.1360A/abstract>`_ and
+on the systematic tests of `Godden and Blundell 2026 (RASTI 5, 1)
+<https://doi.org/10.1093/rasti/rzaf063>`_.
+
+Choosing the oversampling factor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ePSF is tabulated on a grid with a spacing of ``1 / oversampling``
+detector pixels and is evaluated between grid points by cubic spline
+interpolation. The interpolation is accurate when there are at least
+about four grid points per FWHM of the ePSF, so a good rule of thumb
+is ``oversampling >= 4 / FWHM`` with the FWHM in pixels (measured
+along the narrowest direction of an elongated PSF). For example, use
+an oversampling of 3 or 4 for a FWHM of 1.5 pixels, 2 for a FWHM of 2
+pixels, and 1 for a FWHM of 4 pixels or more.
+
+Do not use a larger oversampling factor than the data require. A
+pixel-integrated PSF has essentially no structure on scales smaller
+than a pixel once the PSF is well sampled, so extra grid points add
+no information. They do, however, divide the star samples among more
+grid cells and make the ePSF noisier, and they require more stars. For
+well-sampled data (a FWHM of a few pixels or more), an oversampling of 1
+is usually the best choice.
+
+Choosing the star sample
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each of the ``oversampling**2`` subpixel cells within a pixel must be
+sampled by the centers of several stars. With randomly placed stars,
+plan on at least about 10 stars per cell, i.e., roughly ``10 *
+oversampling**2`` stars (about 40 for an oversampling of 2, 90 for 3,
+and 160 for 4), and considerably more if the stars are faint. Godden
+and Blundell estimate that about 240 randomly placed stars are needed
+for an oversampling of 4 to have a 95 percent probability of at least
+six samples in every cell. A set of exposures dithered by fractions
+of a pixel that uniformly cover the subpixel phases is far more
+effective than random placement and also allows the star positions
+to be constrained across images (see :ref:`epsf-linked-stars`).
+
+The stars should be bright but unsaturated, isolated (no neighbors
+within the cutout), free of cosmic rays and detector artifacts, and have
+a clean background subtraction so that the total flux of each cutout
+is a reliable normalization. Just as important, all of the stars must
+share the same PSF. Do not combine exposures with different seeing or
+focus, and do not mix regions of the field where the PSF differs unless
+the variation is small compared to the accuracy you need. Heterogeneous
+stars produce pixel-to-pixel noise in the oversampled grid that biases
+the fitted star centers toward particular subpixel phases, and the
+builder emits a warning if the subpixel phases of the fitted centers are
+strongly non-uniform at the end of the build. In that case, inspect the
+star sample rather than increasing the number of iterations.
+
+Finally, check the result. The subpixel phases of the fitted star
+centers should be uniformly distributed, and the fitted fluxes and
+positions of the stars (or of an independent set of stars) should not
+depend on their subpixel phase.

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -401,6 +401,20 @@ provide a custom 2D array, or set it to `None` for no smoothing::
     ...                            smoothing_kernel='quadratic',
     ...                            progress_bar=False)  # doctest: +REMOTE_DATA
 
+Independently of the smoothing kernel, when the oversampling factor
+is greater than one the builder also applies a low-pass filter to the
+ePSF in every iteration. The filter removes only the finest-scale
+structure on the oversampled grid, which a real pixel-integrated PSF
+cannot contain, so it does not blur the ePSF. Together with depositing
+each star pixel residual over its full footprint on the oversampled
+grid, this prevents noise from heterogeneous, contaminated, or low
+signal-to-noise stars from growing into a checkerboard pattern in the
+ePSF. If the subpixel phases of the fitted star centers are strongly
+non-uniform at the end of the build, which indicates biased star
+centers, a warning is emitted. In that case the star sample should be
+inspected for stars with different PSFs, saturated or contaminated
+cutouts, or spurious detections.
+
 Customizing the ePSF Fitting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -696,7 +696,6 @@ typical performance improvements of approximately 20–25%. The
 optimizations reduce the overhead of PSF interpolation, improving the
 runtime of PSF photometry workflows.
 
-
 Photutils Deprecation Warning Class
 ===================================
 
@@ -708,6 +707,42 @@ it easier to find the deprecated code path when a warning is raised from
 within a larger pipeline. Because it is a subclass, existing warning
 filters and ``pytest.warns`` checks for ``AstropyDeprecationWarning``
 continue to work unchanged.
+
+More Robust ePSF Building
+=========================
+
+~photutils.psf.EPSFBuilder no longer produces a checkerboard pattern in
+the ePSF when the input stars are heterogeneous. This includes stars
+from exposures with different PSFs, saturated or contaminated cutouts,
+spurious detections, and low signal-to-noise stars. The issue occurred
+when the oversampling factor was greater than one.
+
+Previously, each star-pixel residual was assigned to the nearest
+oversampled grid point. As a result, neighboring grid points were
+estimated from different subsets of stars. These subsets were selected
+based on the stars' subpixel phases. Noise in the grid biased the fitted
+star centers toward particular subpixel phases. This prevented alternate
+grid points from being sampled evenly. The effect grew with each
+iteration and produced a checkerboard, or alias, pattern.
+
+Now, each star-pixel residual is deposited on every oversampled grid
+point within its footprint. This ensures that every star contributes to
+every grid point, regardless of its subpixel phase. In each iteration,
+power at and above one cycle per input pixel is also removed from
+the ePSF. A pixel-integrated PSF has essentially no signal at these
+frequencies. However, the star-pixel sampling lattice can alias onto the
+oversampled grid.
+
+On clean data, the ePSF is at least as accurate as before and is often
+better. Star centers are recovered more accurately, and the build
+converges in fewer iterations. A warning is now emitted if the fitted
+star centers have strongly non-uniform subpixel phases at the end of the
+build. This indicates that the star centers may be biased.
+
+The ePSF building user guide now includes guidelines for choosing the
+oversampling factor and the star sample, e.g., using at least about four
+grid points per FWHM, not using an oversampling factor larger than the
+data require, and providing enough stars to sample every subpixel cell.
 
 .. _whatsnew-3.1-api-changes:
 

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -17,6 +17,7 @@ from astropy.stats import SigmaClip
 from astropy.utils.decorators import deprecated, deprecated_attribute
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy.ndimage import convolve
+from scipy.stats import chi2 as chi2_dist
 
 from photutils.centroids import centroid_com
 from photutils.psf.epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
@@ -53,6 +54,91 @@ def _fitter_accepts_weights(fitter):
     return ('weights' in spec.parameters
             or any(p.kind == inspect.Parameter.VAR_KEYWORD
                    for p in spec.parameters.values()))
+
+
+def _suppress_alias_modes(data, oversampling, *, nu_pass=0.7, nu_stop=1.0):
+    """
+    Low-pass filter an oversampled ePSF above the input pixel sampling
+    frequency.
+
+    The filter is applied independently along each axis with an
+    oversampling factor greater than one. It has unit gain up to
+    ``nu_pass`` cycles per input (undersampled) pixel, a raised-cosine
+    transition, and zero gain at and above ``nu_stop`` cycles per input
+    pixel. Frequencies at integer cycles per input pixel are the zeros
+    of the pixel response, so a pixel-integrated PSF has essentially no
+    power there or above. However, those are exactly the frequencies at
+    which the star-pixel sampling lattice aliases onto the oversampled
+    grid, so noise at those frequencies can grow into a checkerboard
+    pattern during the ePSF build iterations.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The oversampled ePSF data.
+
+    oversampling : tuple of int
+        The (y, x) oversampling factors.
+
+    nu_pass : float, optional
+        The end of the passband in cycles per input pixel.
+
+    nu_stop : float, optional
+        The start of the stopband in cycles per input pixel.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The filtered data. The input is returned unchanged if both
+        oversampling factors are one.
+    """
+    data = np.asarray(data, dtype=float)
+    for axis in (0, 1):
+        factor = int(oversampling[axis])
+        if factor < 2:
+            continue
+
+        npts = data.shape[axis]
+        # Frequency in cycles per input (undersampled) pixel
+        nu = np.abs(np.fft.fftfreq(npts)) * factor
+        frac = np.clip((nu - nu_pass) / (nu_stop - nu_pass), 0.0, 1.0)
+        gain = 0.5 * (1.0 + np.cos(np.pi * frac))
+        shape = [1, 1]
+        shape[axis] = npts
+
+        spectrum = np.fft.fft(data, axis=axis) * gain.reshape(shape)
+        data = np.fft.ifft(spectrum, axis=axis).real
+
+    return data
+
+
+def _phase_uniformity_pvalue(centers, *, nbins=4):
+    """
+    Compute a chi-square p-value for the uniformity of the subpixel
+    phases of star centers.
+
+    Parameters
+    ----------
+    centers : 2D `~numpy.ndarray`
+        The (x, y) star centers, one row per star.
+
+    nbins : int, optional
+        The number of phase bins per axis.
+
+    Returns
+    -------
+    pvalue : float
+        The p-value of the chi-square test of a uniform phase
+        distribution, combining both axes.
+    """
+    chi2 = 0.0
+    for axis in (0, 1):
+        phases = np.mod(centers[:, axis], 1.0)
+        hist = np.histogram(phases, bins=nbins, range=(0.0, 1.0))[0]
+        expected = len(phases) / nbins
+        chi2 += np.sum((hist - expected) ** 2) / expected
+
+    return chi2_dist.sf(chi2, 2 * (nbins - 1))
 
 
 class _SmoothingKernel:
@@ -1079,6 +1165,21 @@ class EPSFBuilder:
 
     Notes
     -----
+    In each build iteration, the residual between each star and the
+    current ePSF model is deposited on every oversampled grid point
+    inside the footprint of each star pixel, so that every star
+    contributes to every grid point regardless of its subpixel phase.
+    After the residuals are combined and the ePSF is smoothed, power
+    at and above one cycle per input pixel is removed along each
+    oversampled axis. A pixel-integrated PSF has essentially no power
+    there, but those are the frequencies at which the star-pixel
+    sampling lattice aliases onto the oversampled grid. Without
+    these two measures, noise in the ePSF grid from heterogeneous
+    or contaminated stars can bias the fitted star centers toward
+    particular subpixel phases and grow into a checkerboard pattern in
+    the ePSF. A warning is emitted if the subpixel phases of the fitted
+    star centers are strongly non-uniform at the end of the build.
+
     This class stores per-call state on the instance (e.g., the list
     of per-iteration ePSFs), so a single instance must not be called
     concurrently from multiple threads. Create one instance per
@@ -1293,8 +1394,13 @@ class EPSFBuilder:
         A normalized residual image is calculated by subtracting the
         normalized ePSF model from the normalized star at the location
         of the star in the undersampled grid. The normalized residual
-        image is then resampled from the undersampled star grid to the
-        oversampled ePSF grid.
+        image is then resampled from the undersampled star grid to
+        the oversampled ePSF grid by depositing each star pixel value
+        on every oversampled grid point inside the footprint of that
+        pixel. Every star therefore contributes to every grid point that
+        its cutout covers, regardless of its subpixel phase. For an
+        oversampling factor of one along an axis, this reduces to the
+        nearest grid point.
 
         Parameters
         ----------
@@ -1323,20 +1429,29 @@ class EPSFBuilder:
                                     y=yidx_centered,
                                     flux=1.0, x_0=0.0, y_0=0.0))
 
-        # Use coordinate transformer to map to the oversampled ePSF grid
-        xidx, yidx = self._coord_transformer.star_to_epsf_coords(
-            xidx_centered, yidx_centered, epsf.origin)
+        # Star pixel centers in the oversampled ePSF grid
+        x_over, y_over = self._coord_transformer.undersampled_to_oversampled(
+            xidx_centered, yidx_centered)
+        x_over = x_over + epsf.origin[0]
+        y_over = y_over + epsf.origin[1]
 
         epsf_shape = epsf.data.shape
         if out_image is None:
             out_image = np.full(epsf_shape, np.nan)
 
-        mask = np.logical_and(np.logical_and(xidx >= 0, xidx < epsf_shape[1]),
-                              np.logical_and(yidx >= 0, yidx < epsf_shape[0]))
-        xidx_ = xidx[mask]
-        yidx_ = yidx[mask]
-
-        out_image[yidx_, xidx_] = stardata[mask]
+        # Each star pixel covers the grid points k with x_over - os /
+        # 2 < k <= x_over + os / 2, which is exactly oversampled grid
+        # points along each axis.
+        ny_over, nx_over = self.oversampling
+        x_first = np.floor(x_over - nx_over / 2.0).astype(int) + 1
+        y_first = np.floor(y_over - ny_over / 2.0).astype(int) + 1
+        for j in range(ny_over):
+            yidx = y_first + j
+            for i in range(nx_over):
+                xidx = x_first + i
+                mask = ((xidx >= 0) & (xidx < epsf_shape[1])
+                        & (yidx >= 0) & (yidx < epsf_shape[0]))
+                out_image[yidx[mask], xidx[mask]] = stardata[mask]
 
         return out_image
 
@@ -1605,6 +1720,11 @@ class EPSFBuilder:
 
         # Smooth the ePSF
         smoothed_data = self._smooth_epsf(new_epsf)
+
+        # Remove power at and above the input pixel sampling frequency
+        # along oversampled axes, where the star-pixel lattice aliases
+        # onto the ePSF grid.
+        smoothed_data = _suppress_alias_modes(smoothed_data, self.oversampling)
 
         # Recenter the ePSF using an intermediate ePSF that keeps the
         # current epsf's origin. The recentering shifts the ePSF by
@@ -1922,6 +2042,47 @@ class EPSFBuilder:
 
         return epsf, stars, fit_failed
 
+    @staticmethod
+    def _warn_nonuniform_phases(stars, *, min_stars=32, pvalue=1.0e-6):
+        """
+        Warn if the subpixel phases of the fitted star centers are
+        strongly non-uniform.
+
+        Unbiased star centers have uniformly distributed subpixel
+        phases. A strongly non-uniform distribution indicates that
+        the fitted centers are biased toward particular phases, which
+        happens when the ePSF grid is noisy (e.g., for heterogeneous,
+        contaminated, or low signal-to-noise stars).
+
+        Parameters
+        ----------
+        stars : `EPSFStars` object
+            The fitted stars.
+
+        min_stars : int, optional
+            The minimum number of successfully fitted stars needed to
+            perform the check.
+
+        pvalue : float, optional
+            The chi-square p-value below which the warning is emitted.
+        """
+        centers = [star.cutout_center for star in stars.all_stars
+                   if not star._excluded_from_fit
+                   and star._fit_error_status == 0]
+        if len(centers) < min_stars:
+            return
+
+        if _phase_uniformity_pvalue(np.array(centers)) < pvalue:
+            msg = ('The subpixel phases of the fitted star centers are '
+                   'strongly non-uniform, which indicates that the star '
+                   'centers are biased. The ePSF and the fitted star '
+                   'centers may be unreliable. This can be caused by '
+                   'stars with different PSFs, contaminated or saturated '
+                   'star cutouts, spurious detections, or low '
+                   'signal-to-noise stars. Consider using a cleaner '
+                   'star sample or a lower oversampling factor.')
+            warnings.warn(msg, AstropyUserWarning)
+
     def _finalize_build(self, epsf, stars, progress_reporter, iter_num,
                         converged, final_center_accuracy):
         """
@@ -1964,6 +2125,10 @@ class EPSFBuilder:
         excluded_star_indices = [i for i, star
                                  in enumerate(stars.all_stars)
                                  if star._excluded_from_fit]
+
+        # Warn if the fitted star centers have strongly non-uniform
+        # subpixel phases.
+        self._warn_nonuniform_phases(stars)
 
         # Create structured result
         return EPSFBuildResults(

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -1077,7 +1077,15 @@ class EPSFBuilder:
         The integer oversampling factor(s) of the output ePSF relative
         to the input ``stars`` along each axis. If ``oversampling`` is a
         scalar then it will be used for both axes. If ``oversampling``
-        has two elements, they must be in ``(y, x)`` order.
+        has two elements, they must be in ``(y, x)`` order. The ePSF
+        should have at least about four grid points per FWHM, so a good
+        rule of thumb is ``oversampling >= 4 / FWHM`` with the FWHM
+        in pixels. Do not use a larger value than the data require.
+        For well-sampled data (a FWHM of a few pixels or more), an
+        oversampling of 1 is usually the best choice. Larger values
+        require more stars, roughly ``10 * oversampling**2`` stars with
+        uniformly distributed subpixel phases. See the guidelines in the
+        ePSF building user guide for details.
 
     shape : int, tuple of two ints, or `None`, optional
         The (ny, nx) shape of the output ePSF. If the input shape is
@@ -1091,8 +1099,14 @@ class EPSFBuilder:
         The smoothing kernel to apply to the ePSF during each iteration
         step. The predefined ``'quartic'`` and ``'quadratic'`` kernels
         are derived from fourth and second degree polynomials,
-        respectively. Alternatively, a custom 2D array can be input. If
-        `None` then no smoothing will be performed.
+        respectively. Alternatively, a custom 2D array can be input.
+        If `None` then no smoothing will be performed. The kernels are
+        applied on the oversampled grid, so their physical width depends
+        on the oversampling factor. For heavily undersampled ePSFs with
+        only a few grid points per FWHM, the kernels can lower the peak
+        of the ePSF and `None` is a reasonable choice. Power at and
+        above one cycle per input pixel is always removed from the ePSF
+        along oversampled axes, independently of this parameter.
 
     sigma_clip : `astropy.stats.SigmaClip` instance, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -2238,8 +2238,10 @@ class TestEPSFBuilder:
         with pytest.raises(ValueError, match=match):
             builder(stars)
 
-    @pytest.mark.parametrize('oversamp', [1, 2, 3, 4, 5])
-    def test_build_oversampling(self, oversamp):
+    @pytest.mark.parametrize(('oversamp', 'fwhm'),
+                             [(1, 7.0), (2, 7.0), (3, 7.0), (4, 7.0),
+                              (5, 7.0), (2, 3.0), (4, 2.0)])
+    def test_build_oversampling(self, oversamp, fwhm):
         """
         Test that the ePSF built with oversampling has the expected
         shape and properties.
@@ -2247,9 +2249,10 @@ class TestEPSFBuilder:
         Sources are placed on a regular grid with exact subpixel offsets
         to ensure that the ePSF is properly sampled. The test checks
         that the resulting ePSF has the expected shape, that it sums to
-        the expected value for an oversampled PSF, and that its shape
-        matches the input PSF model when scaled by the sum of the ePSF
-        data.
+        the expected value for an oversampled PSF, and that it matches
+        the true ePSF, i.e., the PSF integrated over a full input pixel
+        at each oversampled grid offset. The undersampled cases are
+        sensitive to this definition of the truth.
         """
         offsets = (np.arange(oversamp) * 1.0 / oversamp - 0.5 + 1.0
                    / (2.0 * oversamp))
@@ -2258,7 +2261,6 @@ class TestEPSFBuilder:
         ydithers = np.transpose(xydithers)[1]
 
         n_stars = oversamp**2
-        fwhm = 7.0
         sources = Table()
         offset = 50
         size = oversamp * offset + offset
@@ -2303,21 +2305,21 @@ class TestEPSFBuilder:
         expected_sum = oversamp**2
         assert_allclose(epsf.data.sum(), expected_sum, rtol=0.02)
 
-        # Check that the shape of the ePSF matches the input PSF model
-        # when scaled by the sum of the ePSF data. The input PSF model
-        # is a circular Gaussian with the specified FWHM, and the ePSF
-        # should approximate this shape when scaled by the total flux.
-
-        # Calculate the expected PSF shape based on the input model and
-        # the oversampling factor. The FWHM should be scaled by the
-        # oversampling factor to match the ePSF sampling.
+        # Check that the ePSF matches the true ePSF. The true ePSF
+        # at each oversampled grid point is the PSF integrated over
+        # a full input pixel centered at that grid offset (in input
+        # pixel units), which is what the pixel-integrated PRF model
+        # evaluates. Note that evaluating the PRF with the FWHM scaled
+        # by the oversampling factor on the oversampled grid would
+        # instead integrate over 1 / oversamp of a pixel and is not
+        # the ePSF.
         size = epsf.data.shape[0]
         cen = (size - 1) / 2
-        fwhm2 = oversamp * fwhm
-        model = CircularGaussianPRF(flux=1, x_0=cen, y_0=cen, fwhm=fwhm2)
+        model = CircularGaussianPRF(flux=1, x_0=0, y_0=0, fwhm=fwhm)
         yy, xx = np.mgrid[0:size, 0:size]
-        psf = model(xx, yy) * oversamp**2
-        assert_allclose(epsf.data, psf, atol=2e-4)
+        psf = model((xx - cen) / oversamp, (yy - cen) / oversamp)
+        assert_allclose(psf.sum(), expected_sum, rtol=1e-3)
+        assert_allclose(epsf.data, psf, atol=3e-3 * psf.max())
 
         # Check that the fitted centers are close to the true source
         # positions

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 from astropy.modeling.fitting import TRFLSQFitter
+from astropy.modeling.models import Gaussian2D
 from astropy.nddata import NDData
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
@@ -22,7 +23,8 @@ from photutils.psf import (CircularGaussianPRF, EPSFBuilder, EPSFBuildResults,
                            EPSFFitter, EPSFStar, EPSFStars, ImagePSF,
                            extract_stars, make_psf_model_image)
 from photutils.psf.epsf_builder import (_CoordinateTransformer, _EPSFValidator,
-                                        _ProgressReporter, _SmoothingKernel)
+                                        _ProgressReporter, _SmoothingKernel,
+                                        _suppress_alias_modes)
 from photutils.psf.epsf_stars import LinkedEPSFStar
 from photutils.utils._optional_deps import HAS_TQDM
 from photutils.utils.exceptions import PhotutilsDeprecationWarning
@@ -2765,3 +2767,172 @@ def test_invalid_recentering_maxiters(value):
     match = 'recentering_maxiters must be a strictly-positive integer'
     with pytest.raises(ValueError, match=match):
         EPSFBuilder(recentering_maxiters=value)
+
+
+def _make_heterogeneous_stars(seed=0, n_side=14):
+    """
+    Make a star sample that mimics non-ideal data.
+
+    The stars have a range of FWHMs and ellipticities, a wide range of
+    fluxes, initial center errors, and about 30 percent of the cutouts
+    contain only noise.
+    """
+    rng = np.random.default_rng(seed)
+    offset = 32
+    size = n_side * offset + offset
+    yy, xx = np.mgrid[0:size, 0:size]
+    image = np.zeros((size, size))
+    xpos = []
+    ypos = []
+    for y0 in np.arange(offset, size - offset // 2, offset):
+        for x0 in np.arange(offset, size - offset // 2, offset):
+            x = x0 + rng.uniform(-0.5, 0.5)
+            y = y0 + rng.uniform(-0.5, 0.5)
+            if rng.uniform() > 0.3:
+                sigma = rng.uniform(3.0, 6.0) / 2.3548
+                ellip = rng.uniform(0, 0.3)
+                theta = rng.uniform(0, np.pi)
+                amp = np.exp(rng.uniform(np.log(50), np.log(2000)))
+                slc = (slice(int(y) - 14, int(y) + 15),
+                       slice(int(x) - 14, int(x) + 15))
+                model = Gaussian2D(amp, x, y, sigma * (1 + ellip),
+                                   sigma * (1 - ellip), theta)
+                image[slc] += model(xx[slc], yy[slc])
+            xpos.append(x)
+            ypos.append(y)
+    image += rng.normal(0, 5.0, image.shape)
+    xpos = np.array(xpos)
+    ypos = np.array(ypos)
+    catalog = Table()
+    catalog['x'] = xpos + rng.normal(0, 0.5, len(xpos))
+    catalog['y'] = ypos + rng.normal(0, 0.5, len(ypos))
+    return extract_stars(NDData(image), catalog, size=25)
+
+
+def _alias_power_fraction(data, oversampling):
+    """
+    Fraction of the ePSF power near the star-pixel alias frequencies
+    along each axis.
+    """
+    power = np.abs(np.fft.fft2(data))**2
+    fractions = []
+    for axis in (0, 1):
+        freq = np.abs(np.fft.fftfreq(data.shape[axis]))
+        near = np.zeros(data.shape[axis], dtype=bool)
+        for k in range(1, oversampling // 2 + 1):
+            near |= np.abs(freq - k / oversampling) < 0.03
+        idx = [slice(None), slice(None)]
+        idx[axis] = near
+        fractions.append(power[tuple(idx)].sum() / power.sum())
+    return fractions
+
+
+@pytest.mark.parametrize('oversampling', [2, 4])
+def test_build_heterogeneous_stars_no_checkerboard(oversampling):
+    """
+    Regression test for a checkerboard ePSF built from non-ideal
+    stars with oversampling > 1.
+
+    Star-to-star heterogeneity produces pixel-to-pixel noise in the
+    oversampled ePSF grid, which biases the fitted star centers toward
+    particular subpixel phases. The biased centers then feed alternate
+    oversampled grid points with different subsets of stars, which
+    grows a checkerboard (alias) pattern in the ePSF.
+    """
+    stars = _make_heterogeneous_stars()
+    builder = EPSFBuilder(oversampling=oversampling, maxiters=4,
+                          fit_shape=11, recentering_boxsize=11,
+                          progress_bar=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', AstropyUserWarning)
+        result = builder(stars)
+
+    assert np.all(np.isfinite(result.epsf.data))
+    alias_power = _alias_power_fraction(result.epsf.data, oversampling)
+    assert max(alias_power) < 5.0e-4
+
+    # The fitted subpixel phases must stay uniform
+    centers = result.fitted_stars.cutout_center_flat
+    for axis in (0, 1):
+        hist = np.histogram(centers[:, axis] % 1, bins=4,
+                            range=(0, 1))[0]
+        chi2 = np.sum((hist - hist.mean())**2) / hist.mean()
+        assert chi2 < 20.0
+
+
+def test_resample_residual_pixel_footprint():
+    """
+    Each star pixel residual is deposited on every oversampled grid
+    point inside the pixel footprint, so a single star covers both
+    parities of the grid along each axis.
+    """
+    data = _make_gaussian_star_data()
+    star = EPSFStar(data, cutout_center=(5.25, 5.25))
+    stars = EPSFStars([star])
+    builder = EPSFBuilder(oversampling=2, progress_bar=False)
+    epsf = builder._create_initial_epsf(stars)
+    resid = builder._resample_residual(star, epsf)
+
+    finite = np.isfinite(resid)
+    assert finite[:, 0::2].any()
+    assert finite[:, 1::2].any()
+    assert finite[0::2, :].any()
+    assert finite[1::2, :].any()
+
+    # Every finite grid value equals one of the normalized star pixel
+    # values and each star pixel covers exactly 2x2 grid points.
+    values = data.ravel() / star.flux
+    assert np.all(np.isin(resid[finite], values))
+    assert finite.sum() == 4 * data.size
+
+    # With oversampling=1 the deposit reduces to the nearest grid point.
+    builder1 = EPSFBuilder(oversampling=1, progress_bar=False)
+    epsf1 = builder1._create_initial_epsf(stars)
+    resid1 = builder1._resample_residual(star, epsf1)
+    assert np.isfinite(resid1).sum() == data.size
+
+
+def test_suppress_alias_modes():
+    """
+    The alias low-pass removes a checkerboard, leaves a well-sampled
+    PSF unchanged, and is a no-op for oversampling=1.
+    """
+    yy, xx = np.mgrid[0:61, 0:61]
+    sigma = 2 * 7.0 / 2.3548
+    psf = np.exp(-((xx - 30.0)**2 + (yy - 30.0)**2) / (2 * sigma**2))
+    checker = 0.1 * (-1.0)**(xx + yy) * psf
+
+    result = _suppress_alias_modes(psf + checker, (2, 2))
+    assert_allclose(result, psf, atol=2e-3)
+    assert_allclose(_suppress_alias_modes(psf, (2, 2)), psf, atol=1e-5)
+    assert_array_equal(_suppress_alias_modes(psf + checker, (1, 1)),
+                       psf + checker)
+
+    # Only the oversampled axis is filtered. A single-axis alternation
+    # is suppressed by more than a factor of ten.
+    rows = 0.1 * (-1.0)**yy * psf
+    result = _suppress_alias_modes(psf + rows, (2, 1))
+    assert np.abs(result - psf).max() < 0.1 * np.abs(rows).max()
+    result = _suppress_alias_modes(psf + rows, (1, 2))
+    assert_allclose(result, psf + rows, atol=1e-5)
+
+
+def test_nonuniform_phase_warning():
+    """
+    A warning is emitted when the fitted star centers have strongly
+    non-uniform subpixel phases.
+    """
+    data = _make_gaussian_star_data()
+    # All stars at integer pixel phase and a fitter that does not move
+    # the centers.
+    stars = EPSFStars([EPSFStar(data, cutout_center=(5.0, 5.0))
+                       for _ in range(60)])
+
+    def fitter(model, **_kwargs):
+        return model
+
+    builder = EPSFBuilder(oversampling=2, maxiters=1, fitter=fitter,
+                          progress_bar=False)
+    match = 'subpixel phases of the fitted star centers'
+    with pytest.warns(AstropyUserWarning, match=match):
+        builder(stars)


### PR DESCRIPTION
With oversampling > 1, each star pixel residual went to the nearest grid point, so neighboring grid points were estimated from different star subsets selected by subpixel phase. Noise from heterogeneous or contaminated stars biased the fitted centers and grew into a checkerboard. Residuals are now deposited over each pixel's full footprint on the oversampled grid, power at and above one cycle per input pixel is removed each iteration, and a warning is emitted for strongly non-uniform subpixel phases. 

This PR also adds user-guide guidelines for choosing the oversampling factor and the star sample. 

Fixes #1066, #1404, #1855