### PR TITLE
Constrain the fluxes of linked stars during ePSF building

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -229,6 +229,15 @@ New Features
     roughly 60% of the model evaluations performed during fitting.
     [#2393]
 
+  - Added a ``constrain_fluxes`` method to ``LinkedEPSFStar`` and a
+    ``constrain_fluxes`` keyword to ``EPSFBuilder`` (default `True`)
+    that constrains the fluxes of linked stars (the same star observed
+    in multiple dithered images) to their mean value after each fitting
+    iteration, in addition to their centers. This breaks the degeneracy
+    between the flux of a star and its subpixel position caused by
+    intra-pixel sensitivity variations, which would otherwise be
+    absorbed into the ePSF. [#2420]
+
 - ``photutils.segmentation``
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -198,7 +198,8 @@ objects) and the `~astropy.nddata.NDData` objects must contain valid
 `~astropy.wcs.WCS` objects. In the case of using multiple images (i.e.,
 dithered images) and a single catalog, the same physical star will be
 "linked" across images, meaning it will be constrained to have the same
-sky coordinate in each input image.
+sky coordinate and, by default, the same flux in each input image (see
+:ref:`epsf-linked-stars`).
 
 Let's extract the 25 x 25 pixel cutouts of our selected stars::
 
@@ -427,6 +428,43 @@ centers, a warning is emitted. In that case the star sample should be
 inspected for stars with different PSFs, saturated or contaminated
 cutouts, or spurious detections.
 
+.. _epsf-linked-stars:
+
+Linked Stars from Dithered Images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the same star is observed in several dithered images, the cutouts
+can be linked as a `~photutils.psf.LinkedEPSFStar` (this happens
+automatically when :func:`~photutils.psf.extract_stars` is given
+multiple images and a single catalog of sky coordinates). After each
+fitting iteration, the builder constrains the centers of the linked
+stars to a single sky coordinate and, by default, their fluxes to
+their mean value. Averaging both the positions and the fluxes across
+dithers is the key step of `Anderson and King 2000 (PASP 112, 1360)
+<https://ui.adsabs.harvard.edu/abs/2000PASP..112.1360A/abstract>`_
+that breaks the degeneracy between the flux of a star and its subpixel
+position caused by intra-pixel sensitivity variations. Without it, the
+pixel-phase dependence of the individual flux measurements is absorbed
+into the ePSF. The flux constraint assumes that the linked images have
+the same flux scale (e.g., the same exposure time and throughput). If
+they do not, set ``constrain_fluxes=False``::
+
+    >>> epsf_builder = EPSFBuilder(oversampling=4, maxiters=3,
+    ...                            constrain_fluxes=False,
+    ...                            progress_bar=False)  # doctest: +REMOTE_DATA
+
+To link stars across images, provide a single catalog with sky
+coordinates and multiple `~astropy.nddata.NDData` objects, each with a
+valid WCS:
+
+.. doctest-skip::
+
+    >>> import astropy.units as u
+    >>> from astropy.coordinates import SkyCoord
+    >>> catalog = Table()
+    >>> catalog['skycoord'] = SkyCoord(ra=[...]*u.deg, dec=[...]*u.deg)
+    >>> stars = extract_stars([nddata1, nddata2], catalog, size=25)
+
 Customizing the ePSF Fitting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -486,30 +524,6 @@ any of the `~astropy.nddata.NDUncertainty` subclasses (e.g.,
     >>> nddata = NDData(data=data, uncertainty=uncertainty)  # doctest: +REMOTE_DATA, +SKIP
 
 
-.. _epsf-linked-stars:
-
-Linked Stars for Dithered Images
---------------------------------
-
-When building an ePSF from multiple dithered images, you can link
-stars across images to ensure they are constrained to have the same
-sky coordinates. This is done by providing a single catalog with sky
-coordinates and multiple `~astropy.nddata.NDData` objects, each with a
-valid WCS.
-
-The :func:`~photutils.psf.extract_stars` function will create
-`~photutils.psf.LinkedEPSFStar` objects that link the corresponding star
-cutouts from each image. During the ePSF building process, linked stars
-are constrained to have the same sky coordinate across all images.
-
-.. doctest-skip::
-
-    >>> import astropy.units as u
-    >>> from astropy.coordinates import SkyCoord
-    >>> catalog = Table()
-    >>> catalog['skycoord'] = SkyCoord(ra=[...]*u.deg, dec=[...]*u.deg)
-    >>> stars = extract_stars([nddata1, nddata2], catalog, size=25)
-
 
 .. _epsf-guidelines:
 
@@ -547,17 +561,17 @@ is usually the best choice.
 Choosing the star sample
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Each of the ``oversampling**2`` subpixel cells within a pixel must be
-sampled by the centers of several stars. With randomly placed stars,
-plan on at least about 10 stars per cell, i.e., roughly ``10 *
+Each of the ``oversampling**2`` subpixel cells within a pixel must
+be sampled by the centers of several stars. With randomly placed
+stars, plan on at least about 10 stars per cell, i.e., roughly ``10 *
 oversampling**2`` stars (about 40 for an oversampling of 2, 90 for 3,
 and 160 for 4), and considerably more if the stars are faint. Godden
 and Blundell estimate that about 240 randomly placed stars are needed
 for an oversampling of 4 to have a 95 percent probability of at least
-six samples in every cell. A set of exposures dithered by fractions
-of a pixel that uniformly cover the subpixel phases is far more
-effective than random placement and also allows the star positions
-to be constrained across images (see :ref:`epsf-linked-stars`).
+six samples in every cell. A set of exposures dithered by fractions of
+a pixel that uniformly cover the subpixel phases is far more effective
+than random placement and also allows the star fluxes and positions to
+be constrained across images (see :ref:`epsf-linked-stars`).
 
 The stars should be bright but unsaturated, isolated (no neighbors
 within the cutout), free of cosmic rays and detector artifacts, and have

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -744,6 +744,20 @@ oversampling factor and the star sample, e.g., using at least about four
 grid points per FWHM, not using an oversampling factor larger than the
 data require, and providing enough stars to sample every subpixel cell.
 
+The fluxes of linked stars (the same star observed in multiple
+dithered images) are now constrained to their mean value after each
+fitting iteration, in addition to their centers, following Anderson
+and King (2000). This breaks the degeneracy between the flux of a
+star and its subpixel position caused by intra-pixel sensitivity
+variations, which would otherwise be absorbed into the ePSF. Set
+``constrain_fluxes=False`` if the linked images have different flux
+scales.
+
+The ePSF building user guide now includes guidelines for choosing the
+oversampling factor and the star sample, e.g., using at least about four
+grid points per FWHM, not using an oversampling factor larger than the
+data require, and providing enough stars to sample every subpixel cell.
+
 .. _whatsnew-3.1-api-changes:
 
 

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -1169,6 +1169,20 @@ class EPSFBuilder:
         is not converging. This parameter is passed to the ``fitter``
         if it supports the ``maxiter`` parameter and ignored otherwise.
 
+    constrain_fluxes : bool, optional
+        Whether to constrain the fluxes of the stars within each
+        `~photutils.psf.LinkedEPSFStar` (i.e., the same physical star
+        observed in multiple dithered images) to their mean value after
+        each fitting iteration, in addition to constraining their
+        centers to the same sky coordinate. This breaks the degeneracy
+        between the flux of a star and its subpixel position caused
+        by intra-pixel sensitivity variations, which would otherwise
+        be absorbed into the ePSF. It assumes that the linked images
+        have the same flux scale (e.g., the same exposure time and
+        throughput). Set to `False` if the linked images have different
+        flux scales. This parameter has no effect on stars that are not
+        linked.
+
     maxiters : int, optional
         The maximum number of ePSF building iterations to perform.
 
@@ -1211,7 +1225,7 @@ class EPSFBuilder:
                  recentering_func=centroid_com, recentering_boxsize=(5, 5),
                  recentering_maxiters=20, center_accuracy=1.0e-3,
                  fitter=None, fit_shape=5, fitter_maxiters=100,
-                 maxiters=10, progress_bar=True):
+                 constrain_fluxes=True, maxiters=10, progress_bar=True):
 
         # Validate and store oversampling using the validator
         self.oversampling = _EPSFValidator.validate_oversampling(
@@ -1287,6 +1301,8 @@ class EPSFBuilder:
 
         self._fitter_has_fit_info = hasattr(self.fitter, 'fit_info')
         self._fitter_accepts_weights = _fitter_accepts_weights(self.fitter)
+
+        self.constrain_fluxes = bool(constrain_fluxes)
 
         # Validate center accuracy using the validator
         _EPSFValidator.validate_center_accuracy(center_accuracy)
@@ -1869,6 +1885,8 @@ class EPSFBuilder:
 
                     fitted_star = LinkedEPSFStar(fitted_star)
                     fitted_star.constrain_centers()
+                    if self.constrain_fluxes:
+                        fitted_star.constrain_fluxes()
 
             else:
                 msg = ('stars must contain only EPSFStar and/or '

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -578,7 +578,8 @@ class LinkedEPSFStar:
 
     Linked stars are `EPSFStar` cutouts from different images that
     represent the same physical star. When building the ePSF, linked
-    stars are constrained to have the same sky coordinates.
+    stars are constrained to have the same sky coordinates and, by
+    default, the same flux.
 
     Note that unlike `EPSFStars` (which is a collection of potentially
     unrelated stars), `LinkedEPSFStar` represents a single logical star
@@ -764,6 +765,37 @@ class LinkedEPSFStar:
             pixel_center = star.wcs_large.world_to_pixel_values(
                 mean_lon, mean_lat)
             star.cutout_center = np.asarray(pixel_center) - star.origin
+
+    def constrain_fluxes(self):
+        """
+        Constrain the fluxes of linked `EPSFStar` objects (i.e., the
+        same physical star) to have the same value.
+
+        Only `EPSFStar` objects that have not been excluded during the
+        ePSF build process will be used to constrain the fluxes.
+
+        The single flux is calculated as the mean of the fluxes of the
+        linked stars. This assumes that the linked images have the
+        same flux scale (e.g., the same exposure time and throughput).
+        Averaging the fluxes across dithered images removes the
+        pixel-phase dependence of the individual flux measurements
+        caused by intra-pixel sensitivity variations, which would
+        otherwise be absorbed into the ePSF (Anderson and King 2000).
+        """
+        if len(self._data) < 2:  # no linked stars
+            return
+
+        if self.all_excluded:
+            msg = ('Cannot constrain fluxes of linked stars because '
+                   'they have all been excluded during the ePSF '
+                   'build process.')
+            warnings.warn(msg, AstropyUserWarning)
+            return
+
+        good_stars = self.all_good_stars
+        mean_flux = np.mean([star.flux for star in good_stars])
+        for star in good_stars:
+            star.flux = mean_flux
 
 
 def _compute_mean_sky_coordinate(sky_coords):

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -115,6 +115,34 @@ def test_build_epsf_linked_stars():
     assert result.epsf.data.shape[0] >= 11
 
 
+@pytest.mark.parametrize('constrain_fluxes', [True, False])
+def test_build_epsf_linked_stars_constrain_fluxes(constrain_fluxes):
+    """
+    Test that the fluxes of linked stars are constrained to their mean
+    after fitting when ``constrain_fluxes`` is `True`.
+    """
+    yy, xx = np.indices((11, 11))
+    sig = 2.5 / 2.3548
+    star_data = np.exp(-((xx - 5.0)**2 + (yy - 5.0)**2) / (2 * sig**2))
+
+    # The same star with different flux scales in the two images
+    stars_list = [EPSFStar(scale * star_data, cutout_center=(5.0, 5.0),
+                           origin=(0, 0), wcs_large=_MockWCS())
+                  for scale in (1.0, 3.0)]
+    linked = LinkedEPSFStar(stars_list)
+    stars = EPSFStars([linked])
+    builder = EPSFBuilder(oversampling=1, maxiters=2,
+                          constrain_fluxes=constrain_fluxes,
+                          progress_bar=False)
+    assert builder.constrain_fluxes is constrain_fluxes
+    result = builder(stars)
+    fluxes = result.fitted_stars[0].flux
+    if constrain_fluxes:
+        assert_allclose(fluxes[0], fluxes[1])
+    else:
+        assert_allclose(fluxes[1] / fluxes[0], 3.0, rtol=0.05)
+
+
 class TestSmoothingKernel:
     """
     Tests for the _SmoothingKernel class.

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -1115,6 +1115,48 @@ class TestLinkedEPSFStar:
         with pytest.warns(AstropyUserWarning, match=match):
             linked.constrain_centers()
 
+    def test_constrain_fluxes(self, simple_wcs):
+        """
+        Test that constrain_fluxes sets the fluxes of the good linked
+        stars to their mean and leaves excluded stars unchanged.
+        """
+        star1 = EPSFStar(np.ones((5, 5)), wcs_large=simple_wcs, flux=10.0)
+        star2 = EPSFStar(np.ones((5, 5)), wcs_large=simple_wcs, flux=20.0)
+        star3 = EPSFStar(np.ones((5, 5)), wcs_large=simple_wcs, flux=90.0)
+        star3._excluded_from_fit = True
+        linked = LinkedEPSFStar([star1, star2, star3])
+
+        linked.constrain_fluxes()
+        assert star1.flux == 15.0
+        assert star2.flux == 15.0
+        assert star3.flux == 90.0
+
+    def test_constrain_fluxes_single_star(self, simple_wcs):
+        """
+        Test that constrain_fluxes is a no-op for a single star.
+        """
+        star = EPSFStar(np.ones((5, 5)), wcs_large=simple_wcs, flux=10.0)
+        linked = LinkedEPSFStar([star])
+        linked.constrain_fluxes()
+        assert star.flux == 10.0
+
+    def test_constrain_fluxes_all_excluded(self, simple_wcs):
+        """
+        Test that constrain_fluxes warns and does nothing when all
+        stars are excluded.
+        """
+        star1 = EPSFStar(np.ones((5, 5)), wcs_large=simple_wcs, flux=10.0)
+        star2 = EPSFStar(np.ones((5, 5)), wcs_large=simple_wcs, flux=20.0)
+        star1._excluded_from_fit = True
+        star2._excluded_from_fit = True
+        linked = LinkedEPSFStar([star1, star2])
+
+        match = 'Cannot constrain fluxes'
+        with pytest.warns(AstropyUserWarning, match=match):
+            linked.constrain_fluxes()
+        assert star1.flux == 10.0
+        assert star2.flux == 20.0
+
     def test_len_getitem_iter(self, simple_wcs):
         """
         Test __len__, __getitem__, and __iter__ methods.


### PR DESCRIPTION
This PR adds `LinkedEPSFStar.constrain_fluxes` and `EPSFBuilder(constrain_fluxes=True)`, which set the fluxes of linked stars to their mean after each fitting iteration, in addition to their centers. This is the Anderson and King (2000) step that breaks the flux versus subpixel-position degeneracy from intra-pixel sensitivity variations. Set `constrain_fluxes=False` for images with different flux scales.

Followup to #2419.