### PR TITLE
Scale the default ePSF smoothing kernel and fit shape with the FWHM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -238,6 +238,10 @@ New Features
     intra-pixel sensitivity variations, which would otherwise be
     absorbed into the ePSF. [#2420]
 
+  - Added ``smoothing_kernel`` and ``fit_shape`` attributes to
+    ``EPSFBuildResults`` that report the smoothing kernel and fitting
+    box used in the final iteration. [#2421]
+
 - ``photutils.segmentation``
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``
@@ -1039,6 +1043,24 @@ API Changes
     container holding a single star (e.g., from indexing) converts to
     that star's 2D cutout, and a container holding multiple stars
     converts to a 3D stack of the cutouts. [#2395]
+
+  - The default ``smoothing_kernel`` and ``fit_shape`` of
+    ``EPSFBuilder`` are now ``'auto'``. The smoothing kernel is a
+    least-squares quartic polynomial kernel whose width is 0.7 times
+    the FWHM of the ePSF in oversampled grid points (no smoothing
+    below 5 grid points), and the fitting box is twice the FWHM of the
+    ePSF in detector pixels (at least 5 pixels and at most the star
+    cutout size). The FWHM is measured in each iteration along the
+    narrowest axis of the ePSF. The previous fixed 5x5 ``'quartic'``
+    kernel (in oversampled grid points) and 5-pixel fitting box (in
+    detector pixels) were designed for HST images with an oversampling
+    factor of 4. A fixed kernel oversmooths heavily undersampled
+    ePSFs, and a fixed 5-pixel fitting box applied to a well-sampled
+    star uses only its flat core, which biases the fitted centers and
+    can prevent convergence. The previous behavior is available with
+    ``smoothing_kernel='quartic'`` and ``fit_shape=5``. An invalid
+    string value for either parameter now raises a ``ValueError``.
+    [#2421]
 
 - ``photutils.segmentation``
 

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -315,6 +315,11 @@ information about the build process::
     >>> result.n_excluded_stars  # doctest: +REMOTE_DATA
     0
 
+The results also report the largest center movement in the final
+iteration (``final_center_accuracy``) and the smoothing kernel and
+fitting box that were used (``smoothing_kernel`` and ``fit_shape``). See
+`~photutils.psf.EPSFBuildResults` for the full list.
+
 The returned ``epsf`` is an `~photutils.psf.ImagePSF` object, and
 ``fitted_stars`` is a new `~photutils.psf.EPSFStars` object with the
 updated star positions and fluxes from fitting the final ePSF model.
@@ -400,18 +405,23 @@ the surrounding grid values, which removes noise while preserving the
 polynomial shape of the ePSF within the kernel window.
 
 The default is ``'auto'``, which uses a quartic (fourth-degree)
-polynomial kernel whose width is 0.7 times the FWHM of the ePSF,
-measured in each iteration along its narrowest axis. The width is
-rounded to an odd number of grid points, and no smoothing is applied
-when it would be smaller than 5 grid points, i.e., for heavily
-undersampled ePSFs with fewer than about 7 grid points per FWHM, where
-a fixed 5x5 kernel would lower the peak of the ePSF. The chosen kernel
-shape is reported in the ``smoothing_kernel_shape`` attribute of the
-results. If the FWHM cannot be measured, the ``'quartic'`` kernel is
-used and a warning is emitted.
+polynomial kernel whose width is 0.7 times the FWHM of the ePSF in
+oversampled grid points, measured in each iteration along its narrowest
+axis. The width is rounded to an odd number of grid points, and no
+smoothing is applied when it would be smaller than 5 grid points, i.e.,
+for heavily undersampled ePSFs with fewer than about 5 grid points per
+FWHM, where a fixed 5x5 kernel would lower the peak of the ePSF. The
+kernel is square, so with anisotropic oversampling the axis with the
+fewer grid points per FWHM sets its size. The chosen kernel is reported
+in the ``smoothing_kernel`` attribute of the results, and it can be
+input as a fixed ``smoothing_kernel`` to reproduce the build. If the
+FWHM cannot be measured, the ``'quartic'`` kernel is used and a warning
+is emitted.
 
 You can also use ``'quartic'`` or ``'quadratic'`` for the fixed 5x5
-fourth- and second-degree polynomial kernels of Anderson and King,
+fourth- and second-degree polynomial kernels of `Anderson and King 2000
+(PASP 112, 1360)
+<https://ui.adsabs.harvard.edu/abs/2000PASP..112.1360A/abstract>`_,
 provide a custom 2D array, or set it to `None` for no smoothing::
 
     >>> epsf_builder = EPSFBuilder(oversampling=4, maxiters=3,
@@ -419,13 +429,14 @@ provide a custom 2D array, or set it to `None` for no smoothing::
     ...                            progress_bar=False)  # doctest: +REMOTE_DATA
 
 The fixed kernels are applied on the oversampled grid, so their physical
-width is ``5 / oversampling`` input pixels. The 5x5 quartic kernel was
-developed for HST data with an oversampling factor of 4, where it is
-about 0.7 FWHM wide. For a heavily undersampled ePSF with only about
-four to six grid points per FWHM, even the ``'quartic'`` kernel lowers
-the peak of the ePSF, and ``smoothing_kernel=None`` is a reasonable
-choice, especially when the stars have high signal-to-noise. Smoothing
-is most useful for well-sampled ePSFs built from noisy or few stars.
+width is ``5 / oversampling`` detector pixels. The 5x5 quartic kernel
+was developed for HST data with an oversampling factor of 4, where
+it is about 0.7 FWHM wide. When using a fixed kernel for a heavily
+undersampled ePSF with fewer than about five grid points per FWHM, the
+kernel lowers the peak of the ePSF, and ``smoothing_kernel=None`` is
+a better choice, especially when the stars have high signal-to-noise.
+Smoothing is most useful for well-sampled ePSFs built from noisy or few
+stars.
 
 Independently of the smoothing kernel, when the oversampling factor
 is greater than one the builder also applies a low-pass filter to the
@@ -483,16 +494,18 @@ Customizing the ePSF Fitting
 
 The :class:`~photutils.psf.EPSFBuilder` class allows you to customize
 the fitting process using the ``fit_shape`` parameter. This parameter
-specifies the size of the box (in pixels) centered on each star used for
-fitting. The default is ``'auto'``, which uses a square box of twice the
-FWHM of the ePSF (measured in each iteration along its narrowest axis),
-with a minimum of 5 pixels and a maximum of the star cutout size. The
-chosen box is reported in the ``fit_shape`` attribute of the results. A
-box that is much smaller than the star, such as the 5-pixel box used for
-HST data, uses only the flat core of a well-sampled star, which biases
-the fitted centers and can prevent the build from converging. Using a
-smaller box can speed up the fitting process while still capturing the
-core of the PSF::
+specifies the size of the box (in detector pixels) centered on each
+star used for fitting. The default is ``'auto'``, which uses a square
+box of twice the FWHM of the ePSF in detector pixels (measured in
+each iteration along its narrowest axis), with a minimum of 5 pixels
+and a maximum of the star cutout size. The chosen box is reported in
+the ``fit_shape`` attribute of the results. A fixed box can be given
+instead. A smaller box speeds up the fitting, but it should still cover
+the core of the star. A box that is much smaller than the star uses only
+its flat core, which biases the fitted centers and can prevent the build
+from converging. The 5-pixel box of Anderson and King is about 2.5 FWHM
+wide for HST data but only about 1 FWHM wide for a star with a FWHM of 5
+pixels::
 
     >>> epsf_builder = EPSFBuilder(oversampling=4, maxiters=3,
     ...                            fit_shape=7,

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -392,27 +392,40 @@ Smoothing Kernel
 ^^^^^^^^^^^^^^^^
 
 The ``smoothing_kernel`` parameter controls the smoothing applied to
-the ePSF during each iteration. The smoothing helps to reduce noise in
-the ePSF, especially when the number of stars is small. The default is
-``'quartic'``, which uses a fourth-degree polynomial kernel. This 5x5
-pixel kernel was initially developed by Anderson and King for HST data
-with an ePSF oversampling factor of 4. It is designed to provide a good
-balance between smoothing and preserving the shape of the ePSF.
+the ePSF during each iteration. The smoothing helps to reduce noise
+in the ePSF, especially when the star sample is small or noisy. The
+smoothing kernels are least-squares polynomial smoothers. Each grid
+value is replaced by the value at the center of a polynomial fit to
+the surrounding grid values, which removes noise while preserving the
+polynomial shape of the ePSF within the kernel window.
 
-You can also use ``'quadratic'`` for a second-degree polynomial kernel,
+The default is ``'auto'``, which uses a quartic (fourth-degree)
+polynomial kernel whose width is 0.7 times the FWHM of the ePSF,
+measured in each iteration along its narrowest axis. The width is
+rounded to an odd number of grid points, and no smoothing is applied
+when it would be smaller than 5 grid points, i.e., for heavily
+undersampled ePSFs with fewer than about 7 grid points per FWHM, where
+a fixed 5x5 kernel would lower the peak of the ePSF. The chosen kernel
+shape is reported in the ``smoothing_kernel_shape`` attribute of the
+results. If the FWHM cannot be measured, the ``'quartic'`` kernel is
+used and a warning is emitted.
+
+You can also use ``'quartic'`` or ``'quadratic'`` for the fixed 5x5
+fourth- and second-degree polynomial kernels of Anderson and King,
 provide a custom 2D array, or set it to `None` for no smoothing::
 
     >>> epsf_builder = EPSFBuilder(oversampling=4, maxiters=3,
     ...                            smoothing_kernel='quadratic',
     ...                            progress_bar=False)  # doctest: +REMOTE_DATA
 
-The kernels are applied on the oversampled grid, so their physical width
-is ``5 / oversampling`` input pixels. For a heavily undersampled ePSF
-with only about four to six grid points per FWHM, even the ``'quartic'``
-kernel lowers the peak of the ePSF, and ``smoothing_kernel=None`` is a
-reasonable choice, especially when the stars have high signal-to-noise.
-Smoothing is most useful for well-sampled ePSFs built from noisy or few
-stars.
+The fixed kernels are applied on the oversampled grid, so their physical
+width is ``5 / oversampling`` input pixels. The 5x5 quartic kernel was
+developed for HST data with an oversampling factor of 4, where it is
+about 0.7 FWHM wide. For a heavily undersampled ePSF with only about
+four to six grid points per FWHM, even the ``'quartic'`` kernel lowers
+the peak of the ePSF, and ``smoothing_kernel=None`` is a reasonable
+choice, especially when the stars have high signal-to-noise. Smoothing
+is most useful for well-sampled ePSFs built from noisy or few stars.
 
 Independently of the smoothing kernel, when the oversampling factor
 is greater than one the builder also applies a low-pass filter to the
@@ -470,9 +483,16 @@ Customizing the ePSF Fitting
 
 The :class:`~photutils.psf.EPSFBuilder` class allows you to customize
 the fitting process using the ``fit_shape`` parameter. This parameter
-specifies the size of the box (in pixels) centered on each star used
-for fitting. Using a smaller box can speed up the fitting process while
-still capturing the core of the PSF::
+specifies the size of the box (in pixels) centered on each star used for
+fitting. The default is ``'auto'``, which uses a square box of twice the
+FWHM of the ePSF (measured in each iteration along its narrowest axis),
+with a minimum of 5 pixels and a maximum of the star cutout size. The
+chosen box is reported in the ``fit_shape`` attribute of the results. A
+box that is much smaller than the star, such as the 5-pixel box used for
+HST data, uses only the flat core of a well-sampled star, which biases
+the fitted centers and can prevent the build from converging. Using a
+smaller box can speed up the fitting process while still capturing the
+core of the PSF::
 
     >>> epsf_builder = EPSFBuilder(oversampling=4, maxiters=3,
     ...                            fit_shape=7,

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -753,10 +753,23 @@ variations, which would otherwise be absorbed into the ePSF. Set
 ``constrain_fluxes=False`` if the linked images have different flux
 scales.
 
-The ePSF building user guide now includes guidelines for choosing the
-oversampling factor and the star sample, e.g., using at least about four
-grid points per FWHM, not using an oversampling factor larger than the
-data require, and providing enough stars to sample every subpixel cell.
+The default smoothing kernel and fitting box now scale with the FWHM of
+the ePSF (``smoothing_kernel='auto'`` and ``fit_shape='auto'``). The
+previous fixed 5x5 ``'quartic'`` kernel (in oversampled grid points) and
+5-pixel fitting box (in detector pixels) were designed for HST images
+with an oversampling factor of 4, where they correspond to about 0.7 and
+2.5 FWHM, respectively. A fixed kernel oversmooths heavily undersampled
+ePSFs, and a fixed 5-pixel fitting box applied to a well-sampled star
+uses only its flat core, which biases the fitted centers and can prevent
+the build from converging. The automatic kernel is a least-squares
+quartic polynomial kernel 0.7 FWHM wide in oversampled grid points
+(no smoothing below 5 grid points), and the automatic fitting box
+is 2 FWHM wide in detector pixels (at least 5 pixels and at most
+the star cutout size). The choices made in the final iteration are
+reported in the new ``smoothing_kernel`` and ``fit_shape`` attributes
+of `~photutils.psf.EPSFBuildResults`, and they can be input as fixed
+values to reproduce the build. The previous behavior is available with
+``smoothing_kernel='quartic'`` and ``fit_shape=5``.
 
 .. _whatsnew-3.1-api-changes:
 

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -8,7 +8,7 @@ import copy
 import inspect
 import numbers
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 from astropy.modeling.fitting import TRFLSQFitter
@@ -33,6 +33,16 @@ from photutils.utils.exceptions import PhotutilsDeprecationWarning
 __all__ = ['EPSFBuildResults', 'EPSFBuilder', 'EPSFFitter']
 
 SIGMA_CLIP = SigmaClipSentinelDefault(sigma=3.0, maxiters=10)
+
+# Parameters of the automatic ('auto') smoothing kernel and fit shape.
+# The smoothing window is this fraction of the ePSF FWHM (in oversampled
+# grid points) and no smoothing is applied below the minimum size. The
+# fit shape is this multiple of the ePSF FWHM (in detector pixels), with
+# the given minimum size.
+_AUTO_KERNEL_FWHM_FRACTION = 0.7
+_AUTO_KERNEL_MIN_SIZE = 5
+_AUTO_FIT_FWHM_FRACTION = 2.0
+_AUTO_FIT_MIN_SIZE = 5
 
 
 def _fitter_accepts_weights(fitter):
@@ -112,6 +122,120 @@ def _suppress_alias_modes(data, oversampling, *, nu_pass=0.7, nu_stop=1.0):
     return data
 
 
+def _odd_size(value):
+    """
+    Round a positive value to the nearest integer and then up to an odd
+    integer.
+
+    The result is the nearest integer when that is odd and the next
+    larger integer when it is even, so the rounding is biased upward
+    rather than to the nearest odd integer (e.g., 5.9 gives 7).
+
+    Parameters
+    ----------
+    value : float
+        The input value.
+
+    Returns
+    -------
+    size : int
+        The odd integer, at least 1.
+    """
+    size = round(value)
+    if size % 2 == 0:
+        size += 1
+    return max(size, 1)
+
+
+def _profile_fwhm(profile):
+    """
+    Measure the full width at half maximum of a 1D profile.
+
+    The width is measured between the first crossings of the half
+    maximum on each side of the peak, using linear interpolation between
+    the neighboring samples.
+
+    Parameters
+    ----------
+    profile : 1D `~numpy.ndarray`
+        The profile.
+
+    Returns
+    -------
+    width : float or `None`
+        The width in samples, or `None` if the peak is not finite and
+        positive or the profile does not cross the half maximum on both
+        sides of the peak within the array.
+    """
+    if not np.any(np.isfinite(profile)):
+        return None
+
+    peak_index = int(np.nanargmax(profile))
+    peak = profile[peak_index]
+    if not np.isfinite(peak) or peak <= 0:
+        return None
+
+    half_max = 0.5 * peak
+    edges = []
+    for step in (-1, 1):
+        i = peak_index
+        while (0 <= i + step < len(profile)
+               and profile[i + step] > half_max):
+            i += step
+        j = i + step
+        if j < 0 or j >= len(profile) or not np.isfinite(profile[j]):
+            return None
+        # Linear interpolation between the last sample above the half
+        # maximum and the first sample at or below it.
+        edges.append(i + step * (profile[i] - half_max)
+                     / (profile[i] - profile[j]))
+
+    return abs(edges[1] - edges[0])
+
+
+def _measure_fwhm(data):
+    """
+    Measure the FWHM of a 2D ePSF along each axis.
+
+    The FWHM is measured along the row and the column through the
+    peak, from the first crossings of the half maximum on each side of
+    the peak. To reduce the sensitivity to noise, the row and column
+    profiles are averaged over the three rows and columns centered on
+    the peak.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The ePSF data.
+
+    Returns
+    -------
+    fwhm : tuple of float or `None`
+        The (y, x) FWHM in grid points, or `None` if the FWHM could not
+        be measured (e.g., a non-positive peak or a profile that does
+        not fall below half of the peak within the array).
+    """
+    data = np.asarray(data, dtype=float)
+    if data.size == 0 or not np.any(np.isfinite(data)):
+        return None
+
+    iy, ix = np.unravel_index(np.nanargmax(data), data.shape)
+    if data[iy, ix] <= 0:
+        return None
+
+    # The rows (columns) of a separable PSF are scaled copies of each
+    # other, so averaging the three rows (columns) around the peak
+    # reduces the noise without broadening the profiles.
+    profile_x = data[max(iy - 1, 0):iy + 2, :].mean(axis=0)
+    profile_y = data[:, max(ix - 1, 0):ix + 2].mean(axis=1)
+    fwhm_x = _profile_fwhm(profile_x)
+    fwhm_y = _profile_fwhm(profile_y)
+    if fwhm_x is None or fwhm_y is None:
+        return None
+
+    return fwhm_y, fwhm_x
+
+
 def _phase_uniformity_pvalue(centers, *, nbins=4):
     """
     Compute a chi-square p-value for the uniformity of the subpixel
@@ -141,6 +265,55 @@ def _phase_uniformity_pvalue(centers, *, nbins=4):
     return chi2_dist.sf(chi2, 2 * (nbins - 1))
 
 
+def _make_polynomial_kernel(size, *, degree=4):
+    """
+    Make the kernel of a least-squares polynomial smoother.
+
+    Convolving an array with this kernel replaces each value by the
+    value at the center of a 2D polynomial of the given degree fit by
+    least squares to the ``size`` x ``size`` values centered on it. The
+    5x5 ``'quartic'`` and ``'quadratic'`` kernels of `_SmoothingKernel`
+    are the ``degree=4`` and ``degree=2`` cases. The quartic kernel
+    is the smoothing kernel of equation 8 of Anderson and King 2000
+    (PASP 112, 1360).
+
+    Parameters
+    ----------
+    size : int
+        The odd size of the square kernel.
+
+    degree : int, optional
+        The degree of the 2D polynomial. The number of polynomial terms
+        must be smaller than the number of kernel elements.
+
+    Returns
+    -------
+    kernel : 2D `~numpy.ndarray`
+        The smoothing kernel.
+    """
+    if size < 3 or size % 2 == 0:
+        msg = 'size must be an odd integer greater than or equal to 3'
+        raise ValueError(msg)
+
+    nterms = (degree + 1) * (degree + 2) // 2
+    if degree < 1 or nterms >= size**2:
+        msg = ('degree must be at least 1 and the number of polynomial '
+               'terms must be smaller than the number of kernel elements')
+        raise ValueError(msg)
+
+    half = size // 2
+    yy, xx = np.mgrid[-half:half + 1, -half:half + 1]
+    design = np.array([xx.ravel()**i * yy.ravel()**j
+                       for i in range(degree + 1)
+                       for j in range(degree + 1 - i)], dtype=float).T
+
+    # The smoothed value at the center is the center row of the
+    # least-squares projection matrix applied to the data.
+    center = half * size + half
+    weights = design @ np.linalg.solve(design.T @ design, design[center])
+    return weights.reshape(size, size)
+
+
 class _SmoothingKernel:
     """
     Utility class for ePSF smoothing kernel generation and convolution.
@@ -149,20 +322,14 @@ class _SmoothingKernel:
     ePSF building and provides consistent smoothing operations.
     """
 
-    # Pre-computed kernels based on polynomial fits
-    QUARTIC_KERNEL = np.array([
-        [+0.041632, -0.080816, 0.078368, -0.080816, +0.041632],
-        [-0.080816, -0.019592, 0.200816, -0.019592, -0.080816],
-        [+0.078368, +0.200816, 0.441632, +0.200816, +0.078368],
-        [-0.080816, -0.019592, 0.200816, -0.019592, -0.080816],
-        [+0.041632, -0.080816, 0.078368, -0.080816, +0.041632]])
+    # The 5x5 least-squares polynomial kernels. The quartic kernel is
+    # equation 8 of Anderson and King 2000.
+    QUARTIC_KERNEL = _make_polynomial_kernel(5, degree=4)
+    QUADRATIC_KERNEL = _make_polynomial_kernel(5, degree=2)
 
-    QUADRATIC_KERNEL = np.array([
-        [-0.07428311, 0.01142786, 0.03999952, 0.01142786, -0.07428311],
-        [+0.01142786, 0.09714283, 0.12571449, 0.09714283, +0.01142786],
-        [+0.03999952, 0.12571449, 0.15428215, 0.12571449, +0.03999952],
-        [+0.01142786, 0.09714283, 0.12571449, 0.09714283, +0.01142786],
-        [-0.07428311, 0.01142786, 0.03999952, 0.01142786, -0.07428311]])
+    # The kernel constructor is a module-level function so that the
+    # class attributes above can be generated when the class is created.
+    make_polynomial_kernel = staticmethod(_make_polynomial_kernel)
 
     @classmethod
     def get_kernel(cls, kernel_type):
@@ -189,14 +356,11 @@ class _SmoothingKernel:
 
         Notes
         -----
-        The predefined kernels are derived from polynomial fits:
-
-        - 'quartic': From Polynomial2D fit with degree=4 to 5x5 array of
-          zeros with 1.0 at the center. Based on fourth degree polynomial.
-
-        - 'quadratic': From Polynomial2D fit with degree=2 to 5x5
-          array of zeros with 1.0 at the center. Based on second degree
-          polynomial.
+        The predefined kernels are 5x5 least-squares polynomial
+        smoothing kernels generated by ``make_polynomial_kernel``. The
+        ``'quartic'`` kernel (degree 4) is the smoothing kernel of
+        equation 8 of Anderson and King 2000 (PASP 112, 1360), and the
+        ``'quadratic'`` kernel is the degree 2 counterpart.
         """
         if isinstance(kernel_type, np.ndarray):
             if kernel_type.ndim != 2:
@@ -782,6 +946,17 @@ class EPSFBuildResults:
         building process. These correspond to positions in the flattened
         star list (stars.all_stars).
 
+    smoothing_kernel : 2D `~numpy.ndarray` or `None`
+        The smoothing kernel applied in the final iteration, or `None`
+        if no smoothing was applied. This includes the kernel chosen
+        by ``smoothing_kernel='auto'``, which can be input as a fixed
+        ``smoothing_kernel`` to reproduce the build.
+
+    fit_shape : tuple or `None`
+        The (ny, nx) shape of the fitting box used in the final
+        iteration, or `None` if the entire star cutouts were fit. This
+        includes the shape chosen by ``fit_shape='auto'``.
+
     Notes
     -----
     This result object maintains backward compatibility by implementing
@@ -809,6 +984,9 @@ class EPSFBuildResults:
     final_center_accuracy: float
     n_excluded_stars: int
     excluded_star_indices: list
+    smoothing_kernel: np.ndarray | None = field(default=None, compare=False,
+                                                repr=False)
+    fit_shape: tuple | None = None
 
     def __iter__(self):
         """
@@ -1095,16 +1273,24 @@ class EPSFBuilder:
         factor. The output ePSF will always have odd sizes along both
         axes to ensure a well-defined central pixel.
 
-    smoothing_kernel : {'quartic', 'quadratic'}, 2D `~numpy.ndarray`, or `None`
+    smoothing_kernel : {'auto', 'quartic', 'quadratic'}, 2D array, or `None`
         The smoothing kernel to apply to the ePSF during each iteration
-        step. The predefined ``'quartic'`` and ``'quadratic'`` kernels
-        are derived from fourth and second degree polynomials,
+        step. If ``'auto'``, a least-squares quartic polynomial kernel
+        (see Notes) whose width is 0.7 times the FWHM of the current
+        ePSF in oversampled grid points is used, and no smoothing
+        is applied if that width is less than 5 grid points, i.e.,
+        for heavily undersampled ePSFs. The kernel is square and the
+        FWHM is measured in each iteration along the narrowest axis
+        of the ePSF, so with anisotropic oversampling the axis with
+        the fewer grid points per FWHM sets the kernel size. If the
+        FWHM cannot be measured, the ``'quartic'`` kernel is used
+        and a warning is emitted. The predefined ``'quartic'`` and
+        ``'quadratic'`` kernels are 5x5 kernels (in oversampled grid
+        points) derived from fourth and second degree polynomials,
         respectively. Alternatively, a custom 2D array can be input.
         If `None` then no smoothing will be performed. The kernels are
-        applied on the oversampled grid, so their physical width depends
-        on the oversampling factor. For heavily undersampled ePSFs with
-        only a few grid points per FWHM, the kernels can lower the peak
-        of the ePSF and `None` is a reasonable choice. Power at and
+        applied on the oversampled grid, so the physical width of a
+        fixed kernel depends on the oversampling factor. Power at and
         above one cycle per input pixel is always removed from the ePSF
         along oversampled axes, independently of this parameter.
 
@@ -1152,16 +1338,21 @@ class EPSFBuilder:
             the ``fitter``, ``fit_shape``, and ``fitter_maxiters``
             parameters instead.
 
-    fit_shape : int, tuple of int, or `None`, optional
-        The size (in pixels) of the box centered on the star to be
-        used for ePSF fitting. This allows using only a small number
-        of central pixels of the star (i.e., where the star is
-        brightest) for fitting. If ``fit_shape`` is a scalar then a
-        square box of size ``fit_shape`` will be used. If ``fit_shape``
-        has two elements, they must be in ``(ny, nx)`` order.
-        ``fit_shape`` must have odd values and be greater than or equal
-        to 3 for both axes. If `None`, the fitter will use the entire
-        star image.
+    fit_shape : {'auto'}, int, tuple of int, or `None`, optional
+        The size (in detector pixels) of the box centered on the star
+        to be used for ePSF fitting. This allows using only a small
+        number of central pixels of the star (i.e., where the star is
+        brightest) for fitting. If ``'auto'``, a square box of twice the
+        FWHM of the current ePSF (measured in each iteration along its
+        narrowest axis, in detector pixels), with a minimum of 5 pixels
+        and a maximum of the smallest star cutout size, is used. For an
+        elongated ePSF, the narrower axis sets the box size along both
+        axes. If the FWHM cannot be measured, a 5x5 box is used and a
+        warning is emitted. If ``fit_shape`` is a scalar then a square
+        box of size ``fit_shape`` will be used. If ``fit_shape`` has two
+        elements, they must be in ``(ny, nx)`` order. ``fit_shape`` must
+        have odd values and be greater than or equal to 3 for both axes.
+        If `None`, the fitter will use the entire star image.
 
     fitter_maxiters : int, optional
         The maximum number of iterations in which the ``fitter`` is
@@ -1208,12 +1399,27 @@ class EPSFBuilder:
     the ePSF. A warning is emitted if the subpixel phases of the fitted
     star centers are strongly non-uniform at the end of the build.
 
+    The default ``smoothing_kernel='auto'`` and ``fit_shape='auto'``
+    scale the smoothing kernel and the fitting box with the FWHM of the
+    ePSF. The 5x5 ``'quartic'`` kernel (in oversampled grid points)
+    and 5-pixel fitting box (in detector pixels) of Anderson and King
+    2000 were designed for HST images with an oversampling factor
+    of 4, where they correspond to about 0.7 and 2.5 FWHM. A fixed
+    kernel oversmooths heavily undersampled ePSFs, and a fixed 5-pixel
+    fitting box applied to a well-sampled star uses only its flat core,
+    which biases the fitted centers and can prevent convergence. The
+    polynomial kernels replace each grid value by the value at the
+    center of a least-squares polynomial fit to the surrounding grid
+    values. The kernel and fitting box chosen in the final iteration are
+    reported in the ``smoothing_kernel`` and ``fit_shape`` attributes of
+    the returned `EPSFBuildResults`.
+
     This class stores per-call state on the instance (e.g., the list
     of per-iteration ePSFs), so a single instance must not be called
-    concurrently from multiple threads. Create one instance per
-    thread for concurrent use. Sharing a single Astropy fitter
-    instance across concurrently-used objects is also unsafe because
-    Astropy fitters store ``fit_info`` on themselves.
+    concurrently from multiple threads. Create one instance per thread
+    for concurrent use. Sharing a single Astropy fitter instance across
+    concurrently-used objects is also unsafe because Astropy fitters
+    store ``fit_info`` on themselves.
     """
 
     coord_transformer = deprecated_attribute(
@@ -1221,10 +1427,10 @@ class EPSFBuilder:
         warning_type=PhotutilsDeprecationWarning)
 
     def __init__(self, *, oversampling=4, shape=None,
-                 smoothing_kernel='quartic', sigma_clip=SIGMA_CLIP,
+                 smoothing_kernel='auto', sigma_clip=SIGMA_CLIP,
                  recentering_func=centroid_com, recentering_boxsize=(5, 5),
                  recentering_maxiters=20, center_accuracy=1.0e-3,
-                 fitter=None, fit_shape=5, fitter_maxiters=100,
+                 fitter=None, fit_shape='auto', fitter_maxiters=100,
                  constrain_fluxes=True, maxiters=10, progress_bar=True):
 
         # Validate and store oversampling using the validator
@@ -1257,14 +1463,26 @@ class EPSFBuilder:
         self.recentering_boxsize = as_pair('recentering_boxsize',
                                            recentering_boxsize,
                                            lower_bound=(3, 1), check_odd=True)
-        if smoothing_kernel is not None:
+
+        if isinstance(smoothing_kernel, str):
+            if smoothing_kernel not in ('auto', 'quartic', 'quadratic'):
+                msg = ("smoothing_kernel must be 'auto', 'quartic', "
+                       "'quadratic', a 2D array, or None")
+                raise ValueError(msg)
+        elif smoothing_kernel is not None:
             # Validate early so bad kernels fail at construction
-            # instead of in the middle of a build
+            # instead of in the middle of a build.
             _SmoothingKernel.get_kernel(smoothing_kernel)
         self.smoothing_kernel = smoothing_kernel
 
-        # Handle fitter parameter - accept both astropy Fitter and
-        # deprecated EPSFFitter for backward compatibility
+        # Per-call state for the automatic smoothing kernel and fit
+        # shape (reset in build_epsf and updated in each iteration).
+        self._auto_state = None
+        self._auto_fit_max = None
+        self._auto_fallback_warned = False
+
+        # Handle fitter parameter. Accept both astropy Fitter and
+        # deprecated EPSFFitter for backward compatibility.
         if isinstance(fitter, EPSFFitter):
             msg = ('Passing an EPSFFitter instance to EPSFBuilder is '
                    'deprecated. Use the fitter, fit_shape, and '
@@ -1283,12 +1501,15 @@ class EPSFBuilder:
             self.fitter = fitter
 
             # Validate fit_shape
-            if fit_shape is not None:
-                self.fit_shape = as_pair('fit_shape', fit_shape,
-                                         lower_bound=(3, 1),
-                                         check_odd=True)
+            if isinstance(fit_shape, str) and not self._is_auto(fit_shape):
+                msg = ("fit_shape must be 'auto', an integer, a tuple of "
+                       'integers, or None')
+                raise ValueError(msg)
+            if fit_shape is None or self._is_auto(fit_shape):
+                self.fit_shape = fit_shape
             else:
-                self.fit_shape = None
+                self.fit_shape = as_pair('fit_shape', fit_shape,
+                                         lower_bound=(3, 1), check_odd=True)
 
             # Validate fitter_maxiters
             self.fitter_maxiters = self._validate_fitter_maxiters(
@@ -1338,6 +1559,107 @@ class EPSFBuilder:
             The result of the ePSF building process.
         """
         return self.build_epsf(stars)
+
+    @staticmethod
+    def _is_auto(value):
+        """
+        Return whether a parameter value is the string ``'auto'``.
+        """
+        return isinstance(value, str) and value == 'auto'
+
+    def _auto_fallback(self):
+        """
+        Return the fallback state used when the ePSF FWHM cannot be
+        measured, warning once per build.
+        """
+        fit_size = _AUTO_FIT_MIN_SIZE
+        if self._auto_fit_max is not None:
+            fit_size = min(fit_size, self._auto_fit_max)
+
+        if not self._auto_fallback_warned:
+            auto_kernel = self._is_auto(self.smoothing_kernel)
+            auto_fit = self._is_auto(self.fit_shape)
+
+            if auto_kernel and auto_fit:
+                what = ('smoothing_kernel and fit_shape fall back to the '
+                        f"'quartic' kernel and a fit shape of {fit_size}")
+            elif auto_kernel:
+                what = "smoothing_kernel falls back to the 'quartic' kernel"
+            else:
+                what = f'fit_shape falls back to a fit shape of {fit_size}'
+
+            msg = ('The FWHM of the ePSF could not be measured, so the '
+                   f"'auto' {what}.")
+            warnings.warn(msg, AstropyUserWarning)
+
+            self._auto_fallback_warned = True
+
+        return {'kernel': _SmoothingKernel.QUARTIC_KERNEL,
+                'fit_shape': (fit_size, fit_size)}
+
+    def _update_auto_parameters(self, epsf_data):
+        """
+        Choose the smoothing kernel and fit shape from the FWHM of the
+        current ePSF.
+
+        The smoothing window is ``_AUTO_KERNEL_FWHM_FRACTION`` times
+        the FWHM in oversampled grid points (no smoothing below
+        ``_AUTO_KERNEL_MIN_SIZE``), and the fit shape is
+        ``_AUTO_FIT_FWHM_FRACTION`` times the FWHM in detector pixels
+        (at least ``_AUTO_FIT_MIN_SIZE`` and at most the smallest star
+        cutout size). The FWHM is measured along the narrowest axis of
+        the ePSF.
+
+        Parameters
+        ----------
+        epsf_data : 2D `~numpy.ndarray`
+            The current (unsmoothed) ePSF data.
+        """
+        if not (self._is_auto(self.smoothing_kernel)
+                or self._is_auto(self.fit_shape)):
+            return
+
+        fwhm = _measure_fwhm(epsf_data)
+        if fwhm is None:
+            self._auto_state = self._auto_fallback()
+            return
+
+        fwhm_grid = min(fwhm)
+        fwhm_pixels = min(fwhm[0] / self.oversampling[0],
+                          fwhm[1] / self.oversampling[1])
+
+        kernel = None
+        # Cap the kernel at the largest odd size smaller than the ePSF.
+        # A kernel as large as the ePSF would fit every grid value
+        # mostly to edge-reflected data.
+        size = _odd_size(_AUTO_KERNEL_FWHM_FRACTION * fwhm_grid)
+        size = min(size, _odd_size(min(epsf_data.shape)) - 2)
+        if size >= _AUTO_KERNEL_MIN_SIZE:
+            kernel = _SmoothingKernel.make_polynomial_kernel(size, degree=4)
+
+        fit_size = max(_AUTO_FIT_MIN_SIZE,
+                       _odd_size(_AUTO_FIT_FWHM_FRACTION * fwhm_pixels))
+        if self._auto_fit_max is not None:
+            fit_size = min(fit_size, self._auto_fit_max)
+
+        self._auto_state = {'kernel': kernel,
+                            'fit_shape': (fit_size, fit_size)}
+
+    def _current_smoothing_kernel(self):
+        """
+        Return the smoothing kernel for the current iteration.
+        """
+        if self._is_auto(self.smoothing_kernel):
+            return self._auto_state['kernel']
+        return self.smoothing_kernel
+
+    def _current_fit_shape(self):
+        """
+        Return the fit shape for the current iteration.
+        """
+        if self._is_auto(self.fit_shape):
+            return self._auto_state['fit_shape']
+        return self.fit_shape
 
     def _validate_fitter_maxiters(self, fitter_maxiters):
         """
@@ -1534,8 +1856,8 @@ class EPSFBuilder:
         result : 2D `~numpy.ndarray`
             The smoothed (convolved) ePSF data.
         """
-        return _SmoothingKernel.apply_smoothing(epsf_data,
-                                                self.smoothing_kernel)
+        return _SmoothingKernel.apply_smoothing(
+            epsf_data, self._current_smoothing_kernel())
 
     def _normalize_epsf(self, epsf_data):
         """
@@ -1748,6 +2070,10 @@ class EPSFBuilder:
         # Add the residuals to the previous ePSF image
         new_epsf = epsf.data + residuals
 
+        # Choose the automatic smoothing kernel and fit shape from the
+        # FWHM of the current ePSF.
+        self._update_auto_parameters(new_epsf)
+
         # Smooth the ePSF
         smoothed_data = self._smooth_epsf(new_epsf)
 
@@ -1914,7 +2240,7 @@ class EPSFBuilder:
         star : `EPSFStar`
             The fitted star with updated cutout center and flux.
         """
-        fit_shape = self.fit_shape
+        fit_shape = self._current_fit_shape()
         fitter = self.fitter
         fitter_kwargs = self._fitter_kwargs
         fitter_has_fit_info = self._fitter_has_fit_info
@@ -2162,7 +2488,17 @@ class EPSFBuilder:
         # subpixel phases.
         self._warn_nonuniform_phases(stars)
 
-        # Create structured result
+        # Create structured result. The kernel is copied so that the
+        # results own it and edits cannot reach the shared predefined
+        # kernels or the input array.
+        kernel = self._current_smoothing_kernel()
+        if kernel is not None:
+            kernel = _SmoothingKernel.get_kernel(kernel).copy()
+
+        fit_shape = self._current_fit_shape()
+        if fit_shape is not None:
+            fit_shape = tuple(int(size) for size in fit_shape)
+
         return EPSFBuildResults(
             epsf=epsf,
             fitted_stars=stars,
@@ -2171,6 +2507,8 @@ class EPSFBuilder:
             final_center_accuracy=final_center_accuracy,
             n_excluded_stars=len(excluded_star_indices),
             excluded_star_indices=excluded_star_indices,
+            smoothing_kernel=kernel,
+            fit_shape=fit_shape,
         )
 
     def build_epsf(self, stars, *, epsf=None):
@@ -2231,6 +2569,15 @@ class EPSFBuilder:
         fit_failed = np.zeros(stars.n_all_stars, dtype=bool)
         centers = stars.cutout_center_flat
 
+        # Reset the per-call automatic kernel and fit shape state. The
+        # automatic fit shape cannot exceed the smallest star cutout.
+        self._auto_state = None
+        self._auto_fallback_warned = False
+        min_cutout = min(min(star.shape) for star in stars.all_stars)
+        self._auto_fit_max = _odd_size(min_cutout)
+        if self._auto_fit_max > min_cutout:
+            self._auto_fit_max -= 2
+
         # Setup progress tracking
         progress_reporter = _ProgressReporter(self.progress_bar,
                                               self.maxiters).setup()
@@ -2259,7 +2606,7 @@ class EPSFBuilder:
             progress_reporter.update()
 
         # Calculate the final center accuracy
-        final_center_accuracy = np.max(center_dist_sq) ** 0.5
+        final_center_accuracy = float(np.max(center_dist_sq) ** 0.5)
 
         # Finalize and return structured results
         return self._finalize_build(epsf, stars, progress_reporter,

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -2547,6 +2547,8 @@ class EPSFBuilder:
         - final_center_accuracy: Final center movement accuracy
         - n_excluded_stars: Number of stars excluded due to fit failures
         - excluded_star_indices: Indices of excluded stars
+        - smoothing_kernel: Smoothing kernel of the final iteration
+        - fit_shape: Fitting box of the final iteration
         """
         if epsf is not None:
             if not np.array_equal(epsf.oversampling, self.oversampling):

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -23,7 +23,8 @@ from photutils.psf import (CircularGaussianPRF, EPSFBuilder, EPSFBuildResults,
                            EPSFFitter, EPSFStar, EPSFStars, ImagePSF,
                            extract_stars, make_psf_model_image)
 from photutils.psf.epsf_builder import (_CoordinateTransformer, _EPSFValidator,
-                                        _ProgressReporter, _SmoothingKernel,
+                                        _measure_fwhm, _ProgressReporter,
+                                        _SmoothingKernel,
                                         _suppress_alias_modes)
 from photutils.psf.epsf_stars import LinkedEPSFStar
 from photutils.utils._optional_deps import HAS_TQDM
@@ -824,7 +825,7 @@ class TestEPSFBuildResults:
         assert result.fitted_stars is not None
         assert isinstance(result.iterations, int)
         assert isinstance(result.converged, bool)
-        assert isinstance(result.final_center_accuracy, (float, np.floating))
+        assert type(result.final_center_accuracy) is float
         assert isinstance(result.n_excluded_stars, int)
         assert isinstance(result.excluded_star_indices, list)
 
@@ -1271,8 +1272,9 @@ class TestEPSFBuilder:
         # Test with default fitter (TRFLSQFitter)
         builder1 = EPSFBuilder(maxiters=3)
         assert isinstance(builder1.fitter, TRFLSQFitter)
-        # Default fit_shape is 5
-        assert_array_equal(builder1.fit_shape, (5, 5))
+        # Default fit_shape is 'auto'
+        assert builder1.fit_shape == 'auto'
+        assert builder1.smoothing_kernel == 'auto'
         assert builder1.fitter_maxiters == 100
 
         # Test with explicit astropy fitter
@@ -1749,7 +1751,8 @@ class TestEPSFBuilder:
         original_star._excluded_from_fit = True
 
         # Create an ePSF for fitting
-        builder = EPSFBuilder(oversampling=1, maxiters=1, progress_bar=False)
+        builder = EPSFBuilder(oversampling=1, maxiters=1, fit_shape=5,
+                              progress_bar=False)
         epsf = builder._create_initial_epsf(stars)
 
         # Fit the stars using the builder's internal method
@@ -2347,7 +2350,9 @@ class TestEPSFBuilder:
         yy, xx = np.mgrid[0:size, 0:size]
         psf = model((xx - cen) / oversamp, (yy - cen) / oversamp)
         assert_allclose(psf.sum(), expected_sum, rtol=1e-3)
-        assert_allclose(epsf.data, psf, atol=3e-3 * psf.max())
+        # The default 'auto' smoothing kernel (0.7 FWHM wide) lowers
+        # the peak of a noiseless ePSF by a few tenths of a percent.
+        assert_allclose(epsf.data, psf, atol=5e-3 * psf.max())
 
         # Check that the fitted centers are close to the true source
         # positions
@@ -2786,10 +2791,18 @@ def test_build_epsf_fully_excluded_linked_star():
     assert result.epsf is not None
 
 
-def test_invalid_smoothing_kernel_at_init():
-    match = 'Unsupported kernel type'
-    with pytest.raises(TypeError, match=match):
-        EPSFBuilder(smoothing_kernel='bogus')
+@pytest.mark.parametrize('value', ['bogus', 'AUTO'])
+def test_invalid_smoothing_kernel_at_init(value):
+    match = "smoothing_kernel must be 'auto', 'quartic', 'quadratic'"
+    with pytest.raises(ValueError, match=match):
+        EPSFBuilder(smoothing_kernel=value)
+
+
+@pytest.mark.parametrize('value', ['bogus', 'AUTO'])
+def test_invalid_fit_shape_string(value):
+    match = "fit_shape must be 'auto', an integer, a tuple of integers"
+    with pytest.raises(ValueError, match=match):
+        EPSFBuilder(fit_shape=value)
 
 
 @pytest.mark.parametrize('value', [-3, 0, 2.5, True])
@@ -2966,3 +2979,290 @@ def test_nonuniform_phase_warning():
     match = 'subpixel phases of the fitted star centers'
     with pytest.warns(AstropyUserWarning, match=match):
         builder(stars)
+
+
+class TestPolynomialKernel:
+    """
+    Tests for _SmoothingKernel.make_polynomial_kernel.
+    """
+
+    def test_quartic_matches_anderson_king(self):
+        """
+        The 'quartic' kernel is the 5x5 least-squares quartic kernel
+        of equation 8 of Anderson and King 2000 (PASP 112, 1360). The
+        printed table contains two misprints in its first and last rows
+        that break the symmetry of the kernel, so the symmetric values
+        are used here.
+        """
+        published = np.array([
+            [+0.041632, -0.080816, 0.078368, -0.080816, +0.041632],
+            [-0.080816, -0.019592, 0.200816, -0.019592, -0.080816],
+            [+0.078368, +0.200816, 0.441632, +0.200816, +0.078368],
+            [-0.080816, -0.019592, 0.200816, -0.019592, -0.080816],
+            [+0.041632, -0.080816, 0.078368, -0.080816, +0.041632]])
+        assert_allclose(_SmoothingKernel.QUARTIC_KERNEL, published,
+                        atol=1e-6)
+        assert_allclose(_SmoothingKernel.get_kernel('quartic'), published,
+                        atol=1e-6)
+
+    def test_exact_values(self):
+        """
+        The 5x5 kernels have exact rational values.
+        """
+        quartic = _SmoothingKernel.QUARTIC_KERNEL
+        assert_allclose(quartic[2, 2], 541 / 1225, rtol=1e-12)
+        assert_allclose(quartic[2, 1], 246 / 1225, rtol=1e-12)
+        assert_allclose(quartic[2, 0], 96 / 1225, rtol=1e-12)
+        assert_allclose(quartic[0, 0], 51 / 1225, rtol=1e-12)
+        assert_allclose(quartic.sum(), 1.0, rtol=1e-12)
+
+        quadratic = _SmoothingKernel.QUADRATIC_KERNEL
+        assert_allclose(quadratic[2, 2], 27 / 175, rtol=1e-12)
+        assert_allclose(quadratic[2, 1], 22 / 175, rtol=1e-12)
+        assert_allclose(quadratic[2, 0], 1 / 25, rtol=1e-12)
+        assert_allclose(quadratic[0, 0], -13 / 175, rtol=1e-12)
+        assert_allclose(quadratic.sum(), 1.0, rtol=1e-12)
+
+    @pytest.mark.parametrize('size', [7, 9, 11])
+    def test_properties(self, size):
+        kernel = _SmoothingKernel.make_polynomial_kernel(size)
+        assert kernel.shape == (size, size)
+        assert_allclose(kernel.sum(), 1.0)
+        assert_allclose(kernel, kernel.T)
+        assert_allclose(kernel, kernel[::-1, ::-1])
+
+        # The kernel preserves any quartic polynomial exactly.
+        yy, xx = np.mgrid[0:41, 0:41] - 20.0
+        poly = 1.0 + 0.1 * xx - 0.2 * yy + 0.01 * xx * yy**3 + 1e-3 * xx**4
+        smoothed = _SmoothingKernel.apply_smoothing(poly, kernel)
+        half = size // 2
+        assert_allclose(smoothed[half:-half, half:-half],
+                        poly[half:-half, half:-half], atol=1e-9)
+
+    def test_invalid(self):
+        match = 'size must be an odd integer'
+        with pytest.raises(ValueError, match=match):
+            _SmoothingKernel.make_polynomial_kernel(4)
+        with pytest.raises(ValueError, match=match):
+            _SmoothingKernel.make_polynomial_kernel(1)
+        match = 'degree must be at least 1'
+        with pytest.raises(ValueError, match=match):
+            _SmoothingKernel.make_polynomial_kernel(5, degree=0)
+        with pytest.raises(ValueError, match=match):
+            _SmoothingKernel.make_polynomial_kernel(3, degree=4)
+
+
+class TestMeasureFWHM:
+    """
+    Tests for _measure_fwhm.
+    """
+
+    @staticmethod
+    def _gaussian(fwhm_y, fwhm_x, size=61):
+        yy, xx = np.mgrid[0:size, 0:size] - size // 2
+        sig_y = fwhm_y / 2.3548
+        sig_x = fwhm_x / 2.3548
+        return np.exp(-0.5 * ((xx / sig_x)**2 + (yy / sig_y)**2))
+
+    def test_gaussian(self):
+        fwhm_y, fwhm_x = _measure_fwhm(self._gaussian(6.0, 10.0))
+        assert_allclose(fwhm_y, 6.0, rtol=0.02)
+        assert_allclose(fwhm_x, 10.0, rtol=0.02)
+
+    def test_scaled_and_offset_peak(self):
+        data = 1000.0 * self._gaussian(8.0, 8.0)
+        data = np.roll(data, (5, -7), axis=(0, 1))
+        fwhm = _measure_fwhm(data)
+        assert_allclose(fwhm, (8.0, 8.0), rtol=0.02)
+
+    def test_unmeasurable(self):
+        # Non-positive peak
+        assert _measure_fwhm(np.zeros((11, 11))) is None
+        assert _measure_fwhm(-self._gaussian(5.0, 5.0)) is None
+        # No finite values
+        assert _measure_fwhm(np.full((11, 11), np.nan)) is None
+        # Flat profile that never falls below half of the peak
+        assert _measure_fwhm(np.ones((11, 11))) is None
+        # Peak at the edge of the array
+        data = self._gaussian(5.0, 5.0)[30:, :]
+        assert _measure_fwhm(data) is None
+        # Non-finite value next to the peak
+        data = self._gaussian(5.0, 5.0)
+        data[30, 31] = np.nan
+        assert _measure_fwhm(data) is None
+        # Non-finite row next to the peak, so the averaged row profile
+        # has no finite values
+        data = self._gaussian(5.0, 5.0)
+        data[29, :] = np.nan
+        assert _measure_fwhm(data) is None
+        # Negative row next to the peak, so the averaged row profile
+        # has a non-positive peak
+        data = np.zeros((11, 11))
+        data[5, 5] = 1.0
+        data[4, :] = -3.0
+        assert _measure_fwhm(data) is None
+        # Infinite peak
+        data = self._gaussian(5.0, 5.0)
+        data[30, 30] = np.inf
+        assert _measure_fwhm(data) is None
+
+    def test_low_pixel_next_to_peak(self):
+        """
+        The profiles are averaged over the three rows and columns
+        around the peak, so a single low pixel next to the peak does
+        not truncate the width.
+        """
+        data = self._gaussian(11.2, 11.2)
+        data[30, 33] = 0.1
+        fwhm = _measure_fwhm(data)
+        assert_allclose(fwhm, (11.2, 11.2), rtol=0.05)
+
+
+class TestAutoSmoothingAndFitShape:
+    """
+    Tests for the 'auto' smoothing kernel and fit shape.
+    """
+
+    @pytest.fixture
+    def stars(self, epsf_test_data):
+        return extract_stars(epsf_test_data['nddata'],
+                             epsf_test_data['init_stars'][:30], size=11)
+
+    def test_auto_choices_oversampled(self, stars):
+        """
+        The ePSF FWHM is about 2.9 pixels (11.2 grid points at
+        oversampling 4), so the kernel is 0.7 x 11.2 = 7.9 -> 9 grid
+        points and the fit shape is 2 x 2.9 = 5.7 -> 7 pixels.
+        """
+        builder = EPSFBuilder(oversampling=4, maxiters=3,
+                              progress_bar=False)
+        result = builder(stars)
+        assert result.smoothing_kernel.shape == (9, 9)
+        assert result.fit_shape == (7, 7)
+        fwhm = _measure_fwhm(result.epsf.data)
+        assert_allclose(fwhm, (11.2, 11.2), rtol=0.05)
+
+        # The reported kernel and fit shape reproduce the build when
+        # input as fixed values.
+        builder = EPSFBuilder(oversampling=4, maxiters=3,
+                              smoothing_kernel=result.smoothing_kernel,
+                              fit_shape=result.fit_shape,
+                              progress_bar=False)
+        fixed = builder(stars)
+        assert_allclose(fixed.epsf.data, result.epsf.data)
+        assert_array_equal(fixed.smoothing_kernel, result.smoothing_kernel)
+
+    def test_auto_no_smoothing_undersampled(self, stars):
+        """
+        At oversampling 1 the window (0.7 x 2.9 = 2 grid points) is
+        below the minimum kernel size, so no smoothing is applied.
+        """
+        builder = EPSFBuilder(oversampling=1, maxiters=3,
+                              progress_bar=False)
+        result = builder(stars)
+        assert result.smoothing_kernel is None
+        assert result.fit_shape == (7, 7)
+
+    def test_auto_anisotropic_oversampling(self, stars):
+        """
+        The FWHM along the narrowest axis in input pixels sets the fit
+        shape and the narrowest axis in grid points sets the kernel.
+        """
+        builder = EPSFBuilder(oversampling=(1, 2), maxiters=3,
+                              progress_bar=False)
+        result = builder(stars)
+        assert result.smoothing_kernel is None
+        assert result.fit_shape == (7, 7)
+
+    def test_auto_fit_shape_capped_by_cutout(self):
+        """
+        A wide PSF in small cutouts: the 2 FWHM fit box (15 pixels)
+        is capped at the cutout size and the kernel is 0.7 x 7 = 5.
+        """
+        fwhm = 7.0
+        data, params = make_psf_model_image(
+            (600, 600), CircularGaussianPRF(flux=1, fwhm=fwhm), 30,
+            model_shape=(25, 25), flux=(500, 700), min_separation=40,
+            border_size=30, seed=1)
+        tbl = Table({'x': params['x_0'], 'y': params['y_0']})
+        stars = extract_stars(NDData(data), tbl, size=11)
+        builder = EPSFBuilder(oversampling=1, maxiters=3, progress_bar=False)
+        result = builder(stars)
+        assert result.smoothing_kernel.shape == (5, 5)
+        assert result.fit_shape == (11, 11)
+
+    def test_auto_fit_shape_capped_by_even_cutout(self):
+        """
+        The automatic fit shape is capped at the largest odd size that
+        fits in an even-sized cutout.
+        """
+        yy, xx = np.indices((10, 10))
+        sig = 7.0 / 2.3548
+        data = np.exp(-((xx - 4.5)**2 + (yy - 4.5)**2) / (2 * sig**2))
+        stars = EPSFStars([EPSFStar(data, cutout_center=(4.5, 4.5))
+                           for _ in range(3)])
+        builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False)
+        result = builder(stars)
+        assert result.fit_shape == (9, 9)
+
+    @pytest.mark.parametrize(
+        ('kwargs', 'match', 'kernel_shape', 'fit_shape'),
+        [({}, ("the 'auto' smoothing_kernel and fit_shape fall back to "
+               "the 'quartic' kernel and a fit shape of 5"), (5, 5), (5, 5)),
+         ({'smoothing_kernel': None},
+          "the 'auto' fit_shape falls back to a fit shape of 5", None,
+          (5, 5)),
+         ({'fit_shape': 7},
+          "the 'auto' smoothing_kernel falls back to the 'quartic' kernel",
+          (5, 5), (7, 7))])
+    def test_auto_fallback_warning(self, kwargs, match, kernel_shape,
+                                   fit_shape):
+        """
+        The FWHM of flat cutouts cannot be measured, so the build falls
+        back to the quartic kernel and a 5x5 fit shape with a single
+        warning that names only the 'auto' parameters.
+        """
+        stars = EPSFStars([EPSFStar(np.ones((11, 11))) for _ in range(3)])
+        builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False,
+                              **kwargs)
+        with pytest.warns(AstropyUserWarning, match=match) as record:
+            result = builder(stars)
+        messages = [str(r.message) for r in record
+                    if 'could not be measured' in str(r.message)]
+        assert len(messages) == 1
+        assert messages[0].endswith(f'{match}.')
+        if kernel_shape is None:
+            assert result.smoothing_kernel is None
+        else:
+            assert result.smoothing_kernel.shape == kernel_shape
+        assert result.fit_shape == fit_shape
+
+    def test_fixed_choices_reported(self, stars):
+        """
+        The results report fixed kernels and fit shapes too.
+        """
+        builder = EPSFBuilder(oversampling=1, maxiters=1,
+                              smoothing_kernel='quadratic', fit_shape=None,
+                              progress_bar=False)
+        result = builder(stars)
+        assert_array_equal(result.smoothing_kernel,
+                           _SmoothingKernel.QUADRATIC_KERNEL)
+        assert result.fit_shape is None
+        # The results own a copy of the kernel, so editing it does not
+        # change the shared predefined kernel
+        result.smoothing_kernel[0, 0] = 0.0
+        assert _SmoothingKernel.QUADRATIC_KERNEL[0, 0] != 0.0
+
+        kernel = np.full((3, 3), 1 / 9)
+        builder = EPSFBuilder(oversampling=1, maxiters=1,
+                              smoothing_kernel=kernel, fit_shape=(5, 7),
+                              progress_bar=False)
+        result = builder(stars)
+        assert result.smoothing_kernel is not kernel
+        assert_array_equal(result.smoothing_kernel, kernel)
+        assert result.fit_shape == (5, 7)
+
+        builder = EPSFBuilder(oversampling=1, maxiters=1,
+                              smoothing_kernel=None, progress_bar=False)
+        result = builder(stars)
+        assert result.smoothing_kernel is None


### PR DESCRIPTION
The default `smoothing_kernel` and `fit_shape` are now `'auto'`. Each iteration measures the FWHM of the ePSF and uses a quartic least-squares kernel 0.7 FWHM wide (none below 5 grid points) and a fitting box 2 FWHM wide (minimum 5 pixels, capped by the cutout). The fixed 5x5 kernel and 5-pixel box were designed for HST at oversampling 4 and oversmooth undersampled ePSFs or bias the centers of well-sampled stars. The choices are reported in new `smoothing_kernel` and `fit_shape` result attributes.