### PR TITLE
Speed up EPSFBuilder convergence and star fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -242,6 +242,20 @@ New Features
     ``EPSFBuildResults`` that report the smoothing kernel and fitting
     box used in the final iteration. [#2421]
 
+  - Added a ``converged_fraction`` keyword to ``EPSFBuilder`` (default
+    0.95) giving the fraction of the successfully fitted stars
+    whose centers must change by less than ``center_accuracy``
+    between iterations for the build to converge, so that a few
+    spurious or contaminated stars whose centers never settle do
+    not prevent convergence. The fraction achieved in the final
+    iteration is reported in the new ``converged_fraction`` attribute
+    of ``EPSFBuildResults``. Set ``converged_fraction=1.0`` for the
+    previous behavior. [#2422]
+
+  - ``EPSFBuilder`` now builds the ePSF spline interpolators once per
+    iteration instead of once per star, which speeds up the star fitting
+    step. [#2422]
+
 - ``photutils.segmentation``
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -253,8 +253,9 @@ New Features
     previous behavior. [#2422]
 
   - ``EPSFBuilder`` now builds the ePSF spline interpolators once per
-    iteration instead of once per star, which speeds up the star fitting
-    step. [#2422]
+    iteration instead of once per star and stacks the star residuals
+    in a single vectorized operation instead of a loop over the stars,
+    which makes each build iteration about 20% faster. [#2422]
 
 - ``photutils.segmentation``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -243,13 +243,13 @@ New Features
     box used in the final iteration. [#2421]
 
   - Added a ``converged_fraction`` keyword to ``EPSFBuilder`` (default
-    0.95) giving the fraction of the successfully fitted stars
-    whose centers must change by less than ``center_accuracy``
-    between iterations for the build to converge, so that a few
-    spurious or contaminated stars whose centers never settle do
-    not prevent convergence. The fraction achieved in the final
-    iteration is reported in the new ``converged_fraction`` attribute
-    of ``EPSFBuildResults``. Set ``converged_fraction=1.0`` for the
+    0.95) giving the fraction of the successfully fitted stars whose
+    centers must change by less than ``center_accuracy`` between
+    iterations for the build to converge, so that a few spurious or
+    contaminated stars whose centers never settle do not prevent
+    convergence. The fraction achieved in the final iteration is
+    reported in the new ``final_converged_fraction`` attribute of
+    ``EPSFBuildResults``. Set ``converged_fraction=1.0`` for the
     previous behavior. [#2422]
 
   - ``EPSFBuilder`` now builds the ePSF spline interpolators once per
@@ -995,6 +995,13 @@ API Changes
   - The ``EPSFBuildResult`` class returned by ``EPSFBuilder`` has been
     renamed to ``EPSFBuildResults``. The old ``EPSFBuildResult`` name is
     deprecated and will be removed in a future version. [#2326]
+
+  - The default convergence criterion of ``EPSFBuilder`` has changed.
+    The build now converges when at least 95% of the successfully
+    fitted stars (the new ``converged_fraction`` keyword) have met the
+    ``center_accuracy``, instead of all of them, so the same inputs
+    may now stop after fewer iterations with ``converged=True``. Set
+    ``converged_fraction=1.0`` for the previous behavior. [#2422]
 
   - The ``nxpsfs`` and ``nypsfs`` metadata keys of the
     ``GriddedPSFModel`` returned when reading a STDPSF file have been

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -209,6 +209,24 @@ python benchmarks/bench_psf.py
 python benchmarks/bench_psf.py --which photometry --n-sources-list 500,5000
 ```
 
+## ePSF building (`bench_epsf_builder.py`)
+
+Benchmarks for `EPSFBuilder` on noisy Gaussian stars with random
+subpixel positions:
+
+- a full build (total time, number of iterations, time per iteration,
+  and time per star per iteration) versus the number of stars
+- a full build versus the oversampling factor
+- the stages of a single build iteration (residual stacking, sigma
+  clipping and median, smoothing and recentering, and star fitting)
+  on a converged ePSF
+
+```bash
+python benchmarks/bench_epsf_builder.py
+python benchmarks/bench_epsf_builder.py --which stages --n-stars 2000
+python benchmarks/bench_epsf_builder.py --which stars --oversampling 4 --fwhm 1.5
+```
+
 ## PSF matching (`bench_psf_matching.py`)
 
 Benchmarks for the `photutils.psf_matching` subpackage:

--- a/benchmarks/bench_epsf_builder.py
+++ b/benchmarks/bench_epsf_builder.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for ePSF building with EPSFBuilder.
+
+The benchmarks cover the wall-clock time of a full build and its
+number of iterations versus the number of stars and versus the
+oversampling factor, and the cost of the stages of a single build
+iteration (residual stacking, sigma clipping and median, smoothing
+and recentering, and star fitting).
+
+Run ``python benchmarks/bench_epsf_builder.py --help`` to see the
+available options.
+"""
+
+import argparse
+import time
+import warnings
+from functools import partial
+
+import numpy as np
+from astropy.nddata import NDData
+from astropy.table import Table
+from bench_helpers import parse_int_list, print_environment, time_best
+
+from photutils.datasets import make_model_image
+from photutils.psf import CircularGaussianPRF, EPSFBuilder, extract_stars
+
+
+def make_stars(n_stars, *, fwhm=2.8, cutout_size=25, seed=0):
+    """
+    Return extracted star cutouts from a noisy scene of Gaussian stars.
+
+    The stars are placed on a regular grid with random subpixel
+    offsets so that exactly ``n_stars`` well-separated stars are
+    generated. They have fluxes spanning a factor of ten and
+    Poisson-like noise plus a constant background noise.
+
+    Parameters
+    ----------
+    n_stars : int
+        The number of stars.
+
+    fwhm : float, optional
+        The FWHM of the stars in pixels.
+
+    cutout_size : int, optional
+        The size of the star cutouts in pixels.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    result : `~photutils.psf.EPSFStars`
+        The extracted stars.
+    """
+    rng = np.random.default_rng(seed)
+    separation = cutout_size + 10
+    n_side = int(np.ceil(np.sqrt(n_stars)))
+    size = (n_side + 1) * separation
+
+    # Grid cell centers, leaving a border of one cell around the image
+    grid = (np.arange(n_side) + 1) * separation
+    yy, xx = np.meshgrid(grid, grid, indexing='ij')
+    xpos = xx.ravel()[:n_stars] + rng.uniform(-0.5, 0.5, n_stars)
+    ypos = yy.ravel()[:n_stars] + rng.uniform(-0.5, 0.5, n_stars)
+    flux = rng.uniform(1e4, 1e5, n_stars)
+    params = Table({'x_0': xpos, 'y_0': ypos, 'flux': flux})
+
+    model = CircularGaussianPRF(fwhm=fwhm)
+    data = make_model_image((size, size), model, params,
+                            model_shape=(cutout_size + 4, cutout_size + 4))
+    data += rng.normal(0.0, np.sqrt(np.abs(data) + 100.0))
+    catalog = Table({'x': xpos, 'y': ypos})
+    return extract_stars(NDData(data), catalog, size=cutout_size)
+
+
+def make_builder(oversampling, *, maxiters=10, **kwargs):
+    """
+    Return an `~photutils.psf.EPSFBuilder` with the benchmark settings.
+
+    Parameters
+    ----------
+    oversampling : int
+        The oversampling factor.
+
+    maxiters : int, optional
+        The maximum number of build iterations.
+
+    **kwargs : dict, optional
+        Additional keyword arguments passed to `EPSFBuilder`.
+
+    Returns
+    -------
+    result : `~photutils.psf.EPSFBuilder`
+        The builder.
+    """
+    return EPSFBuilder(oversampling=oversampling, maxiters=maxiters,
+                       progress_bar=False, **kwargs)
+
+
+def build(builder, stars):
+    """
+    Build an ePSF, suppressing the builder warnings.
+
+    Parameters
+    ----------
+    builder : `~photutils.psf.EPSFBuilder`
+        The builder.
+
+    stars : `~photutils.psf.EPSFStars`
+        The stars.
+
+    Returns
+    -------
+    result : `~photutils.psf.EPSFBuildResults`
+        The build results.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return builder(stars)
+
+
+def bench_stars(*, n_stars_list=(100, 400, 1600), oversampling=2, fwhm=2.8,
+                cutout_size=25, maxiters=10, repeats=3, seed=0):
+    """
+    Benchmark a full build versus the number of stars.
+
+    Parameters
+    ----------
+    n_stars_list : tuple of int, optional
+        The numbers of stars.
+
+    oversampling : int, optional
+        The oversampling factor.
+
+    fwhm : float, optional
+        The FWHM of the stars in pixels.
+
+    cutout_size : int, optional
+        The size of the star cutouts in pixels.
+
+    maxiters : int, optional
+        The maximum number of build iterations.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print(f'\n== EPSFBuilder versus the number of stars '
+          f'(oversampling={oversampling}, fwhm={fwhm}, '
+          f'cutout_size={cutout_size}, maxiters={maxiters}) ==')
+    print(f'{"n_stars":>10}{"iterations":>12}{"total":>12}'
+          f'{"per iter":>12}{"per star-iter":>16}')
+    for n_stars in n_stars_list:
+        stars = make_stars(n_stars, fwhm=fwhm, cutout_size=cutout_size,
+                           seed=seed)
+        builder = make_builder(oversampling, maxiters=maxiters)
+        result = build(builder, stars)
+        t_build = time_best(partial(build, builder, stars),
+                            repeats=repeats)
+        per_iter = t_build / result.iterations
+        print(f'{n_stars:>10}{result.iterations:>12}'
+              f'{f"{t_build:.2f}s":>12}{f"{per_iter:.3f}s":>12}'
+              f'{f"{per_iter / n_stars * 1e3:.3f}ms":>16}')
+
+
+def bench_oversampling(*, oversampling_list=(1, 2, 4), n_stars=400,
+                       fwhm=2.8, cutout_size=25, maxiters=10, repeats=3,
+                       seed=0):
+    """
+    Benchmark a full build versus the oversampling factor.
+
+    Parameters
+    ----------
+    oversampling_list : tuple of int, optional
+        The oversampling factors.
+
+    n_stars : int, optional
+        The number of stars.
+
+    fwhm : float, optional
+        The FWHM of the stars in pixels.
+
+    cutout_size : int, optional
+        The size of the star cutouts in pixels.
+
+    maxiters : int, optional
+        The maximum number of build iterations.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    stars = make_stars(n_stars, fwhm=fwhm, cutout_size=cutout_size,
+                       seed=seed)
+    print(f'\n== EPSFBuilder versus the oversampling factor '
+          f'(n_stars={n_stars}, fwhm={fwhm}, cutout_size={cutout_size}, '
+          f'maxiters={maxiters}) ==')
+    print(f'{"oversampling":>14}{"ePSF shape":>14}{"iterations":>12}'
+          f'{"total":>12}{"per iter":>12}')
+    for oversampling in oversampling_list:
+        builder = make_builder(oversampling, maxiters=maxiters)
+        result = build(builder, stars)
+        t_build = time_best(partial(build, builder, stars),
+                            repeats=repeats)
+        shape = 'x'.join(str(s) for s in result.epsf.data.shape)
+        print(f'{oversampling:>14}{shape:>14}{result.iterations:>12}'
+              f'{f"{t_build:.2f}s":>12}'
+              f'{f"{t_build / result.iterations:.3f}s":>12}')
+
+
+def bench_stages(*, n_stars=400, oversampling=2, fwhm=2.8, cutout_size=25,
+                 repeats=3, seed=0):
+    """
+    Benchmark the stages of a single build iteration.
+
+    The stages are timed on the ePSF and star centers of a converged
+    build, so that the star fits start close to their solutions as
+    they do in the later build iterations.
+
+    Parameters
+    ----------
+    n_stars : int, optional
+        The number of stars.
+
+    oversampling : int, optional
+        The oversampling factor.
+
+    fwhm : float, optional
+        The FWHM of the stars in pixels.
+
+    cutout_size : int, optional
+        The size of the star cutouts in pixels.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    from photutils.psf.epsf_builder import _suppress_alias_modes
+    from photutils.psf.image_models import ImagePSF
+    from photutils.utils._stats import nanmedian
+
+    stars = make_stars(n_stars, fwhm=fwhm, cutout_size=cutout_size,
+                       seed=seed)
+    builder = make_builder(oversampling, maxiters=10)
+    result = build(builder, stars)
+    epsf = result.epsf
+    stars = result.fitted_stars
+
+    def stack():
+        """
+        Stack the resampled star residuals.
+        """
+        return builder._resample_residuals(stars, epsf)
+
+    residuals = stack()
+
+    def clip_and_median():
+        """
+        Sigma clip the residual stack and take its median.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            clipped = builder._sigma_clip(residuals, axis=0, masked=False,
+                                          return_bounds=False)
+            return nanmedian(clipped, axis=0)
+
+    median = clip_and_median()
+    new_epsf = epsf.data + median
+
+    def smooth_and_recenter():
+        """
+        Smooth, low-pass filter, recenter, and normalize the ePSF.
+        """
+        builder._update_auto_parameters(new_epsf)
+        smoothed = builder._smooth_epsf(new_epsf)
+        smoothed = _suppress_alias_modes(smoothed, builder.oversampling)
+        temp = ImagePSF(data=smoothed, origin=epsf.origin,
+                        oversampling=builder.oversampling, fill_value=0.0)
+        return builder._normalize_epsf(builder._recenter_epsf(temp))
+
+    def fit():
+        """
+        Fit the ePSF to the stars.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return builder._fit_stars(epsf, stars)
+
+    def iteration():
+        """
+        Run a full build iteration.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return builder._process_iteration(stars, epsf, 2)
+
+    timings = [('residual stacking', time_best(stack, repeats=repeats)),
+               ('sigma clip and median',
+                time_best(clip_and_median, repeats=repeats)),
+               ('smooth and recenter',
+                time_best(smooth_and_recenter, repeats=repeats)),
+               ('star fitting', time_best(fit, repeats=repeats)),
+               ('full iteration', time_best(iteration, repeats=repeats))]
+
+    kernel_shape = (None if result.smoothing_kernel is None
+                    else result.smoothing_kernel.shape)
+    print(f'\n== Build iteration stages (n_stars={n_stars}, '
+          f'oversampling={oversampling}, fwhm={fwhm}, '
+          f'cutout_size={cutout_size}, fit_shape={result.fit_shape}, '
+          f'kernel={kernel_shape}) ==')
+    print(f'{"stage":>26}{"time":>12}{"fraction":>12}')
+    total = timings[-1][1]
+    for name, t_stage in timings:
+        print(f'{name:>26}{f"{t_stage:.3f}s":>12}'
+              f'{f"{t_stage / total * 100:.0f}%":>12}')
+
+
+def main():
+    """
+    Run the ePSF building benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for ePSF building with EPSFBuilder.')
+    parser.add_argument('--n-stars-list', type=parse_int_list,
+                        default=[100, 400, 1600],
+                        help='comma-separated numbers of stars for the '
+                             'stars benchmark (default: 100,400,1600)')
+    parser.add_argument('--n-stars', type=int, default=400,
+                        help='number of stars for the oversampling and '
+                             'stages benchmarks (default: %(default)s)')
+    parser.add_argument('--oversampling-list', type=parse_int_list,
+                        default=[1, 2, 4],
+                        help='comma-separated oversampling factors for '
+                             'the oversampling benchmark (default: 1,2,4)')
+    parser.add_argument('--oversampling', type=int, default=2,
+                        help='oversampling factor for the stars and '
+                             'stages benchmarks (default: %(default)s)')
+    parser.add_argument('--fwhm', type=float, default=2.8,
+                        help='FWHM of the stars in pixels '
+                             '(default: %(default)s)')
+    parser.add_argument('--cutout-size', type=int, default=25,
+                        help='size of the star cutouts in pixels '
+                             '(default: %(default)s)')
+    parser.add_argument('--maxiters', type=int, default=10,
+                        help='maximum number of build iterations '
+                             '(default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'stars', 'oversampling', 'stages'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+    t0 = time.perf_counter()
+
+    if args.which in ('all', 'stars'):
+        bench_stars(n_stars_list=args.n_stars_list,
+                    oversampling=args.oversampling, fwhm=args.fwhm,
+                    cutout_size=args.cutout_size, maxiters=args.maxiters,
+                    repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'oversampling'):
+        bench_oversampling(oversampling_list=args.oversampling_list,
+                           n_stars=args.n_stars, fwhm=args.fwhm,
+                           cutout_size=args.cutout_size,
+                           maxiters=args.maxiters, repeats=args.repeats,
+                           seed=args.seed)
+    if args.which in ('all', 'stages'):
+        bench_stages(n_stars=args.n_stars, oversampling=args.oversampling,
+                     fwhm=args.fwhm, cutout_size=args.cutout_size,
+                     repeats=args.repeats, seed=args.seed)
+
+    print(f'\ntotal benchmark time: {time.perf_counter() - t0:.1f}s')
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/bench_epsf_builder.py
+++ b/benchmarks/bench_epsf_builder.py
@@ -284,7 +284,7 @@ def bench_stages(*, n_stars=400, oversampling=2, fwhm=2.8, cutout_size=25,
         smoothed = builder._smooth_epsf(new_epsf)
         smoothed = _suppress_alias_modes(smoothed, builder.oversampling)
         temp = ImagePSF(data=smoothed, origin=epsf.origin,
-                        oversampling=builder.oversampling, fill_value=0.0)
+                        oversampling=builder.oversampling, fill_value=None)
         return builder._normalize_epsf(builder._recenter_epsf(temp))
 
     def fit():

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -316,7 +316,7 @@ information about the build process::
     0
 
 The results also report the fraction of stars whose centers converged
-(``converged_fraction``), the largest center movement in the final
+(``final_converged_fraction``), the largest center movement in the final
 iteration (``final_center_accuracy``), and the smoothing kernel and
 fitting box that were used (``smoothing_kernel`` and ``fit_shape``). See
 `~photutils.psf.EPSFBuildResults` for the full list.

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -315,8 +315,9 @@ information about the build process::
     >>> result.n_excluded_stars  # doctest: +REMOTE_DATA
     0
 
-The results also report the largest center movement in the final
-iteration (``final_center_accuracy``) and the smoothing kernel and
+The results also report the fraction of stars whose centers converged
+(``converged_fraction``), the largest center movement in the final
+iteration (``final_center_accuracy``), and the smoothing kernel and
 fitting box that were used (``smoothing_kernel`` and ``fit_shape``). See
 `~photutils.psf.EPSFBuildResults` for the full list.
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -771,8 +771,18 @@ of `~photutils.psf.EPSFBuildResults`, and they can be input as fixed
 values to reproduce the build. The previous behavior is available with
 ``smoothing_kernel='quartic'`` and ``fit_shape=5``.
 
-.. _whatsnew-3.1-api-changes:
+The build now converges when at least a ``converged_fraction`` (default
+0.95) of the successfully fitted stars have settled to the requested
+``center_accuracy``, instead of requiring every star. A few spurious
+detections or contaminated cutouts whose centers never settle previously
+forced the build to run to ``maxiters``. The fraction achieved is
+reported in the new ``converged_fraction`` attribute of the results,
+and ``converged_fraction=1.0`` restores the previous behavior. The star
+fitting step is also faster because the ePSF spline interpolators are
+built once per iteration instead of once per star.
 
+
+.. _whatsnew-3.1-api-changes:
 
 API Changes
 ===========

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -777,9 +777,9 @@ stars have settled to the requested ``center_accuracy``, instead of
 requiring every star. A few spurious detections or contaminated cutouts
 whose centers never settle previously forced the build to run to
 ``maxiters``. On a real sample of about 2000 stars with 30% spurious
-detections, the build now stops after 6 iterations instead of 100,
-in 21 seconds instead of about 5 minutes. The fraction achieved is
-reported in the new ``converged_fraction`` attribute of the results,
+detections, the build now stops after 6 iterations instead of 100, in 21
+seconds instead of about 5 minutes. The fraction achieved is reported
+in the new ``final_converged_fraction`` attribute of the results,
 and ``converged_fraction=1.0`` restores the previous behavior. Each
 iteration is also about 20% faster (25% at an oversampling of 4) because
 the ePSF spline interpolators are built once per iteration instead of

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -771,15 +771,20 @@ of `~photutils.psf.EPSFBuildResults`, and they can be input as fixed
 values to reproduce the build. The previous behavior is available with
 ``smoothing_kernel='quartic'`` and ``fit_shape=5``.
 
-The build now converges when at least a ``converged_fraction`` (default
-0.95) of the successfully fitted stars have settled to the requested
-``center_accuracy``, instead of requiring every star. A few spurious
-detections or contaminated cutouts whose centers never settle previously
-forced the build to run to ``maxiters``. The fraction achieved is
+ePSF building is also faster. The build now converges when at least
+a ``converged_fraction`` (default 0.95) of the successfully fitted
+stars have settled to the requested ``center_accuracy``, instead of
+requiring every star. A few spurious detections or contaminated cutouts
+whose centers never settle previously forced the build to run to
+``maxiters``. On a real sample of about 2000 stars with 30% spurious
+detections, the build now stops after 6 iterations instead of 100,
+in 21 seconds instead of about 5 minutes. The fraction achieved is
 reported in the new ``converged_fraction`` attribute of the results,
-and ``converged_fraction=1.0`` restores the previous behavior. The star
-fitting step is also faster because the ePSF spline interpolators are
-built once per iteration instead of once per star.
+and ``converged_fraction=1.0`` restores the previous behavior. Each
+iteration is also about 20% faster (25% at an oversampling of 4) because
+the ePSF spline interpolators are built once per iteration instead of
+once per star and the star residuals are stacked in a single vectorized
+operation.
 
 
 .. _whatsnew-3.1-api-changes:

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -936,6 +936,12 @@ class EPSFBuildResults:
         pixels. This indicates how much the star centers changed in the
         last iteration and can be used to assess convergence quality.
 
+    converged_fraction : float
+        The fraction of the successfully fitted stars whose centers
+        changed by less than ``center_accuracy`` in the final iteration.
+        The build is converged when this fraction is at least the
+        ``converged_fraction`` of the builder.
+
     n_excluded_stars : int
         The number of individual stars (including those from linked
         stars) that were excluded from fitting due to repeated fit
@@ -987,6 +993,7 @@ class EPSFBuildResults:
     smoothing_kernel: np.ndarray | None = field(default=None, compare=False,
                                                 repr=False)
     fit_shape: tuple | None = None
+    converged_fraction: float | None = None
 
     def __iter__(self):
         """
@@ -1322,11 +1329,21 @@ class EPSFBuilder:
         each ePSF build iteration.
 
     center_accuracy : float, optional
-        The desired accuracy for the centers of stars. The building
-        iterations will stop if the centers of all the stars change by
-        less than ``center_accuracy`` pixels between iterations. All
-        stars must meet this condition for the building iterations to
-        stop.
+        The desired accuracy for the centers of stars. The
+        building iterations will stop when the centers of at least
+        ``converged_fraction`` of the successfully fitted stars change
+        by less than ``center_accuracy`` pixels between iterations.
+
+    converged_fraction : float, optional
+        The fraction of the successfully fitted stars whose centers
+        must change by less than ``center_accuracy`` pixels between
+        iterations for the build to be considered converged. The
+        default of 0.95 allows a small number of stars (e.g., spurious
+        detections or contaminated cutouts) whose centers never settle
+        to not prevent convergence. Set to 1.0 to require all stars
+        to converge. The fraction achieved in the final iteration is
+        reported in the ``converged_fraction`` attribute of the returned
+        `EPSFBuildResults`.
 
     fitter : `~astropy.modeling.fitting.Fitter` or `EPSFFitter`, optional
         A `~astropy.modeling.fitting.Fitter` object used to fit the
@@ -1430,8 +1447,9 @@ class EPSFBuilder:
                  smoothing_kernel='auto', sigma_clip=SIGMA_CLIP,
                  recentering_func=centroid_com, recentering_boxsize=(5, 5),
                  recentering_maxiters=20, center_accuracy=1.0e-3,
-                 fitter=None, fit_shape='auto', fitter_maxiters=100,
-                 constrain_fluxes=True, maxiters=10, progress_bar=True):
+                 converged_fraction=0.95, fitter=None, fit_shape='auto',
+                 fitter_maxiters=100, constrain_fluxes=True, maxiters=10,
+                 progress_bar=True):
 
         # Validate and store oversampling using the validator
         self.oversampling = _EPSFValidator.validate_oversampling(
@@ -1528,6 +1546,13 @@ class EPSFBuilder:
         # Validate center accuracy using the validator
         _EPSFValidator.validate_center_accuracy(center_accuracy)
         self.center_accuracy_sq = center_accuracy**2
+
+        if (isinstance(converged_fraction, bool)
+                or not isinstance(converged_fraction, numbers.Real)
+                or not 0.0 < converged_fraction <= 1.0):
+            msg = 'converged_fraction must be a number in the range (0, 1]'
+            raise ValueError(msg)
+        self.converged_fraction = float(converged_fraction)
 
         # Validate maxiters using the validator
         _EPSFValidator.validate_maxiters(maxiters)
@@ -2108,9 +2133,9 @@ class EPSFBuilder:
         Check if the ePSF building has converged.
 
         Convergence is determined by the movement of the star centers
-        between iterations. The build has converged when the maximum
-        squared center movement among successfully fitted stars is less
-        than the configured center accuracy.
+        between iterations. The build has converged when at least
+        ``converged_fraction`` of the successfully fitted stars moved by
+        less than the configured center accuracy.
 
         Parameters
         ----------
@@ -2152,8 +2177,8 @@ class EPSFBuilder:
         center_dist_sq = np.sum(dx_dy_good * dx_dy_good, axis=1,
                                 dtype=np.float64)
 
-        max_movement = np.max(center_dist_sq)
-        converged = bool(max_movement < self.center_accuracy_sq)
+        fraction = np.mean(center_dist_sq < self.center_accuracy_sq)
+        converged = bool(fraction >= self.converged_fraction)
 
         return converged, center_dist_sq, new_centers
 
@@ -2185,6 +2210,12 @@ class EPSFBuilder:
         if not isinstance(epsf, ImagePSF):
             msg = 'The input epsf must be an ImagePSF'
             raise TypeError(msg)
+
+        # Build the (cached) spline interpolators once so that the
+        # model copies made by the fitter for every star share them
+        # instead of each rebuilding the spline.
+        epsf.interpolator  # noqa: B018
+        epsf._deriv_interpolators  # noqa: B018
 
         fitted_stars = []
         for star in stars:
@@ -2442,7 +2473,8 @@ class EPSFBuilder:
             warnings.warn(msg, AstropyUserWarning)
 
     def _finalize_build(self, epsf, stars, progress_reporter, iter_num,
-                        converged, final_center_accuracy):
+                        converged, final_center_accuracy,
+                        converged_fraction=None):
         """
         Finalize the ePSF building process and create result object.
 
@@ -2468,6 +2500,11 @@ class EPSFBuilder:
 
         final_center_accuracy : float
             Final center accuracy achieved.
+
+        converged_fraction : float, optional
+            The fraction of the successfully fitted stars whose centers
+            changed by less than the center accuracy in the final
+            iteration.
 
         Returns
         -------
@@ -2509,6 +2546,7 @@ class EPSFBuilder:
             excluded_star_indices=excluded_star_indices,
             smoothing_kernel=kernel,
             fit_shape=fit_shape,
+            converged_fraction=converged_fraction,
         )
 
     def build_epsf(self, stars, *, epsf=None):
@@ -2607,13 +2645,16 @@ class EPSFBuilder:
             # Update progress bar
             progress_reporter.update()
 
-        # Calculate the final center accuracy
+        # Calculate the final center accuracy and converged fraction
         final_center_accuracy = float(np.max(center_dist_sq) ** 0.5)
+        converged_fraction = float(
+            np.mean(center_dist_sq < self.center_accuracy_sq))
 
         # Finalize and return structured results
         return self._finalize_build(epsf, stars, progress_reporter,
                                     iter_num, converged,
-                                    final_center_accuracy)
+                                    final_center_accuracy,
+                                    converged_fraction)
 
 
 def __getattr__(name):

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -632,6 +632,36 @@ class _EPSFValidator:
             warnings.warn(msg, AstropyUserWarning)
 
     @staticmethod
+    def validate_converged_fraction(converged_fraction):
+        """
+        Validate the converged fraction parameter.
+
+        Parameters
+        ----------
+        converged_fraction : float
+            The fraction of the successfully fitted stars that must
+            converge.
+
+        Raises
+        ------
+        TypeError
+            If converged_fraction is not a number.
+
+        ValueError
+            If converged_fraction is not in the range (0, 1].
+        """
+        if (isinstance(converged_fraction, bool)
+                or not isinstance(converged_fraction, numbers.Real)):
+            msg = (f'converged_fraction must be a number, got '
+                   f'{type(converged_fraction)}')
+            raise TypeError(msg)
+
+        if not 0.0 < converged_fraction <= 1.0:
+            msg = (f'converged_fraction must be in the range (0, 1], got '
+                   f'{converged_fraction}')
+            raise ValueError(msg)
+
+    @staticmethod
     def validate_maxiters(maxiters):
         """
         Validate maximum iterations parameter.
@@ -935,10 +965,13 @@ class EPSFBuildResults:
 
     final_center_accuracy : float
         The maximum center displacement in the final iteration, in
-        pixels. This indicates how much the star centers changed in the
-        last iteration and can be used to assess convergence quality.
+        pixels, over all of the successfully fitted stars. This includes
+        the stars that the ``converged_fraction`` of the builder allows
+        to remain unconverged, so it can be much larger than the
+        ``center_accuracy`` for a converged build. Use it together with
+        ``final_converged_fraction`` to assess the convergence quality.
 
-    converged_fraction : float
+    final_converged_fraction : float
         The fraction of the successfully fitted stars whose centers
         changed by less than ``center_accuracy`` in the final iteration.
         The build is converged when this fraction is at least the
@@ -995,7 +1028,7 @@ class EPSFBuildResults:
     smoothing_kernel: np.ndarray | None = field(default=None, compare=False,
                                                 repr=False)
     fit_shape: tuple | None = None
-    converged_fraction: float | None = None
+    final_converged_fraction: float | None = None
 
     def __iter__(self):
         """
@@ -1344,8 +1377,8 @@ class EPSFBuilder:
         detections or contaminated cutouts) whose centers never settle
         to not prevent convergence. Set to 1.0 to require all stars
         to converge. The fraction achieved in the final iteration is
-        reported in the ``converged_fraction`` attribute of the returned
-        `EPSFBuildResults`.
+        reported in the ``final_converged_fraction`` attribute of the
+        returned `EPSFBuildResults`.
 
     fitter : `~astropy.modeling.fitting.Fitter` or `EPSFFitter`, optional
         A `~astropy.modeling.fitting.Fitter` object used to fit the
@@ -1549,11 +1582,8 @@ class EPSFBuilder:
         _EPSFValidator.validate_center_accuracy(center_accuracy)
         self.center_accuracy_sq = center_accuracy**2
 
-        if (isinstance(converged_fraction, bool)
-                or not isinstance(converged_fraction, numbers.Real)
-                or not 0.0 < converged_fraction <= 1.0):
-            msg = 'converged_fraction must be a number in the range (0, 1]'
-            raise ValueError(msg)
+        # Validate converged_fraction using the validator
+        _EPSFValidator.validate_converged_fraction(converged_fraction)
         self.converged_fraction = float(converged_fraction)
 
         # Validate maxiters using the validator
@@ -1765,99 +1795,75 @@ class EPSFBuilder:
         return ImagePSF(data=data, origin=origin_xy, oversampling=oversampling,
                         fill_value=0.0)
 
-    def _resample_residual(self, star, epsf, *, out_image=None):
+    def _resample_residuals(self, stars, epsf, *, chunk_size=128):
         """
-        Compute a normalized residual image in the oversampled ePSF
-        grid.
+        Compute normalized residual images in the oversampled ePSF grid
+        for all the input stars.
 
-        A normalized residual image is calculated by subtracting the
-        normalized ePSF model from the normalized star at the location
-        of the star in the undersampled grid. The normalized residual
-        image is then resampled from the undersampled star grid to
-        the oversampled ePSF grid by depositing each star pixel value
-        on every oversampled grid point inside the footprint of that
-        pixel. Every star therefore contributes to every grid point that
-        its cutout covers, regardless of its subpixel phase. For an
-        oversampling factor of one along an axis, this reduces to the
-        nearest grid point.
-
-        Parameters
-        ----------
-        star : `EPSFStar` object
-            A single star object.
-
-        epsf : `ImagePSF` object
-            The ePSF model.
-
-        out_image : 2D `~numpy.ndarray`, optional
-            A 2D array to hold the resampled residual image. If `None`,
-            a new array will be created.
-
-        Returns
-        -------
-        image : 2D `~numpy.ndarray`
-            A 2D image containing the resampled residual image. The
-            image contains NaNs where there is no data.
-        """
-        # Compute the normalized residual by subtracting the ePSF model
-        # from the normalized star at the location of the star in the
-        # undersampled grid.
-        xidx_centered, yidx_centered = star._xyidx_centered
-        stardata = (star._data_values_normalized
-                    - epsf.evaluate(x=xidx_centered,
-                                    y=yidx_centered,
-                                    flux=1.0, x_0=0.0, y_0=0.0))
-
-        # Star pixel centers in the oversampled ePSF grid
-        x_over, y_over = self._coord_transformer.undersampled_to_oversampled(
-            xidx_centered, yidx_centered)
-        x_over = x_over + epsf.origin[0]
-        y_over = y_over + epsf.origin[1]
-
-        epsf_shape = epsf.data.shape
-        if out_image is None:
-            out_image = np.full(epsf_shape, np.nan)
-
-        # Each star pixel covers the grid points k with x_over - os /
-        # 2 < k <= x_over + os / 2, which is exactly oversampled grid
-        # points along each axis.
-        ny_over, nx_over = self.oversampling
-        x_first = np.floor(x_over - nx_over / 2.0).astype(int) + 1
-        y_first = np.floor(y_over - ny_over / 2.0).astype(int) + 1
-        for j in range(ny_over):
-            yidx = y_first + j
-            for i in range(nx_over):
-                xidx = x_first + i
-                mask = ((xidx >= 0) & (xidx < epsf_shape[1])
-                        & (yidx >= 0) & (yidx < epsf_shape[0]))
-                out_image[yidx[mask], xidx[mask]] = stardata[mask]
-
-        return out_image
-
-    def _resample_residuals(self, stars, epsf):
-        """
-        Compute normalized residual images for all the input stars.
+        A normalized residual image is calculated for each star by
+        subtracting the normalized ePSF model from the normalized
+        star at the location of the star in the undersampled grid.
+        The normalized residual image is then resampled from the
+        undersampled star grid to the oversampled ePSF grid by
+        depositing each star pixel value on every oversampled grid
+        point inside the footprint of that pixel. Every star therefore
+        contributes to every grid point that its cutout covers,
+        regardless of its subpixel phase. For an oversampling factor of
+        one along an axis, this reduces to the nearest grid point.
 
         Parameters
         ----------
         stars : `EPSFStars` object
-            The stars used to build the ePSF.
+            The stars used to build the ePSF. Stars that are excluded
+            from fitting are skipped.
 
         epsf : `ImagePSF` object
             The ePSF model.
 
+        chunk_size : int, optional
+            The number of stars processed together. The stars are
+            resampled in chunks so that the temporary per-pixel arrays
+            stay bounded for large star samples.
+
         Returns
         -------
         epsf_resid : 3D `~numpy.ndarray`
-            A 3D cube containing the resampled residual images.
+            A 3D cube containing the resampled residual images, one
+            per star. The images contain NaNs where there is no data.
         """
-        epsf_shape = epsf.data.shape
+        ny, nx = epsf.data.shape
         good_stars = stars.all_good_stars
         n_good_stars = len(good_stars)
 
-        if n_good_stars == 0:
-            # Return empty array with correct shape
-            return np.zeros((0, epsf_shape[0], epsf_shape[1]))
+        # Pre-allocate with NaN (default for missing data)
+        epsf_resid = np.full((n_good_stars, ny, nx), np.nan)
+
+        for start in range(0, n_good_stars, chunk_size):
+            stop = min(start + chunk_size, n_good_stars)
+            self._deposit_residuals(good_stars[start:stop], epsf,
+                                    epsf_resid[start:stop])
+
+        return epsf_resid
+
+    def _deposit_residuals(self, stars, epsf, epsf_resid):
+        """
+        Deposit the normalized residuals of the input stars into a
+        stack of oversampled ePSF grid images.
+
+        Parameters
+        ----------
+        stars : list of `EPSFStar`
+            The stars to resample.
+
+        epsf : `ImagePSF` object
+            The ePSF model.
+
+        epsf_resid : 3D `~numpy.ndarray`
+            The contiguous stack of residual images, with one image per
+            input star, that is filled in place. Grid points that are
+            not covered by a star pixel are left unchanged.
+        """
+        ny, nx = epsf.data.shape
 
         # Gather the unmasked pixels of all stars so that the ePSF model
         # is evaluated once and the residuals are deposited with a
@@ -1865,46 +1871,52 @@ class EPSFBuilder:
         star_index = []
         xidx_centered = []
         yidx_centered = []
-        values = []
-        for i, star in enumerate(good_stars):
+        residuals = []
+        for i, star in enumerate(stars):
             xidx, yidx = star._xyidx_centered
             star_index.append(np.full(xidx.size, i))
             xidx_centered.append(xidx)
             yidx_centered.append(yidx)
-            values.append(star._data_values_normalized)
+            residuals.append(star._data_values_normalized)
         star_index = np.concatenate(star_index)
         xidx_centered = np.concatenate(xidx_centered)
         yidx_centered = np.concatenate(yidx_centered)
-        values = np.concatenate(values)
 
-        residuals = values - epsf.evaluate(x=xidx_centered, y=yidx_centered,
-                                           flux=1.0, x_0=0.0, y_0=0.0)
+        # The concatenation is a new array, so the model can be
+        # subtracted in place.
+        residuals = np.concatenate(residuals)
+        residuals -= epsf.evaluate(x=xidx_centered, y=yidx_centered,
+                                   flux=1.0, x_0=0.0, y_0=0.0)
 
-        # Star pixel centers in the oversampled ePSF grid
+        # Each star pixel covers the oversampled grid points k with
+        # x_over - os / 2 < k <= x_over + os / 2 along each axis, where
+        # x_over is the pixel center in the oversampled ePSF grid.
+        # Compute the first covered grid point along each axis.
+        ny_over, nx_over = self.oversampling
         x_over, y_over = self._coord_transformer.undersampled_to_oversampled(
             xidx_centered, yidx_centered)
-        x_over = x_over + epsf.origin[0]
-        y_over = y_over + epsf.origin[1]
-
-        # Pre-allocate with NaN (default for missing data)
-        shape = (n_good_stars, epsf_shape[0], epsf_shape[1])
-        epsf_resid = np.full(shape, np.nan)
+        x_first = np.floor(x_over + epsf.origin[0] - nx_over / 2.0)
+        y_first = np.floor(y_over + epsf.origin[1] - ny_over / 2.0)
+        x_first = x_first.astype(int) + 1
+        y_first = y_first.astype(int) + 1
 
         # Deposit each pixel residual on every grid point inside the
-        # pixel footprint (see _resample_residual)
-        ny_over, nx_over = self.oversampling
-        x_first = np.floor(x_over - nx_over / 2.0).astype(int) + 1
-        y_first = np.floor(y_over - ny_over / 2.0).astype(int) + 1
+        # pixel footprint through a flat index into the stack, which
+        # needs only two masked copies per footprint offset. The
+        # in-bounds masks along the x axis are the same for every row
+        # offset, so they are computed once.
+        epsf_resid_flat = epsf_resid.reshape(-1)
+        star_offset = star_index * (ny * nx)
+        x_masks = [((x_first + i) >= 0) & ((x_first + i) < nx)
+                   for i in range(nx_over)]
         for j in range(ny_over):
             yidx = y_first + j
+            y_mask = (yidx >= 0) & (yidx < ny)
+            row_index = star_offset + yidx * nx
             for i in range(nx_over):
-                xidx = x_first + i
-                mask = ((xidx >= 0) & (xidx < epsf_shape[1])
-                        & (yidx >= 0) & (yidx < epsf_shape[0]))
-                epsf_resid[star_index[mask], yidx[mask], xidx[mask]] = (
-                    residuals[mask])
-
-        return epsf_resid
+                mask = y_mask & x_masks[i]
+                flat_index = row_index + (x_first + i)
+                epsf_resid_flat[flat_index[mask]] = residuals[mask]
 
     def _smooth_epsf(self, epsf_data):
         """
@@ -2192,8 +2204,13 @@ class EPSFBuilder:
         converged : bool
             `True` if convergence criteria are met.
 
-        center_dist_sq : `~numpy.ndarray`
-            Squared distances of center movements.
+        converged_fraction : float
+            The fraction of the successfully fitted stars whose centers
+            moved by less than the center accuracy.
+
+        max_center_dist_sq : float
+            The maximum squared center movement of the successfully
+            fitted stars.
 
         new_centers : `~numpy.ndarray`
             Updated star center positions.
@@ -2210,16 +2227,18 @@ class EPSFBuilder:
             # is unreachable from build_epsf (all-failed fits raise
             # earlier), but guards direct calls. NaN indicates that no
             # center movement could be measured.
-            return False, np.array([np.nan]), new_centers
+            return False, 0.0, np.nan, new_centers
 
         dx_dy_good = dx_dy[good_stars]
         center_dist_sq = np.sum(dx_dy_good * dx_dy_good, axis=1,
                                 dtype=np.float64)
 
-        fraction = np.mean(center_dist_sq < self.center_accuracy_sq)
-        converged = bool(fraction >= self.converged_fraction)
+        converged_fraction = float(
+            np.mean(center_dist_sq < self.center_accuracy_sq))
+        converged = converged_fraction >= self.converged_fraction
 
-        return converged, center_dist_sq, new_centers
+        return (converged, converged_fraction, float(np.max(center_dist_sq)),
+                new_centers)
 
     def _fit_stars(self, epsf, stars):
         """
@@ -2250,11 +2269,10 @@ class EPSFBuilder:
             msg = 'The input epsf must be an ImagePSF'
             raise TypeError(msg)
 
-        # Build the (cached) spline interpolators once so that the
-        # model copies made by the fitter for every star share them
-        # instead of each rebuilding the spline.
-        epsf.interpolator  # noqa: B018
-        epsf._deriv_interpolators  # noqa: B018
+        # Build the cached spline interpolators once so that the model
+        # copies made by the fitter for every star share them instead
+        # of each rebuilding the spline.
+        epsf._precompute_interpolators()
 
         fitted_stars = []
         for star in stars:
@@ -2513,7 +2531,7 @@ class EPSFBuilder:
 
     def _finalize_build(self, epsf, stars, progress_reporter, iter_num,
                         converged, final_center_accuracy,
-                        converged_fraction=None):
+                        final_converged_fraction=None):
         """
         Finalize the ePSF building process and create result object.
 
@@ -2540,7 +2558,7 @@ class EPSFBuilder:
         final_center_accuracy : float
             Final center accuracy achieved.
 
-        converged_fraction : float, optional
+        final_converged_fraction : float, optional
             The fraction of the successfully fitted stars whose centers
             changed by less than the center accuracy in the final
             iteration.
@@ -2585,7 +2603,7 @@ class EPSFBuilder:
             excluded_star_indices=excluded_star_indices,
             smoothing_kernel=kernel,
             fit_shape=fit_shape,
-            converged_fraction=converged_fraction,
+            final_converged_fraction=final_converged_fraction,
         )
 
     def build_epsf(self, stars, *, epsf=None):
@@ -2617,12 +2635,14 @@ class EPSFBuilder:
         Notes
         -----
         The structured result object contains:
+
         - epsf: The final constructed ePSF
         - fitted_stars: Stars with updated centers/fluxes
         - iterations: Number of iterations performed
         - converged: Whether convergence was achieved
         - final_center_accuracy: Final center movement accuracy
-        - converged_fraction: Fraction of stars that met the accuracy
+        - final_converged_fraction: Fraction of stars that met the
+          accuracy
         - n_excluded_stars: Number of stars excluded due to fit failures
         - excluded_star_indices: Indices of excluded stars
         - smoothing_kernel: Smoothing kernel of the final iteration
@@ -2665,7 +2685,8 @@ class EPSFBuilder:
         # Initialize iteration variables
         iter_num = 0
         converged = False
-        center_dist_sq = np.array([self.center_accuracy_sq + 1.0])
+        converged_fraction = 0.0
+        max_center_dist_sq = self.center_accuracy_sq + 1.0
 
         # Main iteration loop. Note that an all-failed iteration
         # raises inside _process_iteration, so no fit_failed exit
@@ -2679,16 +2700,13 @@ class EPSFBuilder:
                 stars, epsf, iter_num)
 
             # Check convergence based on center movements
-            converged, center_dist_sq, centers = self._check_convergence(
-                stars, centers, fit_failed)
+            (converged, converged_fraction, max_center_dist_sq,
+             centers) = self._check_convergence(stars, centers, fit_failed)
 
             # Update progress bar
             progress_reporter.update()
 
-        # Calculate the final center accuracy and converged fraction
-        final_center_accuracy = float(np.max(center_dist_sq) ** 0.5)
-        converged_fraction = float(
-            np.mean(center_dist_sq < self.center_accuracy_sq))
+        final_center_accuracy = float(max_center_dist_sq ** 0.5)
 
         # Finalize and return structured results
         return self._finalize_build(epsf, stars, progress_reporter,

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -927,9 +927,11 @@ class EPSFBuildResults:
         This will be <= maxiters specified in EPSFBuilder.
 
     converged : bool
-        Whether the building process converged based on the center
-        accuracy criterion. `True` if star centers moved less than the
-        specified accuracy between the final iterations.
+        Whether the building process converged based on the
+        center accuracy criterion. `True` if at least the
+        ``converged_fraction`` of the successfully fitted stars moved
+        by less than the specified center accuracy between the final
+        iterations.
 
     final_center_accuracy : float
         The maximum center displacement in the final iteration, in
@@ -2620,6 +2622,7 @@ class EPSFBuilder:
         - iterations: Number of iterations performed
         - converged: Whether convergence was achieved
         - final_center_accuracy: Final center movement accuracy
+        - converged_fraction: Fraction of stars that met the accuracy
         - n_excluded_stars: Number of stars excluded due to fit failures
         - excluded_star_indices: Indices of excluded stars
         - smoothing_kernel: Smoothing kernel of the final iteration

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -1850,20 +1850,57 @@ class EPSFBuilder:
             A 3D cube containing the resampled residual images.
         """
         epsf_shape = epsf.data.shape
-        n_good_stars = stars.n_good_stars
+        good_stars = stars.all_good_stars
+        n_good_stars = len(good_stars)
 
         if n_good_stars == 0:
             # Return empty array with correct shape
             return np.zeros((0, epsf_shape[0], epsf_shape[1]))
 
+        # Gather the unmasked pixels of all stars so that the ePSF model
+        # is evaluated once and the residuals are deposited with a
+        # single indexed assignment per footprint offset.
+        star_index = []
+        xidx_centered = []
+        yidx_centered = []
+        values = []
+        for i, star in enumerate(good_stars):
+            xidx, yidx = star._xyidx_centered
+            star_index.append(np.full(xidx.size, i))
+            xidx_centered.append(xidx)
+            yidx_centered.append(yidx)
+            values.append(star._data_values_normalized)
+        star_index = np.concatenate(star_index)
+        xidx_centered = np.concatenate(xidx_centered)
+        yidx_centered = np.concatenate(yidx_centered)
+        values = np.concatenate(values)
+
+        residuals = values - epsf.evaluate(x=xidx_centered, y=yidx_centered,
+                                           flux=1.0, x_0=0.0, y_0=0.0)
+
+        # Star pixel centers in the oversampled ePSF grid
+        x_over, y_over = self._coord_transformer.undersampled_to_oversampled(
+            xidx_centered, yidx_centered)
+        x_over = x_over + epsf.origin[0]
+        y_over = y_over + epsf.origin[1]
+
         # Pre-allocate with NaN (default for missing data)
         shape = (n_good_stars, epsf_shape[0], epsf_shape[1])
         epsf_resid = np.full(shape, np.nan)
 
-        # Loop over stars and compute residuals directly into the
-        # pre-allocated array
-        for i, star in enumerate(stars.all_good_stars):
-            self._resample_residual(star, epsf, out_image=epsf_resid[i])
+        # Deposit each pixel residual on every grid point inside the
+        # pixel footprint (see _resample_residual)
+        ny_over, nx_over = self.oversampling
+        x_first = np.floor(x_over - nx_over / 2.0).astype(int) + 1
+        y_first = np.floor(y_over - ny_over / 2.0).astype(int) + 1
+        for j in range(ny_over):
+            yidx = y_first + j
+            for i in range(nx_over):
+                xidx = x_first + i
+                mask = ((xidx >= 0) & (xidx < epsf_shape[1])
+                        & (yidx >= 0) & (yidx < epsf_shape[0]))
+                epsf_resid[star_index[mask], yidx[mask], xidx[mask]] = (
+                    residuals[mask])
 
         return epsf_resid
 

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -369,6 +369,20 @@ class ImagePSF(Fittable2DModel):
         return (self.interpolator.partial_derivative(1, 0),
                 self.interpolator.partial_derivative(0, 1))
 
+    def _precompute_interpolators(self):
+        """
+        Compute and cache the spline interpolators.
+
+        The cached interpolators are shared by the model copies made
+        with `copy` (e.g., by the fitters), so calling this method
+        before fitting the model to many sources builds the splines
+        once instead of once per copy. The derivative interpolators are
+        computed only when `fit_deriv` is enabled.
+        """
+        _ = self.interpolator
+        if self.fit_deriv is not None:
+            _ = self._deriv_interpolators
+
     def _calc_bounding_box(self):
         """
         Return a bounding box defining the limits of the model.

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -3372,3 +3372,33 @@ def test_fit_stars_shares_spline_cache(epsf_test_data, monkeypatch):
     builder._fit_stars(epsf, stars)
     assert 'interpolator' in epsf.__dict__
     assert '_deriv_interpolators' in epsf.__dict__
+
+
+@pytest.mark.parametrize('oversampling', [1, 2, (1, 2), 4])
+def test_resample_residuals_matches_per_star(epsf_test_data, oversampling):
+    """
+    Test that the vectorized residual stack equals the per-star
+    resampling, including masked pixels, out-of-grid pixels, and
+    excluded stars.
+    """
+    stars = extract_stars(epsf_test_data['nddata'],
+                          epsf_test_data['init_stars'][:8], size=11)
+    # Mask a few pixels in one star and shift another star so that
+    # part of its footprint falls outside the ePSF grid.
+    star0, star1, star2 = stars.all_stars[:3]
+    star0.mask[2:4, 3:6] = True
+    star0.__dict__.pop('_data_values_normalized', None)
+    star1.cutout_center = (1.3, 9.2)
+    star2._excluded_from_fit = True
+
+    builder = EPSFBuilder(oversampling=oversampling, progress_bar=False)
+    epsf = builder._create_initial_epsf(stars)
+    rng = np.random.default_rng(0)
+    epsf.data[:] = rng.uniform(0.0, 1.0, epsf.data.shape)
+    stack = builder._resample_residuals(stars, epsf)
+    assert stack.shape[0] == 7
+
+    for i, star in enumerate(stars.all_good_stars):
+        expected = builder._resample_residual(star, epsf)
+        assert_array_equal(np.isnan(stack[i]), np.isnan(expected))
+        assert_allclose(stack[i], expected, equal_nan=True)

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -1594,13 +1594,14 @@ class TestEPSFBuilder:
         centers = np.array([[2.0, 2.0]])
         fit_failed = np.array([True])  # All stars failed
 
-        converged, center_dist_sq, _ = builder._check_convergence(
+        converged, fraction, max_dist_sq, _ = builder._check_convergence(
             stars, centers, fit_failed)
 
         # Should return False (not converged) when no good stars
         assert converged is False
+        assert fraction == 0.0
         # No center movement could be measured
-        assert np.isnan(center_dist_sq[0])
+        assert np.isnan(max_dist_sq)
 
     def test_resample_residuals_no_good_stars(self, epsf_test_data):
         """
@@ -1621,26 +1622,6 @@ class TestEPSFBuilder:
         # Now resample residuals should handle no good stars
         result = builder._resample_residuals(stars, epsf)
         assert result.shape[0] == 0  # No good stars
-
-    def test_resample_residual_output(self, epsf_test_data):
-        """
-        Test EPSFBuilder._resample_residual creates output image if None
-        is passed.
-        """
-        builder = EPSFBuilder(maxiters=1, progress_bar=False)
-
-        stars = extract_stars(epsf_test_data['nddata'],
-                              epsf_test_data['init_stars'][:2], size=11)
-
-        # Create an initial ePSF
-        epsf = builder._create_initial_epsf(stars)
-
-        # Call _resample_residual without out_image (should create one)
-        star = stars.all_stars[0]
-        result = builder._resample_residual(star, epsf, out_image=None)
-
-        assert result is not None
-        assert result.shape == epsf.data.shape
 
     def test_build_step_with_epsf(self, epsf_test_data):
         """
@@ -2914,7 +2895,7 @@ def test_resample_residual_pixel_footprint():
     stars = EPSFStars([star])
     builder = EPSFBuilder(oversampling=2, progress_bar=False)
     epsf = builder._create_initial_epsf(stars)
-    resid = builder._resample_residual(star, epsf)
+    resid = builder._resample_residuals(stars, epsf)[0]
 
     finite = np.isfinite(resid)
     assert finite[:, 0::2].any()
@@ -2931,7 +2912,7 @@ def test_resample_residual_pixel_footprint():
     # With oversampling=1 the deposit reduces to the nearest grid point.
     builder1 = EPSFBuilder(oversampling=1, progress_bar=False)
     epsf1 = builder1._create_initial_epsf(stars)
-    resid1 = builder1._resample_residual(star, epsf1)
+    resid1 = builder1._resample_residuals(stars, epsf1)[0]
     assert np.isfinite(resid1).sum() == data.size
 
 
@@ -3268,14 +3249,66 @@ class TestAutoSmoothingAndFitShape:
         assert result.smoothing_kernel is None
 
 
+class _ShiftingFitter(TRFLSQFitter):
+    """
+    A fitter that alternately shifts the fitted x center of the first
+    ``n_shift`` stars of every ``n_stars`` fits by half a pixel, so that
+    the centers of those stars never settle.
+    """
+
+    def __init__(self, n_stars, n_shift):
+        super().__init__()
+        self.n_stars = n_stars
+        self.n_shift = n_shift
+        self.n_calls = 0
+
+    def __call__(self, model, x, y, z=None, weights=None, **kwargs):
+        fitted = super().__call__(model, x, y, z=z, weights=weights,
+                                  **kwargs)
+        if self.n_calls % self.n_stars < self.n_shift:
+            iteration = self.n_calls // self.n_stars
+            fitted.x_0 = fitted.x_0.value + 0.5 * (-1) ** iteration
+        self.n_calls += 1
+        return fitted
+
+
+class _FailingFitter(TRFLSQFitter):
+    """
+    A fitter that returns a fitted center outside the cutout for the
+    star whose input flux is ``flux``, so that its fit always fails.
+    """
+
+    def __init__(self, flux):
+        super().__init__()
+        self.flux = flux
+
+    def __call__(self, model, x, y, z=None, weights=None, **kwargs):
+        fitted = super().__call__(model, x, y, z=z, weights=weights,
+                                  **kwargs)
+        if model.flux.value == self.flux:
+            fitted.x_0 = 1000.0
+        return fitted
+
+
 class TestConvergedFraction:
     """
     Tests for the converged_fraction convergence criterion.
     """
 
-    @pytest.mark.parametrize('value', [0.0, 1.5, -0.1, 'auto', True])
-    def test_invalid(self, value):
+    @pytest.fixture
+    def stars(self, epsf_test_data):
+        return extract_stars(epsf_test_data['nddata'],
+                             epsf_test_data['init_stars'][:20], size=11)
+
+    @pytest.mark.parametrize('value', ['auto', True, None])
+    def test_invalid_type(self, value):
         match = 'converged_fraction must be a number'
+        with pytest.raises(TypeError, match=match):
+            EPSFBuilder(converged_fraction=value, progress_bar=False)
+
+    @pytest.mark.parametrize('value', [0.0, 1.5, -0.1, np.nan])
+    def test_invalid_value(self, value):
+        match = r'converged_fraction must be in the range \(0, 1\]'
         with pytest.raises(ValueError, match=match):
             EPSFBuilder(converged_fraction=value, progress_bar=False)
 
@@ -3283,56 +3316,65 @@ class TestConvergedFraction:
         builder = EPSFBuilder(progress_bar=False)
         assert builder.converged_fraction == 0.95
 
-    @pytest.mark.parametrize(('fraction', 'n_movers', 'expected'),
+    @pytest.mark.parametrize(('fraction', 'n_shift', 'expected'),
                              [(1.0, 0, True), (1.0, 1, False),
                               (0.95, 1, True), (0.95, 3, False)])
-    def test_check_convergence(self, epsf_test_data, fraction, n_movers,
-                               expected):
+    def test_convergence(self, stars, fraction, n_shift, expected):
         """
-        With 20 stars, 1 unconverged star is 95 percent converged and
-        3 unconverged stars are 85 percent converged.
+        With 20 stars, 1 unsettled star leaves 95 percent converged
+        and 3 unsettled stars leave 85 percent converged.
         """
-        stars = extract_stars(epsf_test_data['nddata'],
-                              epsf_test_data['init_stars'][:20], size=11)
-        builder = EPSFBuilder(center_accuracy=1e-3,
-                              converged_fraction=fraction,
+        maxiters = 6
+        fitter = _ShiftingFitter(len(stars), n_shift)
+        builder = EPSFBuilder(oversampling=1, maxiters=maxiters,
+                              center_accuracy=1e-2,
+                              converged_fraction=fraction, fitter=fitter,
                               progress_bar=False)
-        centers = stars.cutout_center_flat.copy()
-        centers[:n_movers, 0] += 0.5
-        fit_failed = np.zeros(len(stars), dtype=bool)
-        converged, dist_sq, _ = builder._check_convergence(stars, centers,
-                                                           fit_failed)
-        assert converged is expected
-        assert np.sum(dist_sq > 0) == n_movers
+        result = builder(stars)
 
-    def test_failed_fits_ignored(self, epsf_test_data):
+        assert result.converged is expected
+        assert result.final_converged_fraction == 1.0 - n_shift / 20
+        if expected:
+            assert result.iterations < maxiters
+        else:
+            assert result.iterations == maxiters
+            assert result.final_center_accuracy > 0.5
+
+        # The build converges when the achieved fraction reaches the
+        # requested fraction
+        assert result.converged == (result.final_converged_fraction
+                                    >= builder.converged_fraction)
+
+    def test_failed_fits_ignored(self, stars):
         """
         Stars whose fit failed do not count toward the fraction.
         """
-        stars = extract_stars(epsf_test_data['nddata'],
-                              epsf_test_data['init_stars'][:20], size=11)
-        builder = EPSFBuilder(converged_fraction=1.0, progress_bar=False)
-        centers = stars.cutout_center_flat.copy()
-        centers[:3, 0] += 0.5
-        fit_failed = np.zeros(len(stars), dtype=bool)
-        fit_failed[:3] = True
-        converged, dist_sq, _ = builder._check_convergence(stars, centers,
-                                                           fit_failed)
-        assert converged
-        assert len(dist_sq) == 17
+        # The failing star is never updated, so its flux stays at the
+        # input value that identifies it to the fitter
+        failed_star = stars.all_stars[0]
+        fitter = _FailingFitter(failed_star.flux)
+        builder = EPSFBuilder(oversampling=1, maxiters=10,
+                              center_accuracy=1e-2, converged_fraction=1.0,
+                              fitter=fitter, progress_bar=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            result = builder(stars)
 
-    def test_results_attribute(self, epsf_test_data):
-        stars = extract_stars(epsf_test_data['nddata'],
-                              epsf_test_data['init_stars'][:20], size=11)
+        assert result.converged
+        assert result.final_converged_fraction == 1.0
+        assert_array_equal(result.fitted_stars.all_stars[0].cutout_center,
+                           failed_star.cutout_center)
+
+    def test_results_attribute(self, stars):
         builder = EPSFBuilder(oversampling=1, maxiters=10,
                               center_accuracy=1e-2, progress_bar=False)
         result = builder(stars)
-        assert 0.0 <= result.converged_fraction <= 1.0
-        if result.converged:
-            assert result.converged_fraction >= builder.converged_fraction
+        assert 0.0 <= result.final_converged_fraction <= 1.0
+        assert result.converged == (result.final_converged_fraction
+                                    >= builder.converged_fraction)
 
 
-def test_fit_stars_shares_spline_cache(epsf_test_data, monkeypatch):
+def test_build_shares_spline_cache(epsf_test_data, monkeypatch):
     """
     The spline interpolators are built once per ePSF and shared by
     the model copies made for every star fit, so the number of spline
@@ -3352,9 +3394,9 @@ def test_fit_stars_shares_spline_cache(epsf_test_data, monkeypatch):
                         CountingSpline)
 
     n_constructions = []
-    for nstars in (4, 12):
+    for n_stars in (4, 12):
         stars = extract_stars(epsf_test_data['nddata'],
-                              epsf_test_data['init_stars'][:nstars],
+                              epsf_test_data['init_stars'][:n_stars],
                               size=11)
         counts.clear()
         builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False)
@@ -3364,14 +3406,39 @@ def test_fit_stars_shares_spline_cache(epsf_test_data, monkeypatch):
     assert n_constructions[0] == n_constructions[1]
     assert n_constructions[1] < 12
 
-    # The original ePSF holds the caches after fitting
-    stars = extract_stars(epsf_test_data['nddata'],
-                          epsf_test_data['init_stars'][:4], size=11)
-    builder = EPSFBuilder(oversampling=1, fit_shape=5, progress_bar=False)
-    epsf = builder._create_initial_epsf(stars)
-    builder._fit_stars(epsf, stars)
-    assert 'interpolator' in epsf.__dict__
-    assert '_deriv_interpolators' in epsf.__dict__
+
+def _resample_residual_per_star(builder, star, epsf):
+    """
+    Reference per-star implementation of the residual resampling.
+
+    The normalized ePSF model is subtracted from the normalized star
+    and each pixel residual is deposited on every oversampled grid
+    point inside the footprint of that pixel. Grid points without data
+    are NaN.
+    """
+    xidx_centered, yidx_centered = star._xyidx_centered
+    stardata = (star._data_values_normalized
+                - epsf.evaluate(x=xidx_centered, y=yidx_centered,
+                                flux=1.0, x_0=0.0, y_0=0.0))
+
+    # Star pixel centers in the oversampled ePSF grid
+    ny_over, nx_over = builder.oversampling
+    x_over = xidx_centered * nx_over + epsf.origin[0]
+    y_over = yidx_centered * ny_over + epsf.origin[1]
+
+    epsf_shape = epsf.data.shape
+    out_image = np.full(epsf_shape, np.nan)
+    x_first = np.floor(x_over - nx_over / 2.0).astype(int) + 1
+    y_first = np.floor(y_over - ny_over / 2.0).astype(int) + 1
+    for j in range(ny_over):
+        yidx = y_first + j
+        for i in range(nx_over):
+            xidx = x_first + i
+            mask = ((xidx >= 0) & (xidx < epsf_shape[1])
+                    & (yidx >= 0) & (yidx < epsf_shape[0]))
+            out_image[yidx[mask], xidx[mask]] = stardata[mask]
+
+    return out_image
 
 
 @pytest.mark.parametrize('oversampling', [1, 2, (1, 2), 4])
@@ -3387,7 +3454,6 @@ def test_resample_residuals_matches_per_star(epsf_test_data, oversampling):
     # part of its footprint falls outside the ePSF grid.
     star0, star1, star2 = stars.all_stars[:3]
     star0.mask[2:4, 3:6] = True
-    star0.__dict__.pop('_data_values_normalized', None)
     star1.cutout_center = (1.3, 9.2)
     star2._excluded_from_fit = True
 
@@ -3399,6 +3465,10 @@ def test_resample_residuals_matches_per_star(epsf_test_data, oversampling):
     assert stack.shape[0] == 7
 
     for i, star in enumerate(stars.all_good_stars):
-        expected = builder._resample_residual(star, epsf)
+        expected = _resample_residual_per_star(builder, star, epsf)
         assert_array_equal(np.isnan(stack[i]), np.isnan(expected))
         assert_allclose(stack[i], expected, equal_nan=True)
+
+    # Processing the stars in several chunks gives the same stack
+    chunked = builder._resample_residuals(stars, epsf, chunk_size=3)
+    assert_array_equal(chunked, stack)

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -3266,3 +3266,109 @@ class TestAutoSmoothingAndFitShape:
                               smoothing_kernel=None, progress_bar=False)
         result = builder(stars)
         assert result.smoothing_kernel is None
+
+
+class TestConvergedFraction:
+    """
+    Tests for the converged_fraction convergence criterion.
+    """
+
+    @pytest.mark.parametrize('value', [0.0, 1.5, -0.1, 'auto', True])
+    def test_invalid(self, value):
+        match = 'converged_fraction must be a number'
+        with pytest.raises(ValueError, match=match):
+            EPSFBuilder(converged_fraction=value, progress_bar=False)
+
+    def test_default(self):
+        builder = EPSFBuilder(progress_bar=False)
+        assert builder.converged_fraction == 0.95
+
+    @pytest.mark.parametrize(('fraction', 'n_movers', 'expected'),
+                             [(1.0, 0, True), (1.0, 1, False),
+                              (0.95, 1, True), (0.95, 3, False)])
+    def test_check_convergence(self, epsf_test_data, fraction, n_movers,
+                               expected):
+        """
+        With 20 stars, 1 unconverged star is 95 percent converged and
+        3 unconverged stars are 85 percent converged.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:20], size=11)
+        builder = EPSFBuilder(center_accuracy=1e-3,
+                              converged_fraction=fraction,
+                              progress_bar=False)
+        centers = stars.cutout_center_flat.copy()
+        centers[:n_movers, 0] += 0.5
+        fit_failed = np.zeros(len(stars), dtype=bool)
+        converged, dist_sq, _ = builder._check_convergence(stars, centers,
+                                                           fit_failed)
+        assert converged is expected
+        assert np.sum(dist_sq > 0) == n_movers
+
+    def test_failed_fits_ignored(self, epsf_test_data):
+        """
+        Stars whose fit failed do not count toward the fraction.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:20], size=11)
+        builder = EPSFBuilder(converged_fraction=1.0, progress_bar=False)
+        centers = stars.cutout_center_flat.copy()
+        centers[:3, 0] += 0.5
+        fit_failed = np.zeros(len(stars), dtype=bool)
+        fit_failed[:3] = True
+        converged, dist_sq, _ = builder._check_convergence(stars, centers,
+                                                           fit_failed)
+        assert converged
+        assert len(dist_sq) == 17
+
+    def test_results_attribute(self, epsf_test_data):
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:20], size=11)
+        builder = EPSFBuilder(oversampling=1, maxiters=10,
+                              center_accuracy=1e-2, progress_bar=False)
+        result = builder(stars)
+        assert 0.0 <= result.converged_fraction <= 1.0
+        if result.converged:
+            assert result.converged_fraction >= builder.converged_fraction
+
+
+def test_fit_stars_shares_spline_cache(epsf_test_data, monkeypatch):
+    """
+    The spline interpolators are built once per ePSF and shared by
+    the model copies made for every star fit, so the number of spline
+    constructions does not depend on the number of stars.
+    """
+    from photutils.psf import image_models
+
+    counts = []
+    original = image_models.RectBivariateSpline
+
+    class CountingSpline(original):
+        def __init__(self, *args, **kwargs):
+            counts.append(1)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(image_models, 'RectBivariateSpline',
+                        CountingSpline)
+
+    n_constructions = []
+    for nstars in (4, 12):
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:nstars],
+                              size=11)
+        counts.clear()
+        builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False)
+        builder(stars)
+        n_constructions.append(len(counts))
+
+    assert n_constructions[0] == n_constructions[1]
+    assert n_constructions[1] < 12
+
+    # The original ePSF holds the caches after fitting
+    stars = extract_stars(epsf_test_data['nddata'],
+                          epsf_test_data['init_stars'][:4], size=11)
+    builder = EPSFBuilder(oversampling=1, fit_shape=5, progress_bar=False)
+    epsf = builder._create_initial_epsf(stars)
+    builder._fit_stars(epsf, stars)
+    assert 'interpolator' in epsf.__dict__
+    assert '_deriv_interpolators' in epsf.__dict__


### PR DESCRIPTION
This PR adds `converged_fraction` (default 0.95), the fraction of successfully fitted stars that must meet `center_accuracy` for the ePSF build to converge, so a few spurious or contaminated stars no longer force a run to `maxiters`. The fraction achieved is reported in the results. `converged_fraction=1.0` restores the previous criterion. Each iteration is also about 20% faster from building the spline interpolators once per iteration and vectorizing the residual stacking.