### PR TITLE
Exclude NaN pixels from PSF fit in EPSFBuilder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -829,6 +829,11 @@ Bug Fixes
     star centers are strongly non-uniform, which indicates biased star
     centers. [#2419]
 
+  - Fixed a bug where ``EPSFBuilder`` raised ``NonFiniteValueError``
+    when a star cutout contained a non-finite (e.g., NaN) pixel inside
+    the fitting region. A star whose fitting region is fully masked is
+    now treated as a fit failure instead of raising an error. [#2423]
+
 - ``photutils.psf_matching``
 
   - ``make_wiener_kernel`` now validates a custom ``penalty`` array.

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -1220,6 +1220,7 @@ class EPSFFitter:
 
             data = star.data[large_slc]
             weights = star.weights[large_slc]
+            mask = star.mask[large_slc]
 
             # Define the origin of the fitting region
             x0 = large_slc[1].start
@@ -1228,6 +1229,7 @@ class EPSFFitter:
             # Use the entire cutout image
             data = star.data
             weights = star.weights
+            mask = star.mask
 
             # Define the origin of the fitting region
             x0 = 0
@@ -1239,6 +1241,19 @@ class EPSFFitter:
         yy, xx = np.indices(data.shape, dtype=float)
         xx = xx + x0 - star.cutout_center[0]
         yy = yy + y0 - star.cutout_center[1]
+
+        # Fit only the unmasked pixels. Masked pixels (non-finite data
+        # or non-positive weights) are dropped from the fit because the
+        # fitter objective function raises on non-finite data values
+        # even where the weight is zero.
+        good = ~mask
+        if not np.any(good):
+            star._fit_error_status = 4  # fitting region is fully masked
+            return star
+        xx = xx[good]
+        yy = yy[good]
+        data = data[good]
+        weights = weights[good]
 
         # Define the initial guesses for fitted flux and shifts
         epsf.flux = star.flux
@@ -2351,6 +2366,7 @@ class EPSFBuilder:
 
             data = star.data[large_slc]
             weights = star.weights[large_slc]
+            mask = star.mask[large_slc]
 
             # Define the origin of the fitting region
             x0 = large_slc[1].start
@@ -2359,6 +2375,7 @@ class EPSFBuilder:
             # Use the entire cutout image
             data = star.data
             weights = star.weights
+            mask = star.mask
 
             # Define the origin of the fitting region
             x0 = 0
@@ -2370,6 +2387,19 @@ class EPSFBuilder:
         yy, xx = np.indices(data.shape, dtype=float)
         xx = xx + x0 - star.cutout_center[0]
         yy = yy + y0 - star.cutout_center[1]
+
+        # Fit only the unmasked pixels. Masked pixels (non-finite data
+        # or non-positive weights) are dropped from the fit because the
+        # fitter objective function raises on non-finite data values
+        # even where the weight is zero.
+        good = ~mask
+        if not np.any(good):
+            star._fit_error_status = 4  # fitting region is fully masked
+            return star
+        xx = xx[good]
+        yy = yy[good]
+        data = data[good]
+        weights = weights[good]
 
         # Define the initial guesses for fitted flux and shifts
         epsf.flux = star.flux
@@ -2472,6 +2502,9 @@ class EPSFBuilder:
                     elif star._fit_error_status == 3:
                         reason = ('its fitted position is outside the '
                                   'data cutout')
+                    elif star._fit_error_status == 4:
+                        reason = ('its fitting region contains no '
+                                  'unmasked pixels')
                     else:  # _fit_error_status == 2
                         reason = 'the fit did not converge'
 

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -72,6 +72,22 @@ def epsf_fitter_data(epsf_test_data):
     return {'stars': stars, 'epsf': epsf}
 
 
+def _insert_nan_near_star(epsf_test_data, *, index=0):
+    """
+    Copy the test image and set a pixel one row above the given star
+    center to NaN.
+
+    Returns the NDData copy and the true (x, y) center of that star.
+    """
+    data = epsf_test_data['data'].copy()
+    xtrue = epsf_test_data['init_stars']['x'][index]
+    ytrue = epsf_test_data['init_stars']['y'][index]
+    iy = int(np.round(ytrue)) + 1
+    ix = int(np.round(xtrue))
+    data[iy, ix] = np.nan
+    return NDData(data), (xtrue, ytrue)
+
+
 class _MockWCS:
     """
     Mock WCS with an identity pixel-to-world transform.
@@ -1182,6 +1198,49 @@ class TestEPSFFitter:
         assert_allclose(fitted_star.cutout_center, (5.0, 5.0))
         assert fitted_star.flux == star.flux
 
+    def test_fit_star_masked_pixel_in_fit_box(self, epsf_test_data):
+        """
+        Test that a masked (NaN) pixel inside the fit box is excluded
+        from the fit instead of raising a fitter error.
+        """
+        nddata, (xtrue, ytrue) = _insert_nan_near_star(epsf_test_data)
+        match = 'Input data array contains invalid data'
+        with pytest.warns(AstropyUserWarning, match=match):
+            stars = extract_stars(nddata, epsf_test_data['init_stars'][:4],
+                                  size=11)
+        assert np.isnan(stars[0].data).any()
+
+        builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False)
+        epsf, _ = builder(stars)
+
+        fitter = _make_epsf_fitter(fit_boxsize=5)
+        fitted_stars = fitter(epsf, stars)
+
+        fitted_star = fitted_stars.all_stars[0]
+        assert fitted_star._fit_error_status == 0
+        assert_allclose(fitted_star.center, (xtrue, ytrue), atol=0.1)
+
+    def test_fit_star_all_masked_fit_box(self, epsf_fitter_data):
+        """
+        Test that a star whose fit box is fully masked is flagged as a
+        fit failure and left unchanged.
+        """
+        epsf = epsf_fitter_data['epsf']
+
+        star_data = np.ones((11, 11))
+        weights = np.ones((11, 11))
+        weights[3:8, 3:8] = 0.0
+        star = EPSFStar(star_data, weights=weights, cutout_center=(5.0, 5.0))
+        stars = EPSFStars([star])
+
+        fitter = _make_epsf_fitter(fit_boxsize=5)
+        fitted_stars = fitter(epsf, stars)
+
+        fitted_star = fitted_stars.all_stars[0]
+        assert fitted_star._fit_error_status == 4
+        assert_allclose(fitted_star.cutout_center, (5.0, 5.0))
+        assert fitted_star.flux == star.flux
+
 
 class TestEPSFBuilder:
     """
@@ -2212,6 +2271,78 @@ class TestEPSFBuilder:
         # Check that fitting succeeded
         assert fitted_star._fit_error_status == 0
         assert fitted_star.flux > 0
+
+    def test_build_epsf_masked_pixel_in_fit_shape(self, epsf_test_data):
+        """
+        Regression test for a NaN pixel inside the fit shape.
+
+        A masked pixel next to a star center must be excluded from
+        the fit instead of raising NonFiniteValueError in the astropy
+        fitter.
+        """
+        nddata, (xtrue, ytrue) = _insert_nan_near_star(epsf_test_data)
+        match = 'Input data array contains invalid data'
+        with pytest.warns(AstropyUserWarning, match=match):
+            stars = extract_stars(nddata, epsf_test_data['init_stars'][:25],
+                                  size=25)
+        assert np.isnan(stars[0].data).any()
+
+        builder = EPSFBuilder(oversampling=2, maxiters=3, progress_bar=False)
+        epsf, fitted_stars = builder(stars)
+
+        assert np.all(np.isfinite(epsf.data))
+        fitted_star = fitted_stars.all_stars[0]
+        assert fitted_star._fit_error_status == 0
+        assert_allclose(fitted_star.center, (xtrue, ytrue), atol=0.1)
+
+    def test_fit_star_all_masked_fit_shape(self, epsf_test_data):
+        """
+        Test EPSFBuilder._fit_star with a fully masked fit shape.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:2], size=11)
+        builder = EPSFBuilder(oversampling=1, maxiters=2, fit_shape=5,
+                              progress_bar=False)
+        epsf, _ = builder(stars)
+
+        star_data = np.ones((11, 11))
+        weights = np.ones((11, 11))
+        weights[3:8, 3:8] = 0.0
+        star = EPSFStar(star_data, weights=weights, cutout_center=(5.0, 5.0))
+
+        fitted_star = builder._fit_star(epsf, star)
+
+        assert fitted_star._fit_error_status == 4
+        assert_allclose(fitted_star.cutout_center, (5.0, 5.0))
+        assert fitted_star.flux == star.flux
+
+    def test_process_iteration_excludes_all_masked(self, epsf_test_data):
+        """
+        Test that _process_iteration excludes a star whose fit shape
+        contains no unmasked pixels.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:2], size=11)
+        builder = EPSFBuilder(oversampling=1, maxiters=2, fit_shape=5,
+                              progress_bar=False)
+        epsf, _ = builder(stars)
+
+        star_data = np.ones((11, 11))
+        weights = np.ones((11, 11))
+        weights[3:8, 3:8] = 0.0
+        masked_star = EPSFStar(star_data, weights=weights,
+                               cutout_center=(5.0, 5.0))
+        stars = EPSFStars([masked_star, stars.all_stars[1]])
+
+        match = 'its fitting region contains no unmasked pixels'
+        with pytest.warns(AstropyUserWarning, match=match):
+            _, stars_new, fit_failed = builder._process_iteration(
+                stars, epsf, iter_num=4)
+
+        assert fit_failed[0]
+        assert not fit_failed[1]
+        assert stars_new.all_stars[0]._excluded_from_fit
+        assert stars_new.all_stars[0]._fit_error_status == 4
 
     def test_normalize_epsf_zero_sum(self):
         """


### PR DESCRIPTION
This PR fixes a bug where ``EPSFBuilder`` raised ``NonFiniteValueError`` when a star cutout contained a non-finite (e.g., NaN) pixel inside the fitting region. A star whose fitting region is fully masked is now treated as a fit failure instead of raising an error.