### PR TITLE
Update devdeps CI jobs to Python 3.15

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -48,8 +48,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.14'
-            tox_env: 'py314-test-devdeps'
+            python: '3.15'
+            tox_env: 'py315-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -106,8 +106,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.14'
-            tox_env: 'py314-test-devdeps'
+            python: '3.15'
+            tox_env: 'py315-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{312}-test-oldestdeps
-    py{312,313,314}-test{,-alldeps,-devdeps,-predeps,-devinfra}{,-cov}
+    py{312,313,314,315}-test{,-alldeps,-devdeps,-predeps,-devinfra}{,-cov}
     oldest_cython
     build_docs
     linkcheck


### PR DESCRIPTION
Python 3.15rc2 is currently available.